### PR TITLE
docs: add key agreement evolution guide (book ciphers to Double Ratchet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ or over flattr:
 See [docs/CRYPTO_CAPABILITIES.md](docs/CRYPTO_CAPABILITIES.md) for a full capability matrix of
 what's implemented across this library family (and what's deliberately out of scope, and why).
 
+For background on *why* modern key agreement works the way it does, see
+[docs/KEY_AGREEMENT_EVOLUTION.md](docs/KEY_AGREEMENT_EVOLUTION.md) — an introduction that traces
+the path from book ciphers over Diffie-Hellman and Perfect Forward Secrecy to the Double Ratchet
+protocol, and maps those concepts to the building blocks in this library.
+
 Encryption and decryption processes are always executed in the backround so it is a black box for the user. If you want to
 see this library in action you can download this [gui client](https://github.com/astrapi69/mystic-crypt-ui) and see some features
 described above.

--- a/docs/KEY_AGREEMENT_EVOLUTION.md
+++ b/docs/KEY_AGREEMENT_EVOLUTION.md
@@ -1,0 +1,176 @@
+# Cryptographic Key Agreement - From Book Ciphers to Modern Protocols
+
+## Why This Matters
+
+Every encryption system faces the same fundamental question: **How do two parties agree on a shared secret without an attacker intercepting it?**
+
+This document explains the evolution of that problem and its solutions, from physical book ciphers to modern key agreement protocols.
+
+---
+
+## The Book Cipher - Where It All Started
+
+### How It Works
+
+Two parties (Alice and Bob) each possess identical copies of the same books. Every book is cataloged with an ID, and every character or word in each book has a unique position (page, line, word number).
+
+To send an encrypted message, Alice transmits only references:
+
+```
+Book 7, Page 42, Line 3, Word 5
+Book 7, Page 18, Line 11, Word 2
+Book 3, Page 91, Line 7, Word 9
+...
+```
+
+Without knowing which books Alice and Bob share, an attacker sees only meaningless numbers.
+
+### Strengths
+
+- No statistical analysis (frequency analysis) possible, as long as each position is used only once
+- The "key" (the book collection) is never transmitted over the communication channel
+- Simple to understand and execute, even without technical knowledge
+
+### The Fatal Weakness
+
+The entire book collection is a **static, pre-shared secret**. If an attacker gains access to the catalog once, every past and future message is compromised. This is known as a **single point of failure**.
+
+> **Analogy:** Imagine a master key that opens every door in a building. Convenient, but if someone copies it, every room is exposed, retroactively and permanently.
+
+---
+
+## The Core Problem - Static vs. Dynamic Secrets
+
+The Book Cipher illustrates the fundamental limitation of **pre-shared key** systems:
+
+| Property | Book Cipher | Modern Requirement |
+|---|---|---|
+| Key material | Fixed catalog | Generated per session |
+| Compromise impact | All messages exposed | Only one session exposed |
+| Key distribution | Physical exchange | Mathematical protocol |
+| Scalability | One catalog per partner | Works with any partner |
+
+The question becomes: **Can two parties generate a shared secret dynamically, without ever transmitting it?**
+
+---
+
+## Diffie-Hellman Key Exchange - The Breakthrough
+
+In 1976, Whitfield Diffie and Martin Hellman solved this problem mathematically.
+
+### The Paint Mixing Analogy
+
+1. Alice and Bob publicly agree on a base color (e.g., yellow)
+2. Each secretly picks a private color (Alice: red, Bob: blue)
+3. Each mixes their private color with the public base and sends the result
+   - Alice sends: yellow + red = orange
+   - Bob sends: yellow + blue = green
+4. Each mixes the received color with their own private color
+   - Alice computes: green + red = **brown**
+   - Bob computes: orange + blue = **brown**
+5. Both arrive at the same color (**brown**), but an attacker who saw only yellow, orange, and green cannot derive brown
+
+### In Mathematical Terms
+
+The security relies on the **Discrete Logarithm Problem**: given `g^a mod p`, it is computationally infeasible to determine `a` for sufficiently large numbers.
+
+```
+Public parameters: g (generator), p (large prime)
+Alice: picks secret a, sends A = g^a mod p
+Bob:   picks secret b, sends B = g^b mod p
+
+Alice computes: shared_secret = B^a mod p = g^(ab) mod p
+Bob computes:   shared_secret = A^b mod p = g^(ab) mod p
+```
+
+An attacker sees `g`, `p`, `A`, and `B`, but cannot compute `g^(ab) mod p` without knowing `a` or `b`.
+
+### What This Solves
+
+- No pre-shared secret required
+- The shared secret is never transmitted
+- Works between parties who have never met before
+
+### What It Does Not Solve
+
+If an attacker records all traffic and later obtains Alice's or Bob's long-term private key, they can decrypt **all past sessions**. This is where Perfect Forward Secrecy comes in.
+
+---
+
+## Perfect Forward Secrecy (PFS)
+
+### The Principle
+
+Instead of reusing the same private key across sessions, both parties generate **ephemeral (temporary) key pairs** for each session. After the session ends, the ephemeral keys are destroyed.
+
+> **Back to the Book Cipher analogy:** Instead of maintaining a permanent library, Alice and Bob write a brand-new, unique book for every single conversation, and burn it after reading.
+
+### Why This Matters
+
+Even if an attacker compromises a long-term key:
+
+- **Without PFS:** All recorded past sessions can be decrypted retroactively
+- **With PFS:** Past sessions remain secure, because the ephemeral keys no longer exist
+
+### In Practice
+
+Protocols like **TLS 1.3** mandate ephemeral Diffie-Hellman (DHE or ECDHE), ensuring that every connection generates a fresh shared secret.
+
+---
+
+## The Double Ratchet Protocol - Per-Message Security
+
+The Double Ratchet Protocol (used by Signal, WhatsApp, and other messengers) takes PFS to its logical conclusion: **every single message gets its own key**.
+
+### How It Works
+
+The protocol combines two "ratchets" (mechanisms that move forward but never backward):
+
+1. **Diffie-Hellman Ratchet:** With every message exchange, new ephemeral DH key pairs are generated, producing a fresh shared secret
+2. **Symmetric Key Ratchet:** Between DH exchanges, a hash-based chain derives a new message key for each individual message
+
+```
+Message 1: Key derived from DH exchange #1, chain step 1
+Message 2: Key derived from DH exchange #1, chain step 2
+Message 3: Key derived from DH exchange #2, chain step 1  (new DH ratchet step)
+Message 4: Key derived from DH exchange #2, chain step 2
+...
+```
+
+### Security Properties
+
+- **Forward Secrecy:** Compromising a current key reveals nothing about past messages
+- **Break-in Recovery:** Even if an attacker temporarily compromises a session, the next DH ratchet step locks them out again
+- **No static catalog:** There is no master secret that, if exposed, breaks everything
+
+> **Final analogy:** The Double Ratchet is like Alice and Bob co-authoring a new book for every single sentence they exchange, where each new book depends on the previous one, and all previous books are shredded immediately after use.
+
+---
+
+## Summary
+
+| Concept | Key Lifecycle | Compromise Impact | Book Cipher Equivalent |
+|---|---|---|---|
+| **Book Cipher** | Static, pre-shared | All messages, past and future | Permanent shared library |
+| **Diffie-Hellman** | Per session, dynamic | One session | A new book per conversation |
+| **PFS (Ephemeral DH)** | Per session, destroyed after use | Nothing retroactive | A new book, burned after reading |
+| **Double Ratchet** | Per message, continuously evolving | One message at most | A new book per sentence, shredded immediately |
+
+The evolution from Book Cipher to Double Ratchet is the evolution from **"guard the library"** to **"there is no library to steal"**.
+
+---
+
+## Where These Concepts Live in This Library
+
+The concepts above map to concrete building blocks in the `mystic-crypt` library family:
+
+| Concept | Implementation |
+|---|---|
+| Diffie-Hellman / ECDH (generic) | `KeyAgreementAlgorithm` (`crypt-api`) defines `DIFFIE_HELLMAN`, `ECDH`, `X25519`, `X448` and more; `KeyAgreementFactory` (`crypt-data`) executes the agreement |
+| Modern ephemeral key agreement | `X25519KeyExchange` (`mystic-crypt`) — X25519 ECDH with HKDF key derivation, JDK-native. Generate a fresh key pair per session and you have ephemeral DH (the PFS building block) |
+| Key derivation for the shared secret | `X25519KeyExchange` runs the raw shared secret through HKDF rather than using it directly — the same pattern the symmetric ratchet chain in Double Ratchet builds on |
+
+A full Double Ratchet is a *protocol* (with session state, message ordering, and out-of-order
+handling) and is out of scope for a key/data-encryption utility library — but the primitives it
+is built from (ephemeral ECDH + HKDF chains) are all here. See
+[CRYPTO_CAPABILITIES.md](CRYPTO_CAPABILITIES.md) for the full capability matrix.


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

- Add `docs/KEY_AGREEMENT_EVOLUTION.md`, an educational document tracing the evolution of shared-secret establishment: book ciphers, the static pre-shared-key problem, Diffie-Hellman key exchange, Perfect Forward Secrecy, and the Double Ratchet protocol
- Include a closing section mapping these concepts to the library's actual building blocks (`KeyAgreementAlgorithm`/`KeyAgreementFactory`, `X25519KeyExchange` with HKDF), with a cross-link to `docs/CRYPTO_CAPABILITIES.md`
- Link the new document from the README, next to the existing capability-matrix reference

@astrapi69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT5RJLeeJJFdDTV2HTg5oq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT5RJLeeJJFdDTV2HTg5oq)_