### PR TITLE
Add a picocli command-line interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     alias(libs.plugins.license.gradle.plugin)
     alias(libs.plugins.grgit.gradle)
     alias(libs.plugins.pitest.gradle.plugin)
+    alias(libs.plugins.shadow.gradle)
     alias(libs.plugins.spotless.plugin.gradle)
     alias(libs.plugins.version.catalog.update)
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation libs.bcprov.ext.jdk18on
     implementation libs.bcpkix.jdk18on
     implementation libs.xml.base
+    // command-line interface (io.github.astrapi69.mystic.crypt.cli)
+    implementation libs.picocli
 
     testImplementation libs.silly.strings
     testImplementation libs.json.extensions

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ file-worker-version = "19.0"
 gradle-plugin-grgit-version = "5.3.3"
 gradle-plugin-license-version = "0.16.1"
 gradle-plugin-pitest-version = "1.19.0"
+gradle-plugin-shadow-version = "9.0.0"
 gradle-plugin-spotless-version = "8.10.0"
 gradle-plugin-version-catalog-update-version = "1.1.1"
 gradle-plugin-versions-version = "0.61.0"
@@ -23,6 +24,7 @@ junit-jupiter-params-version = "6.1.3"
 junit-jupiter-version = "6.1.3"
 junit-platform-launcher-version = "6.1.3"
 meanbean-version = "3.0.0-M9"
+picocli-version = "4.7.6"
 pitest-junit5-plugin-version = "1.2.3"
 pitest-version = "1.25.9"
 random-beans-version = "3.9.0"
@@ -54,6 +56,7 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter-params-version" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform-launcher-version" }
 meanbean = { module = "com.github.meanbeanlib:meanbean", version.ref = "meanbean-version" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli-version" }
 random-beans = { module = "io.github.benas:random-beans", version.ref = "random-beans-version" }
 randomizer = { module = "io.github.astrapi69:randomizer", version.ref = "randomizer-version" }
 silly-bean = { module = "io.github.astrapi69:silly-bean", version.ref = "silly-bean-version" }
@@ -77,5 +80,6 @@ gradle-versions-plugin = { id = "com.github.ben-manes.versions", version.ref = "
 grgit-gradle = { id = "org.ajoberstar.grgit", version.ref = "gradle-plugin-grgit-version" }
 license-gradle-plugin = { id = "com.github.hierynomus.license", version.ref = "gradle-plugin-license-version" }
 pitest-gradle-plugin = { id = "info.solidsoft.pitest", version.ref = "gradle-plugin-pitest-version" }
+shadow-gradle = { id = "com.gradleup.shadow", version.ref = "gradle-plugin-shadow-version" }
 spotless-plugin-gradle = { id = "com.diffplug.spotless", version.ref = "gradle-plugin-spotless-version" }
 version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "gradle-plugin-version-catalog-update-version" }

--- a/gradle/packaging.gradle
+++ b/gradle/packaging.gradle
@@ -1,5 +1,20 @@
 import java.text.SimpleDateFormat
 
+// Runnable uber-jar for the command-line interface: mystic-crypt-<version>-all.jar bundles every
+// runtime dependency plus a Main-Class, so it runs with `java -jar mystic-crypt-<version>-all.jar
+// <subcommand>`. It is an additional artifact and does NOT change the primary library jar. Run on
+// the classpath, so the bundled module-info descriptors are dropped to avoid an invalid multi-module
+// jar; shadow strips the dependencies' JAR signatures itself.
+shadowJar {
+    archiveClassifier = 'all'
+    manifest {
+        attributes('Main-Class': 'io.github.astrapi69.mystic.crypt.cli.MysticCryptCli')
+    }
+    exclude 'module-info.class'
+    exclude 'META-INF/versions/*/module-info.class'
+    mergeServiceFiles()
+}
+
 jar {
     manifest {
         attributes(

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommand.java
@@ -1,0 +1,89 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.Callable;
+
+import org.bouncycastle.asn1.x500.X500Name;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.crypt.data.factory.CertFactory;
+import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
+import io.github.astrapi69.crypt.data.key.writer.CertificateWriter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Generates a key pair and writes a self-signed X.509 v3 certificate for it in PEM format. Issuer
+ * and subject are the same distinguished name (self-signed).
+ */
+@Command(name = "cert", mixinStandardHelpOptions = true, //
+	description = "Create a self-signed X.509 certificate and write it as PEM.")
+public class CertificateCommand implements Callable<Integer>
+{
+
+	@Option(names = "--subject", defaultValue = "CN=mystic-crypt", //
+		description = "The distinguished name for issuer and subject (default: CN=mystic-crypt).")
+	String subject;
+
+	@Option(names = { "-a", "--algorithm" }, defaultValue = "RSA", //
+		description = "Key algorithm (default: RSA).")
+	String algorithm;
+
+	@Option(names = { "-s", "--size" }, defaultValue = "2048", //
+		description = "Key size in bits for size-based algorithms like RSA (default: 2048).")
+	int size;
+
+	@Option(names = "--signature-algorithm", defaultValue = "SHA256withRSA", //
+		description = "Certificate signature algorithm (default: SHA256withRSA).")
+	String signatureAlgorithm;
+
+	@Option(names = "--days", defaultValue = "365", //
+		description = "Validity period in days from now (default: 365).")
+	int days;
+
+	@Option(names = "--out", required = true, description = "Write the certificate PEM to this file.")
+	File out;
+
+	@Override
+	public Integer call() throws Exception
+	{
+		KeyPairGeneratorAlgorithm keyPairAlgorithm = CliSupport.parseKeyPairAlgorithm(algorithm);
+		KeyPair keyPair = CliSupport.isSizeBased(keyPairAlgorithm)
+			? KeyPairFactory.newKeyPair(keyPairAlgorithm, size)
+			: KeyPairFactory.newKeyPair(keyPairAlgorithm);
+
+		X500Name distinguishedName = new X500Name(subject);
+		X509Certificate certificate = CertFactory.newX509CertificateV3(keyPair, distinguishedName,
+			days, distinguishedName, signatureAlgorithm);
+		CertificateWriter.writeInPemFormat(certificate, out);
+
+		System.out.println("wrote self-signed certificate for '" + subject + "' to " + out);
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommand.java
@@ -1,0 +1,76 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Computes and prints the checksum (message digest) of a file with a chosen JDK digest algorithm.
+ * <p>
+ * This uses the JDK-native {@link MessageDigest} on purpose: the {@code checksum-up} library's
+ * {@code FileChecksumExtensions.getChecksum(File, Algorithm)} pulls a different crypt-api
+ * {@code Algorithm} across the module boundary and fails to resolve here. Once a checksum-up
+ * release built against the current crypt-api is available, this command can switch to it to also
+ * offer the non-cryptographic digests (CRC32, Adler32).
+ */
+@Command(name = "checksum", mixinStandardHelpOptions = true, //
+	description = "Compute the checksum (message digest) of a file.")
+public class ChecksumCommand implements Callable<Integer>
+{
+
+	@Option(names = { "-a", "--algorithm" }, defaultValue = "SHA-256", //
+		description = "Digest algorithm (a JDK name), e.g. MD5, SHA-1, SHA-256, SHA-512 "
+			+ "(default: SHA-256).")
+	String algorithm;
+
+	@Parameters(index = "0", paramLabel = "FILE", description = "The file to checksum.")
+	File file;
+
+	@Override
+	public Integer call() throws Exception
+	{
+		MessageDigest messageDigest;
+		try
+		{
+			messageDigest = MessageDigest.getInstance(algorithm);
+		}
+		catch (NoSuchAlgorithmException exception)
+		{
+			throw new IllegalArgumentException("unknown digest algorithm '" + algorithm
+				+ "'. Use a JDK digest name such as MD5, SHA-1, SHA-256 or SHA-512.");
+		}
+		byte[] digest = messageDigest.digest(Files.readAllBytes(file.toPath()));
+		System.out.println(CliSupport.HEX.formatHex(digest));
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
@@ -1,0 +1,232 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.EnumSet;
+import java.util.HexFormat;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.crypt.data.key.writer.PrivateKeyWriter;
+import io.github.astrapi69.crypt.data.key.writer.PublicKeyWriter;
+import picocli.CommandLine.Help.Ansi;
+
+/**
+ * Small shared helpers for the CLI subcommands.
+ */
+final class CliSupport
+{
+
+	static final HexFormat HEX = HexFormat.of();
+
+	/** Key algorithms that take a classical key size; everything else has a fixed parameter set. */
+	private static final EnumSet<KeyPairGeneratorAlgorithm> SIZE_BASED = EnumSet.of(
+		KeyPairGeneratorAlgorithm.RSA, KeyPairGeneratorAlgorithm.DSA,
+		KeyPairGeneratorAlgorithm.DIFFIE_HELLMAN, KeyPairGeneratorAlgorithm.DH);
+
+	private CliSupport()
+	{
+	}
+
+	/**
+	 * Parses a {@link KeyPairGeneratorAlgorithm} from a user string, accepting either dashes or
+	 * underscores (e.g. {@code ML-KEM-768} or {@code ML_KEM_768}).
+	 *
+	 * @param value
+	 *            the algorithm name
+	 * @return the parsed algorithm
+	 * @throws IllegalArgumentException
+	 *             if the name is not a known algorithm
+	 */
+	static KeyPairGeneratorAlgorithm parseKeyPairAlgorithm(String value)
+	{
+		try
+		{
+			return KeyPairGeneratorAlgorithm.valueOf(value.trim().toUpperCase().replace('-', '_'));
+		}
+		catch (IllegalArgumentException exception)
+		{
+			throw new IllegalArgumentException("unknown key algorithm '" + value
+				+ "'. Use one of the KeyPairGeneratorAlgorithm names, e.g. RSA, X25519, X448, "
+				+ "ML_KEM_768, ML_DSA_65.");
+		}
+	}
+
+	/** Whether the given key algorithm is initialized with a classical key size. */
+	static boolean isSizeBased(KeyPairGeneratorAlgorithm algorithm)
+	{
+		return SIZE_BASED.contains(algorithm);
+	}
+
+	/**
+	 * Resolves text input from either the {@code --text} value or, when {@code stdin} is set, all
+	 * of standard input.
+	 *
+	 * @param text
+	 *            the value of {@code --text} (may be {@code null})
+	 * @param stdin
+	 *            whether to read the text from standard input instead
+	 * @return the resolved text
+	 */
+	static String resolveText(String text, boolean stdin)
+	{
+		if (stdin)
+		{
+			try
+			{
+				return new String(System.in.readAllBytes(), StandardCharsets.UTF_8);
+			}
+			catch (java.io.IOException exception)
+			{
+				throw new IllegalArgumentException(
+					"could not read text from standard input: " + exception.getMessage(),
+					exception);
+			}
+		}
+		if (text == null)
+		{
+			throw new IllegalArgumentException("text is required: pass --text or --text-stdin");
+		}
+		return text;
+	}
+
+	/**
+	 * Resolves a password from either the {@code --password} value or, when {@code stdin} is set,
+	 * the first line read from standard input. Reading from stdin keeps the secret out of the
+	 * process argument list.
+	 *
+	 * @param password
+	 *            the value of {@code --password} (may be {@code null})
+	 * @param stdin
+	 *            whether to read the password from standard input instead
+	 * @return the resolved password
+	 * @throws IllegalArgumentException
+	 *             if neither a password nor stdin was provided, or stdin was empty
+	 */
+	static String resolvePassword(String password, boolean stdin)
+	{
+		if (stdin)
+		{
+			try
+			{
+				BufferedReader reader = new BufferedReader(
+					new InputStreamReader(System.in, StandardCharsets.UTF_8));
+				String line = reader.readLine();
+				if (line == null)
+				{
+					throw new IllegalArgumentException(
+						"no password was provided on standard input");
+				}
+				return line;
+			}
+			catch (java.io.IOException exception)
+			{
+				throw new IllegalArgumentException(
+					"could not read the password from standard input: " + exception.getMessage(),
+					exception);
+			}
+		}
+		if (password == null)
+		{
+			throw new IllegalArgumentException(
+				"a password is required: pass --password or --password-stdin");
+		}
+		return password;
+	}
+
+	/** Renders an error line for a failed subcommand. */
+	static String error(String message)
+	{
+		return Ansi.AUTO.string("@|red error:|@ " + message);
+	}
+
+	/**
+	 * Writes a private key in PEM to the given file, or prints it to stdout when {@code out} is
+	 * {@code null}. Uses the file-based PEM writer (the only exported one) via a temporary file for
+	 * the stdout case.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @param out
+	 *            the target file, or {@code null} to print to stdout
+	 * @throws IOException
+	 *             if writing fails
+	 */
+	static void writePrivateKeyPem(PrivateKey privateKey, File out) throws IOException
+	{
+		if (out != null)
+		{
+			PrivateKeyWriter.writeInPemFormat(privateKey, out);
+			return;
+		}
+		File temp = File.createTempFile("mystic-crypt-private", ".pem");
+		try
+		{
+			PrivateKeyWriter.writeInPemFormat(privateKey, temp);
+			System.out.print(Files.readString(temp.toPath(), StandardCharsets.UTF_8));
+		}
+		finally
+		{
+			Files.deleteIfExists(temp.toPath());
+		}
+	}
+
+	/**
+	 * Writes a public key in PEM to the given file, or prints it to stdout when {@code out} is
+	 * {@code null}.
+	 *
+	 * @param publicKey
+	 *            the public key
+	 * @param out
+	 *            the target file, or {@code null} to print to stdout
+	 * @throws IOException
+	 *             if writing fails
+	 */
+	static void writePublicKeyPem(PublicKey publicKey, File out) throws IOException
+	{
+		if (out != null)
+		{
+			PublicKeyWriter.writeInPemFormat(publicKey, out);
+			return;
+		}
+		File temp = File.createTempFile("mystic-crypt-public", ".pem");
+		try
+		{
+			PublicKeyWriter.writeInPemFormat(publicKey, temp);
+			System.out.print(Files.readString(temp.toPath(), StandardCharsets.UTF_8));
+		}
+		finally
+		{
+			Files.deleteIfExists(temp.toPath());
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommand.java
@@ -1,0 +1,61 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.security.PrivateKey;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.crypt.data.key.reader.PrivateKeyReader;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Converts a DER-encoded private key to PEM, printing it or writing it to a file.
+ */
+@Command(name = "der2pem", mixinStandardHelpOptions = true, //
+	description = "Convert a DER-encoded private key to PEM.")
+public class DerToPemCommand implements Callable<Integer>
+{
+
+	@Option(names = "--in", required = true, description = "The DER-encoded private key file to read.")
+	File in;
+
+	@Option(names = "--out", description = "Write the PEM to this file instead of stdout.")
+	File out;
+
+	@Override
+	public Integer call() throws Exception
+	{
+		PrivateKey privateKey = PrivateKeyReader.readPrivateKey(in);
+		if (privateKey == null)
+		{
+			throw new IllegalArgumentException("could not read a private key from '" + in
+				+ "' (is it a DER-encoded private key?)");
+		}
+		CliSupport.writePrivateKeyPem(privateKey, out);
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.HashBiMap;
+
+import io.github.astrapi69.mystic.crypt.obfuscation.simple.SimpleObfuscatorExtensions;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Reverses {@link ObfuscateCommand}: given the same character-substitution rules, it recovers the
+ * original text from obfuscated text.
+ */
+@Command(name = "disentangle", mixinStandardHelpOptions = true, //
+	description = "Recover text obfuscated by 'obfuscate', using the same --rule a=x map.")
+public class DisentangleCommand implements Callable<Integer>
+{
+
+	@Option(names = "--rule", required = true, description = "A character substitution a=x (repeatable).")
+	Map<Character, Character> rules;
+
+	@Option(names = "--text", description = "The obfuscated text. Prefer --text-stdin for larger input.")
+	String text;
+
+	@Option(names = "--text-stdin", description = "Read the obfuscated text from standard input.")
+	boolean textStdin;
+
+	@Override
+	public Integer call()
+	{
+		String input = CliSupport.resolveText(text, textStdin);
+		System.out
+			.println(SimpleObfuscatorExtensions.disentangleBiMap(HashBiMap.create(rules), input));
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/HashCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/HashCommand.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.pw.PasswordEncryptor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Hashes a password with Argon2id or PBKDF2 and prints the encoded hash.
+ */
+@Command(name = "hash", mixinStandardHelpOptions = true, //
+	description = "Hash a password with Argon2id or PBKDF2 and print the encoded hash.")
+public class HashCommand implements Callable<Integer>
+{
+
+	@Option(names = { "-a",
+			"--algorithm" }, defaultValue = "argon2id", description = "Hashing algorithm: ${COMPLETION-CANDIDATES} (default: argon2id).")
+	PasswordAlgorithm algorithm;
+
+	@Option(names = "--password", description = "The password to hash. Prefer --password-stdin to keep it out of the process arguments.")
+	String password;
+
+	@Option(names = "--password-stdin", description = "Read the password from the first line of standard input.")
+	boolean passwordStdin;
+
+	@Override
+	public Integer call()
+	{
+		String plainPassword = CliSupport.resolvePassword(password, passwordStdin);
+		PasswordEncryptor passwordEncryptor = PasswordEncryptor.getInstance();
+		String encodedHash = algorithm == PasswordAlgorithm.pbkdf2
+			? passwordEncryptor.hashPasswordPbkdf2(plainPassword)
+			: passwordEncryptor.hashPasswordArgon2id(plainPassword);
+		System.out.println(encodedHash);
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KemCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KemCommand.java
@@ -1,0 +1,141 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.mystic.crypt.key.HybridKemKeyExchange;
+import io.github.astrapi69.mystic.crypt.key.HybridKemKeyExchange.HybridEncapsulation;
+import io.github.astrapi69.mystic.crypt.key.HybridKemKeyExchange.HybridKeyPair;
+import io.github.astrapi69.mystic.crypt.key.HybridKemKeyExchange.HybridPrivateKey;
+import io.github.astrapi69.mystic.crypt.key.HybridKemKeyExchange.HybridPublicKey;
+import io.github.astrapi69.mystic.crypt.key.MlKemKeyExchange;
+import io.github.astrapi69.mystic.crypt.key.MlKemKeyExchange.Encapsulation;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Runs a two-party key-encapsulation exchange and shows that both sides derive the same shared
+ * secret. Supports pure ML-KEM ({@code ML-KEM-512|768|1024}) and a hybrid X25519 + ML-KEM-768 mode.
+ * Exit code 0 means the secrets matched.
+ */
+@Command(name = "kem", mixinStandardHelpOptions = true, //
+	description = "Run a two-party ML-KEM or hybrid X25519+ML-KEM key encapsulation and show that "
+		+ "both sides derive the same shared secret.")
+public class KemCommand implements Callable<Integer>
+{
+
+	/** the hybrid derived key length in bytes (256-bit shared key) */
+	private static final int HYBRID_SHARED_SECRET_BYTES = 32;
+
+	@Option(names = { "-a", "--algorithm" }, defaultValue = "ML-KEM-768", //
+		description = "ML-KEM-512, ML-KEM-768, ML-KEM-1024 or hybrid (default: ML-KEM-768).")
+	String algorithm;
+
+	@Override
+	public Integer call() throws Exception
+	{
+		byte[] senderSecret;
+		byte[] recipientSecret;
+		byte[] ciphertext;
+
+		if ("hybrid".equalsIgnoreCase(algorithm))
+		{
+			HybridKeyPair recipient = HybridKemKeyExchange
+				.newHybridKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+			HybridPublicKey recipientPublicKey = recipient.getHybridPublicKey();
+			HybridPrivateKey recipientPrivateKey = recipient.getHybridPrivateKey();
+
+			HybridEncapsulation encapsulation = HybridKemKeyExchange.hybridEncapsulate(
+				recipientPublicKey.getX25519PublicKey(), recipientPublicKey.getMlKemPublicKey(),
+				KeyPairGeneratorAlgorithm.ML_KEM_768, HYBRID_SHARED_SECRET_BYTES);
+			senderSecret = encapsulation.getSharedSecret().getEncoded();
+			ciphertext = encapsulation.getMlKemCiphertext();
+			recipientSecret = HybridKemKeyExchange.hybridDecapsulate(
+				recipientPrivateKey.getX25519PrivateKey(), recipientPrivateKey.getMlKemPrivateKey(),
+				encapsulation.getSenderX25519PublicKey(), encapsulation.getMlKemCiphertext(),
+				KeyPairGeneratorAlgorithm.ML_KEM_768, HYBRID_SHARED_SECRET_BYTES).getEncoded();
+		}
+		else
+		{
+			KeyPairGeneratorAlgorithm mlKemAlgorithm = parseMlKem(algorithm);
+			KeyPair recipient = MlKemKeyExchange.newKeyPair(mlKemAlgorithm);
+			Encapsulation encapsulation = MlKemKeyExchange.encapsulate(recipient.getPublic(),
+				mlKemAlgorithm);
+			senderSecret = encapsulation.getSharedSecret().getEncoded();
+			ciphertext = encapsulation.getCiphertext();
+			recipientSecret = MlKemKeyExchange
+				.decapsulate(recipient.getPrivate(), ciphertext, mlKemAlgorithm).getEncoded();
+		}
+
+		return report(algorithm, ciphertext, senderSecret, recipientSecret);
+	}
+
+	/**
+	 * Prints the exchange result and returns the exit code (0 when the two shared secrets are
+	 * equal, 1 otherwise). Separated from the crypto so the formatting and both outcomes are
+	 * testable.
+	 *
+	 * @param algorithm
+	 *            the algorithm label to print
+	 * @param ciphertext
+	 *            the ciphertext to print as hex
+	 * @param senderSecret
+	 *            the sender's derived shared secret
+	 * @param recipientSecret
+	 *            the recipient's derived shared secret
+	 * @return 0 if the secrets match, otherwise 1
+	 */
+	static int report(String algorithm, byte[] ciphertext, byte[] senderSecret,
+		byte[] recipientSecret)
+	{
+		boolean match = MessageDigest.isEqual(senderSecret, recipientSecret);
+		System.out.println("algorithm: " + algorithm);
+		System.out.println("ciphertext: " + CliSupport.HEX.formatHex(ciphertext));
+		System.out.println("sender-secret: " + CliSupport.HEX.formatHex(senderSecret));
+		System.out.println("recipient-secret: " + CliSupport.HEX.formatHex(recipientSecret));
+		System.out.println(match ? "shared secrets match" : "shared secrets do not match");
+		return match ? 0 : 1;
+	}
+
+	private static KeyPairGeneratorAlgorithm parseMlKem(String value)
+	{
+		switch (value.trim().toUpperCase().replace('-', '_'))
+		{
+			case "ML_KEM_512" :
+				return KeyPairGeneratorAlgorithm.ML_KEM_512;
+			case "ML_KEM_768" :
+				return KeyPairGeneratorAlgorithm.ML_KEM_768;
+			case "ML_KEM_1024" :
+				return KeyPairGeneratorAlgorithm.ML_KEM_1024;
+			default :
+				throw new IllegalArgumentException("unknown KEM algorithm '" + value
+					+ "'. Use ML-KEM-512, ML-KEM-768, ML-KEM-1024 or hybrid.");
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
@@ -1,0 +1,73 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.security.KeyPair;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Generates a key pair for a chosen algorithm and prints, or writes to files, its private and
+ * public key in PEM format. Classical size-based algorithms (RSA, DSA) use {@code --size}; the
+ * modern fixed-parameter algorithms (X25519/X448, ML-KEM, ML-DSA, ...) ignore it.
+ */
+@Command(name = "keygen", mixinStandardHelpOptions = true, //
+	description = "Generate a key pair and print (or write) its keys as PEM.")
+public class KeygenCommand implements Callable<Integer>
+{
+
+	@Option(names = { "-a", "--algorithm" }, defaultValue = "RSA", //
+		description = "Key algorithm, e.g. RSA, X25519, X448, ML-KEM-768, ML-DSA-65 "
+			+ "(dashes or underscores accepted; default: RSA).")
+	String algorithm;
+
+	@Option(names = { "-s", "--size" }, defaultValue = "2048", //
+		description = "Key size in bits for size-based algorithms like RSA (default: 2048).")
+	int size;
+
+	@Option(names = "--out-private", description = "Write the private key PEM to this file instead of stdout.")
+	File outPrivate;
+
+	@Option(names = "--out-public", description = "Write the public key PEM to this file instead of stdout.")
+	File outPublic;
+
+	@Override
+	public Integer call() throws Exception
+	{
+		KeyPairGeneratorAlgorithm keyPairAlgorithm = CliSupport.parseKeyPairAlgorithm(algorithm);
+		KeyPair keyPair = CliSupport.isSizeBased(keyPairAlgorithm)
+			? KeyPairFactory.newKeyPair(keyPairAlgorithm, size)
+			: KeyPairFactory.newKeyPair(keyPairAlgorithm);
+
+		CliSupport.writePrivateKeyPem(keyPair.getPrivate(), outPrivate);
+		CliSupport.writePublicKeyPem(keyPair.getPublic(), outPublic);
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
@@ -1,0 +1,86 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.security.Security;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * Root command of the mystic-crypt command-line interface. It bundles the individual crypto
+ * operations as subcommands (password hashing, key generation, key encapsulation, checksums,
+ * DER/PEM conversion, obfuscation and X.509 certificate creation), each a thin wrapper over the
+ * corresponding mystic-crypt / crypt-* library API.
+ * <p>
+ * Run without a subcommand it prints the usage help.
+ */
+@Command(name = "mystic-crypt", mixinStandardHelpOptions = true, version = "mystic-crypt CLI 1.0", //
+	description = "Command-line access to mystic-crypt: password hashing, key generation, key "
+		+ "encapsulation (KEM), checksums, DER/PEM conversion, obfuscation and certificates.", //
+	subcommands = { HashCommand.class, VerifyCommand.class, KeygenCommand.class, KemCommand.class,
+			ChecksumCommand.class, DerToPemCommand.class, ObfuscateCommand.class,
+			DisentangleCommand.class, CertificateCommand.class, CommandLine.HelpCommand.class })
+public class MysticCryptCli implements Runnable
+{
+
+	static
+	{
+		// several algorithms used by the subcommands (post-quantum KEM/signatures, certificate
+		// signing) resolve through Bouncy Castle; register it once for the whole CLI, including
+		// when
+		// subcommands are invoked programmatically through the root command in tests
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+		{
+			Security.addProvider(new BouncyCastleProvider());
+		}
+	}
+
+	@Override
+	public void run()
+	{
+		CommandLine.usage(this, System.out);
+	}
+
+	/**
+	 * Runs the CLI with the given arguments and returns the exit code, without terminating the JVM.
+	 * This is the testable core of {@link #main(String[])}.
+	 *
+	 * @param args
+	 *            the command-line arguments
+	 * @return the exit code
+	 */
+	public static int execute(String... args)
+	{
+		return new CommandLine(new MysticCryptCli()).execute(args);
+	}
+
+	public static void main(String[] args)
+	{
+		System.exit(execute(args));
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateCommand.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.HashBiMap;
+
+import io.github.astrapi69.mystic.crypt.obfuscation.simple.SimpleObfuscatorExtensions;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Obfuscates text with a character-substitution map. Each {@code --rule a=x} maps a character to
+ * its replacement; the inverse {@link DisentangleCommand} reverses it with the same rules.
+ */
+@Command(name = "obfuscate", mixinStandardHelpOptions = true, //
+	description = "Obfuscate text with a character-substitution map (--rule a=x, repeatable).")
+public class ObfuscateCommand implements Callable<Integer>
+{
+
+	@Option(names = "--rule", required = true, description = "A character substitution a=x (repeatable).")
+	Map<Character, Character> rules;
+
+	@Option(names = "--text", description = "The text to obfuscate. Prefer --text-stdin for larger input.")
+	String text;
+
+	@Option(names = "--text-stdin", description = "Read the text from standard input.")
+	boolean textStdin;
+
+	@Override
+	public Integer call()
+	{
+		String input = CliSupport.resolveText(text, textStdin);
+		System.out
+			.println(SimpleObfuscatorExtensions.obfuscateBiMap(HashBiMap.create(rules), input));
+		return 0;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/PasswordAlgorithm.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/PasswordAlgorithm.java
@@ -1,0 +1,36 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+/**
+ * The password hashing algorithms the {@code hash} and {@code verify} subcommands support.
+ */
+public enum PasswordAlgorithm
+{
+	/** Argon2id (memory-hard, the recommended default). */
+	argon2id,
+	/** PBKDF2. */
+	pbkdf2
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommand.java
@@ -1,0 +1,67 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.pw.PasswordEncryptor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Verifies a password against an encoded Argon2id/PBKDF2 hash. Exit code 0 means the password
+ * matches, 1 means it does not.
+ */
+@Command(name = "verify", mixinStandardHelpOptions = true, //
+	description = "Verify a password against an encoded Argon2id/PBKDF2 hash. "
+		+ "Exit code 0 = matches, 1 = does not match.")
+public class VerifyCommand implements Callable<Integer>
+{
+
+	@Option(names = { "-a",
+			"--algorithm" }, defaultValue = "argon2id", description = "Hashing algorithm: ${COMPLETION-CANDIDATES} (default: argon2id).")
+	PasswordAlgorithm algorithm;
+
+	@Option(names = "--hash", required = true, description = "The encoded hash to verify against.")
+	String hash;
+
+	@Option(names = "--password", description = "The password to verify. Prefer --password-stdin.")
+	String password;
+
+	@Option(names = "--password-stdin", description = "Read the password from the first line of standard input.")
+	boolean passwordStdin;
+
+	@Override
+	public Integer call()
+	{
+		String plainPassword = CliSupport.resolvePassword(password, passwordStdin);
+		PasswordEncryptor passwordEncryptor = PasswordEncryptor.getInstance();
+		boolean matches = algorithm == PasswordAlgorithm.pbkdf2
+			? passwordEncryptor.matchPbkdf2(plainPassword, hash)
+			: passwordEncryptor.matchArgon2id(plainPassword, hash);
+		System.out.println(matches ? "matches" : "does not match");
+		return matches ? 0 : 1;
+	}
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -38,6 +38,8 @@ module io.github.astrapisixtynine.mystic.crypt
 	requires io.github.astrapisixtynine.silly.bean;
 	requires io.github.astrapisixtynine.silly.collection;
 	requires org.bouncycastle.pkix;
+	// command-line interface
+	requires info.picocli;
 
 
 	exports io.github.astrapi69.mystic.crypt.aead;
@@ -61,5 +63,9 @@ module io.github.astrapisixtynine.mystic.crypt
 	exports io.github.astrapi69.mystic.crypt.simple;
 	exports io.github.astrapi69.mystic.crypt.srp;
 	exports io.github.astrapi69.mystic.crypt.ssl;
+	exports io.github.astrapi69.mystic.crypt.cli;
+
+	// picocli reflectively reads the @Command/@Option annotated fields of the CLI classes
+	opens io.github.astrapi69.mystic.crypt.cli to info.picocli;
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/AbstractCliTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/AbstractCliTest.java
@@ -1,0 +1,81 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Base for the CLI tests: runs the root command with a subcommand's arguments via
+ * {@link MysticCryptCli#execute} while capturing stdout and stderr, so tests can assert on the
+ * printed output and the returned exit code exactly like a shell invocation would.
+ */
+abstract class AbstractCliTest
+{
+
+	/** captured standard output of the most recent {@link #run} call */
+	protected String out;
+
+	/** captured standard error of the most recent {@link #run} call */
+	protected String err;
+
+	protected int run(String... args)
+	{
+		PrintStream originalOut = System.out;
+		PrintStream originalErr = System.err;
+		ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+		ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(outBuffer, true, StandardCharsets.UTF_8));
+		System.setErr(new PrintStream(errBuffer, true, StandardCharsets.UTF_8));
+		try
+		{
+			return MysticCryptCli.execute(args);
+		}
+		finally
+		{
+			out = outBuffer.toString(StandardCharsets.UTF_8);
+			err = errBuffer.toString(StandardCharsets.UTF_8);
+			System.setOut(originalOut);
+			System.setErr(originalErr);
+		}
+	}
+
+	protected int runWithStdin(String stdin, String... args)
+	{
+		InputStream originalIn = System.in;
+		System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
+		try
+		{
+			return run(args);
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommandTest.java
@@ -1,0 +1,74 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for the {@code cert} subcommand.
+ */
+class CertificateCommandTest extends AbstractCliTest
+{
+
+	@Test
+	void writesASelfSignedCertificateForTheSubject(@TempDir File tempDir) throws Exception
+	{
+		File certFile = new File(tempDir, "cert.pem");
+		assertEquals(0, run("cert", "--subject", "CN=unit-test", "--days", "30", "--out",
+			certFile.getAbsolutePath()));
+		assertTrue(certFile.exists() && certFile.length() > 0);
+
+		String pem = Files.readString(certFile.toPath());
+		assertTrue(pem.contains("BEGIN CERTIFICATE"));
+
+		// the written PEM must parse as a real X.509 certificate whose subject is what we asked for
+		X509Certificate certificate;
+		try (var inputStream = Files.newInputStream(certFile.toPath()))
+		{
+			certificate = (X509Certificate)CertificateFactory.getInstance("X.509")
+				.generateCertificate(inputStream);
+		}
+		assertTrue(certificate.getSubjectX500Principal().getName().contains("unit-test"));
+	}
+
+	@Test
+	void writesACertificateForASizeFreeKeyAlgorithm(@TempDir File tempDir) throws Exception
+	{
+		// EC is not size-based, so this exercises the size-free key-generation branch
+		File certFile = new File(tempDir, "ec-cert.pem");
+		assertEquals(0, run("cert", "--subject", "CN=ec-test", "--algorithm", "EC",
+			"--signature-algorithm", "SHA256withECDSA", "--out", certFile.getAbsolutePath()));
+		assertTrue(Files.readString(certFile.toPath()).contains("BEGIN CERTIFICATE"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommandTest.java
@@ -1,0 +1,76 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Unit tests for the {@code checksum} subcommand, asserting the well-known digests of the string
+ * "abc" for each algorithm.
+ */
+class ChecksumCommandTest extends AbstractCliTest
+{
+
+	@ParameterizedTest
+	@CsvSource({ "MD5,900150983cd24fb0d6963f7d28e17f72",
+			"SHA-1,a9993e364706816aba3e25717850c26c9cd0d89d",
+			"SHA-256,ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			"SHA-512,ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f" })
+	void computesKnownDigestOfAbc(String algorithm, String expected, @TempDir File tempDir)
+		throws Exception
+	{
+		File abc = new File(tempDir, "abc.txt");
+		Files.writeString(abc.toPath(), "abc");
+		assertEquals(0, run("checksum", "--algorithm", algorithm, abc.getAbsolutePath()));
+		assertEquals(expected, out.strip());
+	}
+
+	@Test
+	void defaultAlgorithmIsSha256(@TempDir File tempDir) throws Exception
+	{
+		File abc = new File(tempDir, "abc.txt");
+		Files.writeString(abc.toPath(), "abc");
+		assertEquals(0, run("checksum", abc.getAbsolutePath()));
+		assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			out.strip());
+	}
+
+	@Test
+	void unknownAlgorithmFails(@TempDir File tempDir) throws Exception
+	{
+		File abc = new File(tempDir, "abc.txt");
+		Files.writeString(abc.toPath(), "abc");
+		assertNotEquals(0, run("checksum", "--algorithm", "NOPE-1", abc.getAbsolutePath()));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/CliSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/CliSupportTest.java
@@ -1,0 +1,236 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyPair;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
+
+/**
+ * Unit tests for the shared {@link CliSupport} helpers, covering every branch including the error
+ * paths.
+ */
+class CliSupportTest
+{
+
+	@Test
+	void resolvePasswordFromArgument()
+	{
+		assertEquals("secret", CliSupport.resolvePassword("secret", false));
+	}
+
+	@Test
+	void resolvePasswordFromStdin()
+	{
+		InputStream originalIn = System.in;
+		System.setIn(new ByteArrayInputStream("from-stdin\n".getBytes(StandardCharsets.UTF_8)));
+		try
+		{
+			assertEquals("from-stdin", CliSupport.resolvePassword(null, true));
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+
+	@Test
+	void resolvePasswordMissingThrows()
+	{
+		assertThrows(IllegalArgumentException.class, () -> CliSupport.resolvePassword(null, false));
+	}
+
+	@Test
+	void resolvePasswordEmptyStdinThrows()
+	{
+		InputStream originalIn = System.in;
+		System.setIn(new ByteArrayInputStream(new byte[0]));
+		try
+		{
+			assertThrows(IllegalArgumentException.class,
+				() -> CliSupport.resolvePassword(null, true));
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+
+	@Test
+	void resolveTextFromArgumentAndStdin()
+	{
+		assertEquals("hello", CliSupport.resolveText("hello", false));
+
+		InputStream originalIn = System.in;
+		System.setIn(new ByteArrayInputStream("piped".getBytes(StandardCharsets.UTF_8)));
+		try
+		{
+			assertEquals("piped", CliSupport.resolveText(null, true));
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+
+	@Test
+	void resolveTextMissingThrows()
+	{
+		assertThrows(IllegalArgumentException.class, () -> CliSupport.resolveText(null, false));
+	}
+
+	/** An input stream that always fails, to exercise the stdin read-error branches. */
+	private static InputStream failingStdin()
+	{
+		return new InputStream()
+		{
+			@Override
+			public int read() throws java.io.IOException
+			{
+				throw new java.io.IOException("boom");
+			}
+		};
+	}
+
+	@Test
+	void resolvePasswordStdinReadErrorThrows()
+	{
+		InputStream originalIn = System.in;
+		System.setIn(failingStdin());
+		try
+		{
+			assertThrows(IllegalArgumentException.class,
+				() -> CliSupport.resolvePassword(null, true));
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+
+	@Test
+	void resolveTextStdinReadErrorThrows()
+	{
+		InputStream originalIn = System.in;
+		System.setIn(failingStdin());
+		try
+		{
+			assertThrows(IllegalArgumentException.class, () -> CliSupport.resolveText(null, true));
+		}
+		finally
+		{
+			System.setIn(originalIn);
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "RSA,RSA", "rsa,RSA", "ML-KEM-768,ML_KEM_768", "ml_dsa_65,ML_DSA_65",
+			"X25519,X25519" })
+	void parseKeyPairAlgorithmAcceptsDashesAndCase(String input, KeyPairGeneratorAlgorithm expected)
+	{
+		assertEquals(expected, CliSupport.parseKeyPairAlgorithm(input));
+	}
+
+	@Test
+	void parseKeyPairAlgorithmRejectsUnknown()
+	{
+		assertThrows(IllegalArgumentException.class,
+			() -> CliSupport.parseKeyPairAlgorithm("no-such-algo"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "RSA", "DSA", "DIFFIE_HELLMAN", "DH" })
+	void isSizeBasedTrueForClassicalAlgorithms(String algorithm)
+	{
+		assertTrue(CliSupport.isSizeBased(KeyPairGeneratorAlgorithm.valueOf(algorithm)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "X25519", "X448", "ML_KEM_768", "ML_DSA_65" })
+	void isSizeBasedFalseForModernAlgorithms(String algorithm)
+	{
+		assertFalse(CliSupport.isSizeBased(KeyPairGeneratorAlgorithm.valueOf(algorithm)));
+	}
+
+	@Test
+	void writePrivateAndPublicKeyPemToFiles(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = KeyPairFactory.newKeyPair(KeyPairGeneratorAlgorithm.RSA, 2048);
+		File privateFile = new File(tempDir, "private.pem");
+		File publicFile = new File(tempDir, "public.pem");
+
+		CliSupport.writePrivateKeyPem(keyPair.getPrivate(), privateFile);
+		CliSupport.writePublicKeyPem(keyPair.getPublic(), publicFile);
+
+		assertTrue(Files.readString(privateFile.toPath()).contains("PRIVATE KEY"));
+		assertTrue(Files.readString(publicFile.toPath()).contains("PUBLIC KEY"));
+	}
+
+	@Test
+	void writePrivateAndPublicKeyPemToStdout() throws Exception
+	{
+		KeyPair keyPair = KeyPairFactory.newKeyPair(KeyPairGeneratorAlgorithm.RSA, 2048);
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+		try
+		{
+			CliSupport.writePrivateKeyPem(keyPair.getPrivate(), null);
+			CliSupport.writePublicKeyPem(keyPair.getPublic(), null);
+		}
+		finally
+		{
+			System.setOut(originalOut);
+		}
+		String printed = buffer.toString(StandardCharsets.UTF_8);
+		assertTrue(printed.contains("PRIVATE KEY"));
+		assertTrue(printed.contains("PUBLIC KEY"));
+	}
+
+	@Test
+	void errorRendersTheMessage()
+	{
+		assertTrue(CliSupport.error("boom").contains("boom"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommandTest.java
@@ -1,0 +1,81 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.security.KeyPair;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
+import io.github.astrapi69.crypt.data.key.writer.PrivateKeyWriter;
+
+/**
+ * Unit tests for the {@code der2pem} subcommand.
+ */
+class DerToPemCommandTest extends AbstractCliTest
+{
+
+	private File writeDerKey(File tempDir) throws Exception
+	{
+		KeyPair keyPair = KeyPairFactory.newKeyPair(KeyPairGeneratorAlgorithm.RSA, 2048);
+		File derFile = new File(tempDir, "key.der");
+		PrivateKeyWriter.write(keyPair.getPrivate(), derFile);
+		return derFile;
+	}
+
+	@Test
+	void convertsToPemOnStdout(@TempDir File tempDir) throws Exception
+	{
+		File derFile = writeDerKey(tempDir);
+		assertEquals(0, run("der2pem", "--in", derFile.getAbsolutePath()));
+		assertTrue(out.contains("PRIVATE KEY"));
+	}
+
+	@Test
+	void convertsToPemFile(@TempDir File tempDir) throws Exception
+	{
+		File derFile = writeDerKey(tempDir);
+		File pemFile = new File(tempDir, "key.pem");
+		assertEquals(0,
+			run("der2pem", "--in", derFile.getAbsolutePath(), "--out", pemFile.getAbsolutePath()));
+		assertTrue(Files.readString(pemFile.toPath()).contains("PRIVATE KEY"));
+	}
+
+	@Test
+	void invalidInputFails(@TempDir File tempDir) throws Exception
+	{
+		File notDer = new File(tempDir, "not-a-key.der");
+		Files.writeString(notDer.toPath(), "definitely not a DER key");
+		assertNotEquals(0, run("der2pem", "--in", notDer.getAbsolutePath()));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/HashCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/HashCommandTest.java
@@ -1,0 +1,80 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@code hash} subcommand.
+ */
+class HashCommandTest extends AbstractCliTest
+{
+
+	@ParameterizedTest
+	@ValueSource(strings = { "argon2id", "pbkdf2" })
+	void hashesWithEachAlgorithm(String algorithm)
+	{
+		assertEquals(0, run("hash", "--algorithm", algorithm, "--password", "secret"));
+		assertTrue(out.strip().length() > 0, "an encoded hash must be printed");
+	}
+
+	@Test
+	void defaultAlgorithmIsArgon2id()
+	{
+		assertEquals(0, run("hash", "--password", "secret"));
+		assertTrue(out.contains("argon2"), "the default algorithm must be Argon2id");
+	}
+
+	@Test
+	void readsPasswordFromStdin()
+	{
+		assertEquals(0,
+			runWithStdin("piped-secret\n", "hash", "--algorithm", "pbkdf2", "--password-stdin"));
+		assertTrue(out.strip().length() > 0);
+	}
+
+	@Test
+	void differentPasswordsProduceDifferentHashes()
+	{
+		run("hash", "--algorithm", "pbkdf2", "--password", "a");
+		String first = out.strip();
+		run("hash", "--algorithm", "pbkdf2", "--password", "b");
+		String second = out.strip();
+		assertNotEquals(first, second);
+	}
+
+	@Test
+	void missingPasswordFails()
+	{
+		assertNotEquals(0, run("hash", "--algorithm", "pbkdf2"),
+			"without a password the command must fail");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KemCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KemCommandTest.java
@@ -1,0 +1,85 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@code kem} subcommand.
+ */
+class KemCommandTest extends AbstractCliTest
+{
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024", "hybrid" })
+	void bothPartiesDeriveMatchingSecrets(String algorithm)
+	{
+		assertEquals(0, run("kem", "--algorithm", algorithm));
+		assertTrue(out.contains("shared secrets match"),
+			algorithm + " sender and recipient must derive the same secret");
+		assertTrue(out.contains("ciphertext:"), "must print the ciphertext");
+		assertTrue(out.contains("sender-secret:") && out.contains("recipient-secret:"));
+	}
+
+	@org.junit.jupiter.api.Test
+	void hybridIsCaseInsensitive()
+	{
+		assertEquals(0, run("kem", "--algorithm", "HYBRID"));
+		assertTrue(out.contains("shared secrets match"));
+	}
+
+	@org.junit.jupiter.api.Test
+	void unknownAlgorithmFails()
+	{
+		assertNotEquals(0, run("kem", "--algorithm", "ML-KEM-999"));
+	}
+
+	@org.junit.jupiter.api.Test
+	void reportReturnsOneAndReportsNoMatchForDifferingSecrets()
+	{
+		java.io.PrintStream originalOut = System.out;
+		java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+		System
+			.setOut(new java.io.PrintStream(buffer, true, java.nio.charset.StandardCharsets.UTF_8));
+		int exitCode;
+		try
+		{
+			exitCode = KemCommand.report("test", new byte[] { 9 }, new byte[] { 1 },
+				new byte[] { 2 });
+		}
+		finally
+		{
+			System.setOut(originalOut);
+		}
+		assertEquals(1, exitCode, "differing secrets must return exit code 1");
+		assertTrue(buffer.toString(java.nio.charset.StandardCharsets.UTF_8)
+			.contains("shared secrets do not match"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommandTest.java
@@ -1,0 +1,80 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@code keygen} subcommand.
+ */
+class KeygenCommandTest extends AbstractCliTest
+{
+
+	@Test
+	void generatesRsaKeyPairWithKeySize()
+	{
+		assertEquals(0, run("keygen", "--algorithm", "RSA", "--size", "2048"));
+		assertTrue(out.contains("PRIVATE KEY"));
+		assertTrue(out.contains("PUBLIC KEY"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "X25519", "X448", "ML-KEM-768", "ML-DSA-65" })
+	void generatesModernAlgorithmKeyPair(String algorithm)
+	{
+		assertEquals(0, run("keygen", "--algorithm", algorithm));
+		assertTrue(out.contains("PRIVATE KEY"), "must print a private key PEM for " + algorithm);
+		assertTrue(out.contains("PUBLIC KEY"), "must print a public key PEM for " + algorithm);
+	}
+
+	@Test
+	void writesKeysToFiles(@TempDir File tempDir) throws Exception
+	{
+		File privateFile = new File(tempDir, "priv.pem");
+		File publicFile = new File(tempDir, "pub.pem");
+		assertEquals(0, run("keygen", "--algorithm", "X25519", "--out-private",
+			privateFile.getAbsolutePath(), "--out-public", publicFile.getAbsolutePath()));
+
+		assertTrue(Files.readString(privateFile.toPath()).contains("PRIVATE KEY"));
+		assertTrue(Files.readString(publicFile.toPath()).contains("PUBLIC KEY"));
+		assertTrue(out.isBlank(), "with output files nothing goes to stdout");
+	}
+
+	@Test
+	void unknownAlgorithmFails()
+	{
+		assertNotEquals(0, run("keygen", "--algorithm", "NOPE"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCliTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCliTest.java
@@ -1,0 +1,71 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the root {@link MysticCryptCli} command wiring (usage, help, version, unknown
+ * subcommands). The individual subcommands are covered by their own test classes.
+ */
+class MysticCryptCliTest extends AbstractCliTest
+{
+
+	@Test
+	void withoutArgumentsPrintsUsage()
+	{
+		assertEquals(0, run());
+		assertTrue(out.contains("Commands:"), "the usage help must list the subcommands");
+	}
+
+	@Test
+	void helpListsEverySubcommand()
+	{
+		assertEquals(0, run("--help"));
+		for (String subcommand : new String[] { "hash", "verify", "keygen", "kem", "checksum",
+				"der2pem", "obfuscate", "disentangle", "cert" })
+		{
+			assertTrue(out.contains(subcommand),
+				"help must mention the '" + subcommand + "' command");
+		}
+	}
+
+	@Test
+	void versionIsPrinted()
+	{
+		assertEquals(0, run("--version"));
+		assertTrue(out.contains("mystic-crypt"), "the version line must be printed");
+	}
+
+	@Test
+	void unknownSubcommandFails()
+	{
+		assertNotEquals(0, run("no-such-command"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateDisentangleCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateDisentangleCommandTest.java
@@ -1,0 +1,60 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@code obfuscate} and {@code disentangle} subcommands.
+ */
+class ObfuscateDisentangleCommandTest extends AbstractCliTest
+{
+
+	@Test
+	void obfuscateAppliesTheSubstitutionMap()
+	{
+		assertEquals(0, run("obfuscate", "--rule", "a=x", "--rule", "b=y", "--text", "abba"));
+		assertEquals("xyyx", out.strip());
+	}
+
+	@Test
+	void obfuscateAndDisentangleRoundTrip()
+	{
+		run("obfuscate", "--rule", "a=x", "--rule", "b=y", "--text", "abba");
+		String obfuscated = out.strip();
+		assertEquals(0, run("disentangle", "--rule", "a=x", "--rule", "b=y", "--text", obfuscated));
+		assertEquals("abba", out.strip());
+	}
+
+	@Test
+	void readsTextFromStdin()
+	{
+		assertEquals(0,
+			runWithStdin("abba", "obfuscate", "--rule", "a=x", "--rule", "b=y", "--text-stdin"));
+		assertEquals("xyyx", out.strip());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommandTest.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@code verify} subcommand: exit code 0 = matches, 1 = does not match.
+ */
+class VerifyCommandTest extends AbstractCliTest
+{
+
+	private String hash(String algorithm, String password)
+	{
+		run("hash", "--algorithm", algorithm, "--password", password);
+		return out.strip();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "argon2id", "pbkdf2" })
+	void correctPasswordVerifies(String algorithm)
+	{
+		String hash = hash(algorithm, "the-secret");
+		assertEquals(0,
+			run("verify", "--algorithm", algorithm, "--hash", hash, "--password", "the-secret"));
+		assertTrue(out.contains("matches"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "argon2id", "pbkdf2" })
+	void wrongPasswordDoesNotVerify(String algorithm)
+	{
+		String hash = hash(algorithm, "the-secret");
+		assertEquals(1,
+			run("verify", "--algorithm", algorithm, "--hash", hash, "--password", "wrong"));
+		assertTrue(out.contains("does not match"));
+	}
+
+	@org.junit.jupiter.api.Test
+	void readsPasswordFromStdin()
+	{
+		String hash = hash("pbkdf2", "piped");
+		assertEquals(0, runWithStdin("piped\n", "verify", "--algorithm", "pbkdf2", "--hash", hash,
+			"--password-stdin"));
+	}
+}


### PR DESCRIPTION
## Summary

Adds a command-line interface for the library under `io.github.astrapi69.mystic.crypt.cli` (root `MysticCryptCli` + subcommands), each a thin wrapper over the existing library / crypt-* APIs.

| subcommand | does |
|---|---|
| `hash` / `verify` | Argon2id or PBKDF2 (`PasswordEncryptor`); `verify` exits 0 = match, 1 = no match |
| `keygen` | RSA/DSA (key size) and X25519/X448/ML-KEM/ML-DSA (fixed params); prints or writes PEM |
| `kem` | two-party ML-KEM-512/768/1024 and hybrid X25519+ML-KEM, shows both sides derive the same shared secret |
| `checksum` | JDK `MessageDigest` over a file (MD5/SHA-1/SHA-256/…) |
| `der2pem` | DER private key → PEM |
| `obfuscate` / `disentangle` | character-substitution obfuscation (`--rule a=x`) |
| `cert` | self-signed X.509 certificate |

Passwords accept `--password-stdin` to stay out of the process argument list; Bouncy Castle is registered once for the whole CLI.

## Packaging

A shadow uber-jar task (`com.gradleup.shadow`) `shadowJar` produces `mystic-crypt-<version>-all.jar` with `Main-Class` `MysticCryptCli` for `java -jar mystic-crypt-<version>-all.jar <subcommand>`. It is an additional artifact and does **not** change the primary library jar.

`module-info` gains `requires info.picocli` plus `exports`/`opens ...cli to info.picocli` (picocli reflects on the `@Option` fields).

## Notes / decisions

- `checksum` uses JDK-native `MessageDigest` on purpose: `checksum-up`'s `getChecksum(File, Algorithm)` pulls a different crypt-api `Algorithm` across the module boundary and fails to resolve. Documented in the class; can switch to `checksum-up` (for CRC32/Adler32) once a release built against the current crypt-api is available.

## Tests

One test class per command (parametrized over algorithms) plus `CliSupportTest` and root-command tests — **68 CLI tests**, cli-package coverage **~99% instruction / 100% class**. `main()` delegates to a testable `execute()`; `KemCommand.report(...)` is extracted so both outcomes are covered. Full library suite green: **342 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)