### PR TITLE
test: coverage to 99%/98%, PIT mutation score 96%

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Java CI with Gradle](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml/badge.svg)](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml)
 [![Coverage Status](https://codecov.io/gh/astrapi69/mystic-crypt/branch/develop/graph/badge.svg)](https://codecov.io/gh/astrapi69/mystic-crypt)
-[![Mutation Coverage](https://img.shields.io/badge/mutation%20coverage-69%25-yellow)](https://pitest.org/)
+[![Mutation Coverage](https://img.shields.io/badge/mutation%20coverage-96%25-brightgreen)](https://pitest.org/)
 [![Open Issues](https://img.shields.io/github/issues/astrapi69/mystic-crypt.svg?style=flat)](https://github.com/astrapi69/mystic-crypt/issues)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.astrapi69/mystic-crypt.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.astrapi69/mystic-crypt)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](http://opensource.org/licenses/MIT)

--- a/gradle/mutation-testing.gradle
+++ b/gradle/mutation-testing.gradle
@@ -7,6 +7,6 @@ pitest {
     pitestVersion = libs.versions.pitest.version.get()
     targetClasses = ["io.github.astrapi69.mystic.crypt.*"]
     threads = 4
-    outputFormats = ["HTML"]
+    outputFormats = ["HTML", "XML"]
     timestampedReports = false
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/aead/KeyCommittingAeadEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/aead/KeyCommittingAeadEncryptorTest.java
@@ -209,6 +209,27 @@ class KeyCommittingAeadEncryptorTest
 	}
 
 	@Test
+	void testDecryptRejectsDataShorterThanTheMinimumLength()
+	{
+		// NONCE_LENGTH (12) + COMMITMENT_TAG_LENGTH (32) + 1 = 45 is the minimum length; one byte
+		// less must be rejected by the length guard
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> encryptor.decrypt(new byte[44]));
+		assertTrue(exception.getMessage().contains("too short"));
+	}
+
+	@Test
+	void testDecryptWithDataOfExactlyTheMinimumLengthIsNotRejectedByTheLengthGuard()
+	{
+		// data of exactly the minimum length (45 bytes) must pass the length guard and fail later
+		// during commitment verification, not be rejected by the "too short" guard. This pins the
+		// boundary so a <= mutant is caught.
+		Exception exception = assertThrows(Exception.class, () -> encryptor.decrypt(new byte[45]));
+		assertFalse(exception instanceof IllegalArgumentException,
+			"data of exactly the minimum length must pass the length guard, not be rejected by it");
+	}
+
+	@Test
 	void testWrongAssociatedDataFailsDecryption() throws Exception
 	{
 		byte[] plaintext = "Message with AD".getBytes();

--- a/src/test/java/io/github/astrapi69/mystic/crypt/algorithm/MysticSymmetricAlgorithmTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/algorithm/MysticSymmetricAlgorithmTest.java
@@ -1,0 +1,98 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.algorithm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.Stream;
+
+import javax.crypto.Cipher;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The unit test class for the enum {@link MysticSymmetricAlgorithm}
+ */
+public class MysticSymmetricAlgorithmTest
+{
+
+	/**
+	 * A scenario with the expected transformation of an algorithm
+	 *
+	 * @param algorithm
+	 *            the algorithm
+	 * @param expectedTransformation
+	 *            the expected transformation string
+	 */
+	record AlgorithmCase(MysticSymmetricAlgorithm algorithm, String expectedTransformation) {
+		@Override
+		public String toString()
+		{
+			return algorithm.name();
+		}
+	}
+
+	static Stream<AlgorithmCase> algorithmCases()
+	{
+		return Stream.of(
+			new AlgorithmCase(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING, "AES/GCM/NoPadding"),
+			new AlgorithmCase(MysticSymmetricAlgorithm.CHACHA20_POLY1305, "ChaCha20-Poly1305"));
+	}
+
+	/**
+	 * Test method for {@link MysticSymmetricAlgorithm#getAlgorithm()} and
+	 * {@link MysticSymmetricAlgorithm#toString()}, both answer the transformation string
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("algorithmCases")
+	public void getAlgorithmAndToString_answerTheTransformation(final AlgorithmCase testCase)
+	{
+		assertEquals(testCase.expectedTransformation(), testCase.algorithm().getAlgorithm());
+		assertEquals(testCase.expectedTransformation(), testCase.algorithm().toString());
+	}
+
+	/**
+	 * Test method for {@link MysticSymmetricAlgorithm#getAlgorithm()}, every transformation of this
+	 * enum has to be resolvable by the java cryptography architecture
+	 *
+	 * @param algorithm
+	 *            the algorithm
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@ParameterizedTest
+	@EnumSource(MysticSymmetricAlgorithm.class)
+	public void everyAlgorithmIsAKnownTransformation(final MysticSymmetricAlgorithm algorithm)
+		throws Exception
+	{
+		assertNotNull(Cipher.getInstance(algorithm.getAlgorithm()));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/base/BaseByteArrayEnDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/base/BaseByteArrayEnDecryptorTest.java
@@ -26,17 +26,22 @@ package io.github.astrapi69.mystic.crypt.base;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.util.Arrays;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
+import io.github.astrapi69.crypt.api.algorithm.compound.CompoundAlgorithm;
 import io.github.astrapi69.crypt.data.factory.SecretKeyFactoryExtensions;
 import io.github.astrapi69.crypt.data.model.CryptModel;
 import io.github.astrapi69.mystic.crypt.algorithm.MysticSymmetricAlgorithm;
@@ -154,4 +159,78 @@ public class BaseByteArrayEnDecryptorTest
 			new String(decryptor.decrypt(secondEncrypted), StandardCharsets.UTF_8));
 	}
 
+	/**
+	 * Test method for {@link BaseByteArrayDecryptor#decrypt(byte[])}, encrypted data that is
+	 * shorter than the nonce has to be rejected
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testDecryptWithDataShorterThanTheNonce() throws Exception
+	{
+		SecretKey gcmKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.name(), 128);
+		CryptModel<Cipher, SecretKey, String> gcmModel = CryptModel
+			.<Cipher, SecretKey, String> builder().key(gcmKey)
+			.algorithm(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING).build();
+		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(gcmModel);
+
+		assertThrows(IllegalArgumentException.class, () -> decryptor.decrypt(new byte[11]));
+	}
+
+	/**
+	 * Test method for {@link BaseByteArrayDecryptor#decrypt(byte[])}, data of exactly the nonce
+	 * length is <em>not</em> rejected by the length guard (it fails later during GCM decryption).
+	 * This pins the boundary of the {@code length < NONCE_LENGTH} check so a {@code <=} mutant is
+	 * caught.
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testDecryptWithDataOfExactlyTheNonceLengthIsNotRejectedByTheLengthGuard()
+		throws Exception
+	{
+		SecretKey gcmKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.name(), 128);
+		CryptModel<Cipher, SecretKey, String> gcmModel = CryptModel
+			.<Cipher, SecretKey, String> builder().key(gcmKey)
+			.algorithm(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING).build();
+		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(gcmModel);
+
+		Exception exception = assertThrows(Exception.class, () -> decryptor.decrypt(new byte[12]));
+		assertFalse(exception instanceof IllegalArgumentException,
+			"data of exactly the nonce length must pass the length guard, not be rejected by it");
+	}
+
+	/**
+	 * Test method for {@link BaseByteArrayEncryptor#BaseByteArrayEncryptor(SecretKey)} and
+	 * {@link BaseByteArrayDecryptor#BaseByteArrayDecryptor(SecretKey)}, the constructors with the
+	 * symmetric key only have to result in a working encryptor and decryptor pair
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testEncryptDecryptWithSymmetricKeyOnlyConstructors() throws Exception
+	{
+		// the key-only constructors fall back to the default PBE algorithm, which rejects a plain
+		// AES key, so both constructors must fail fast with an InvalidKeyException
+		assertThrows(InvalidKeyException.class, () -> new BaseByteArrayEncryptor(secretKey));
+		assertThrows(InvalidKeyException.class, () -> new BaseByteArrayDecryptor(secretKey));
+
+		// a PBE key that carries its own salt and iteration count is accepted and round trips
+		String algorithm = CompoundAlgorithm.PBE_WITH_SHA1_AND_128BIT_AES_CBC_BC.getAlgorithm();
+		SecretKey pbeKey = SecretKeyFactory.getInstance(algorithm, "BC")
+			.generateSecret(new PBEKeySpec("top secret".toCharArray(),
+				new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, 1000));
+		BaseByteArrayEncryptor encryptor = new BaseByteArrayEncryptor(pbeKey);
+		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(pbeKey);
+		byte[] plainMessageBytes = "the quick brown fox".getBytes(StandardCharsets.UTF_8);
+
+		byte[] encrypted = encryptor.encrypt(plainMessageBytes);
+
+		assertFalse(Arrays.equals(plainMessageBytes, encrypted));
+		assertEquals("the quick brown fox",
+			new String(decryptor.decrypt(encrypted), StandardCharsets.UTF_8));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/core/AbstractCryptorKeyConstructorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/core/AbstractCryptorKeyConstructorTest.java
@@ -1,0 +1,203 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.astrapi69.crypt.data.factory.CipherFactory;
+
+/**
+ * The unit test class for the key only constructors of the abstract cryptor classes
+ * {@link AbstractFileEncryptor}, {@link AbstractFileDecryptor} and {@link AbstractObjectDecryptor}
+ */
+public class AbstractCryptorKeyConstructorTest
+{
+
+	private static final String PRIVATE_KEY = "top-secret-key";
+
+	/**
+	 * Test method for {@link AbstractFileEncryptor#AbstractFileEncryptor(String)}, the key only
+	 * constructor has to create an initialized model with the given key
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void abstractFileEncryptor_withKeyOnly_createsAnInitializedModel() throws Exception
+	{
+		TestFileEncryptor encryptor = new TestFileEncryptor(PRIVATE_KEY);
+
+		assertEquals(PRIVATE_KEY, encryptor.getModel().getKey());
+		assertTrue(encryptor.getModel().isInitialized());
+		assertNotNull(encryptor.getModel().getCipher());
+		assertEquals(Cipher.ENCRYPT_MODE, encryptor.newOperationMode());
+	}
+
+	/**
+	 * Test method for {@link AbstractFileDecryptor#AbstractFileDecryptor(String)}, the key only
+	 * constructor has to create an initialized model with the given key
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void abstractFileDecryptor_withKeyOnly_createsAnInitializedModel() throws Exception
+	{
+		TestFileDecryptor decryptor = new TestFileDecryptor(PRIVATE_KEY);
+
+		assertEquals(PRIVATE_KEY, decryptor.getModel().getKey());
+		assertTrue(decryptor.getModel().isInitialized());
+		assertNotNull(decryptor.getModel().getCipher());
+		assertEquals(Cipher.DECRYPT_MODE, decryptor.newOperationMode());
+	}
+
+	/**
+	 * Test method for {@link AbstractObjectDecryptor#AbstractObjectDecryptor(String)}, the key only
+	 * constructor has to create an initialized model with the given key
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void abstractObjectDecryptor_withKeyOnly_createsAnInitializedModel() throws Exception
+	{
+		TestObjectDecryptor decryptor = new TestObjectDecryptor(PRIVATE_KEY);
+
+		assertEquals(PRIVATE_KEY, decryptor.getModel().getKey());
+		assertTrue(decryptor.getModel().isInitialized());
+		assertNotNull(decryptor.getModel().getCipher());
+		assertEquals(Cipher.DECRYPT_MODE, decryptor.newOperationMode());
+	}
+
+	private static Cipher newPbeCipher(final String key, final String algorithm, final byte[] salt,
+		final int iterationCount, final int operationMode)
+		throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
+		InvalidKeyException, InvalidAlgorithmParameterException
+	{
+		return CipherFactory.newPBECipher(key.toCharArray(), operationMode, algorithm, salt,
+			iterationCount);
+	}
+
+	private static class TestFileEncryptor extends AbstractFileEncryptor
+	{
+		private static final long serialVersionUID = 1L;
+
+		TestFileEncryptor(final String privateKey)
+			throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException,
+			NoSuchPaddingException, InvalidAlgorithmParameterException, UnsupportedEncodingException
+		{
+			super(privateKey);
+		}
+
+		@Override
+		public File encrypt(final File toEncrypt)
+		{
+			throw new UnsupportedOperationException("not needed for this test");
+		}
+
+		@Override
+		public byte[] encrypt(final byte[] toEncrypt)
+		{
+			throw new UnsupportedOperationException("not needed for this test");
+		}
+
+		@Override
+		protected Cipher newCipher(final String key, final String algorithm, final byte[] salt,
+			final int iterationCount, final int operationMode)
+			throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
+			InvalidKeyException, InvalidAlgorithmParameterException
+		{
+			return newPbeCipher(key, algorithm, salt, iterationCount, operationMode);
+		}
+	}
+
+	private static class TestFileDecryptor extends AbstractFileDecryptor
+	{
+		private static final long serialVersionUID = 1L;
+
+		TestFileDecryptor(final String privateKey)
+			throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException,
+			NoSuchPaddingException, InvalidAlgorithmParameterException, UnsupportedEncodingException
+		{
+			super(privateKey);
+		}
+
+		@Override
+		public File decrypt(final File encrypted)
+		{
+			throw new UnsupportedOperationException("not needed for this test");
+		}
+
+		@Override
+		protected Cipher newCipher(final String key, final String algorithm, final byte[] salt,
+			final int iterationCount, final int operationMode)
+			throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
+			InvalidKeyException, InvalidAlgorithmParameterException
+		{
+			return newPbeCipher(key, algorithm, salt, iterationCount, operationMode);
+		}
+	}
+
+	private static class TestObjectDecryptor extends AbstractObjectDecryptor<String, String>
+	{
+		private static final long serialVersionUID = 1L;
+
+		TestObjectDecryptor(final String privateKey)
+			throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException,
+			NoSuchPaddingException, InvalidAlgorithmParameterException, UnsupportedEncodingException
+		{
+			super(privateKey);
+		}
+
+		@Override
+		public String decrypt(final File encrypted)
+		{
+			throw new UnsupportedOperationException("not needed for this test");
+		}
+
+		@Override
+		protected Cipher newCipher(final String key, final String algorithm, final byte[] salt,
+			final int iterationCount, final int operationMode)
+			throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
+			InvalidKeyException, InvalidAlgorithmParameterException
+		{
+			return newPbeCipher(key, algorithm, salt, iterationCount, operationMode);
+		}
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/core/AbstractCryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/core/AbstractCryptorTest.java
@@ -27,18 +27,25 @@ package io.github.astrapi69.mystic.crypt.core;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.Arrays;
 
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
 
 import org.junit.jupiter.api.Test;
 
@@ -156,6 +163,73 @@ public class AbstractCryptorTest
 			CryptModel.<Cipher, String, String> builder().key("test-password").build());
 	}
 
+	@Test
+	public void keyOnlyConstructor_buildsAModelWithThatKeyAndInitializesIt() throws Exception
+	{
+		TestPbeCryptor cryptor = new TestPbeCryptor("test-password");
+
+		assertEquals("test-password", cryptor.getModel().getKey());
+		assertNotNull(cryptor.getModel().getCipher());
+		assertNotNull(cryptor.getModel().getSalt());
+	}
+
+	@Test
+	public void newAlgorithmParameterSpec_answersThePbeParameterSpecWithSaltAndIterationCount()
+		throws Exception
+	{
+		byte[] salt = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		TestPbeCryptor cryptor = new TestPbeCryptor(
+			CryptModel.<Cipher, String, String> builder().key("test-password").build());
+
+		AlgorithmParameterSpec parameterSpec = cryptor.newAlgorithmParameterSpec(salt, 4711);
+
+		assertInstanceOf(PBEParameterSpec.class, parameterSpec);
+		assertArrayEquals(salt, ((PBEParameterSpec)parameterSpec).getSalt());
+		assertEquals(4711, ((PBEParameterSpec)parameterSpec).getIterationCount());
+	}
+
+	@Test
+	public void newKeySpec_answersThePbeKeySpecWithPasswordSaltAndIterationCount() throws Exception
+	{
+		byte[] salt = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		TestPbeCryptor cryptor = new TestPbeCryptor(
+			CryptModel.<Cipher, String, String> builder().key("test-password").build());
+
+		KeySpec keySpec = cryptor.newKeySpec("test-password", salt, 4711);
+
+		assertInstanceOf(PBEKeySpec.class, keySpec);
+		assertArrayEquals("test-password".toCharArray(), ((PBEKeySpec)keySpec).getPassword());
+		assertArrayEquals(salt, ((PBEKeySpec)keySpec).getSalt());
+		assertEquals(4711, ((PBEKeySpec)keySpec).getIterationCount());
+	}
+
+	@Test
+	public void newCipher_withSecretKeyAndParameterSpec_producesAWorkingCipherPair()
+		throws Exception
+	{
+		byte[] salt = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		int iterationCount = 1024;
+		String algorithm = CompoundAlgorithm.PBE_WITH_SHA1_AND_128BIT_AES_CBC_BC.getAlgorithm();
+		TestPbeCryptor cryptor = new TestPbeCryptor(
+			CryptModel.<Cipher, String, String> builder().key("test-password").build());
+
+		SecretKey secretKey = cryptor.newSecretKeyFactory(algorithm)
+			.generateSecret(cryptor.newKeySpec("test-password", salt, iterationCount));
+		AlgorithmParameterSpec parameterSpec = cryptor.newAlgorithmParameterSpec(salt,
+			iterationCount);
+
+		Cipher encryptCipher = cryptor.newCipher(Cipher.ENCRYPT_MODE, secretKey, parameterSpec,
+			algorithm);
+		Cipher decryptCipher = cryptor.newCipher(Cipher.DECRYPT_MODE, secretKey, parameterSpec,
+			algorithm);
+
+		assertEquals(algorithm, encryptCipher.getAlgorithm());
+		byte[] plain = "the quick brown fox".getBytes(StandardCharsets.UTF_8);
+		byte[] encrypted = encryptCipher.doFinal(plain);
+		assertFalse(Arrays.equals(plain, encrypted));
+		assertArrayEquals(plain, decryptCipher.doFinal(encrypted));
+	}
+
 	/**
 	 * Minimal concrete {@link AbstractCryptor} subclass used only to exercise the protected
 	 * factory-method defaults under test. Builds a real PBE {@link Cipher} so construction also
@@ -168,6 +242,11 @@ public class AbstractCryptorTest
 		TestPbeCryptor(final CryptModel<Cipher, String, String> model) throws Exception
 		{
 			super(model);
+		}
+
+		TestPbeCryptor(final String key) throws Exception
+		{
+			super(key);
 		}
 
 		@Override

--- a/src/test/java/io/github/astrapi69/mystic/crypt/core/ChainableCryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/core/ChainableCryptorTest.java
@@ -1,0 +1,119 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.core;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.astrapi69.crypt.api.Decryptor;
+import io.github.astrapi69.crypt.api.Encryptor;
+
+/**
+ * The unit test class for the classes {@link ChainableEncryptor} and {@link ChainableDecryptor}
+ */
+public class ChainableCryptorTest
+{
+
+	private static final Encryptor<String, String> APPEND_ONE = toEncrypt -> toEncrypt + "1";
+
+	private static final Encryptor<String, String> APPEND_TWO = toEncrypt -> toEncrypt + "2";
+
+	private static final Decryptor<String, String> REMOVE_LAST = encrypted -> encrypted.substring(0,
+		encrypted.length() - 1);
+
+	private static class StringChainEncryptor extends ChainableEncryptor<String>
+	{
+		@SafeVarargs
+		StringChainEncryptor(final Encryptor<String, String>... encryptors)
+		{
+			super(encryptors);
+		}
+	}
+
+	private static class StringChainDecryptor extends ChainableDecryptor<String>
+	{
+		@SafeVarargs
+		StringChainDecryptor(final Decryptor<String, String>... decryptors)
+		{
+			super(decryptors);
+		}
+	}
+
+	/**
+	 * Test method for {@link ChainableEncryptor#encrypt(Object)}, every encryptor of the chain has
+	 * to be applied in the given order
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void encrypt_appliesEveryEncryptorOfTheChainInOrder() throws Exception
+	{
+		StringChainEncryptor encryptor = new StringChainEncryptor(APPEND_ONE, APPEND_TWO);
+
+		assertEquals("foo12", encryptor.encrypt("foo"));
+	}
+
+	/**
+	 * Test method for {@link ChainableEncryptor#getEncryptors()}, the chained encryptors are
+	 * answered in the given order
+	 */
+	@Test
+	public void getEncryptors_answersTheChainedEncryptors()
+	{
+		StringChainEncryptor encryptor = new StringChainEncryptor(APPEND_ONE, APPEND_TWO);
+
+		assertArrayEquals(new Object[] { APPEND_ONE, APPEND_TWO }, encryptor.getEncryptors());
+	}
+
+	/**
+	 * Test method for {@link ChainableDecryptor#decrypt(Object)}, every decryptor of the chain has
+	 * to be applied in the given order
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_appliesEveryDecryptorOfTheChainInOrder() throws Exception
+	{
+		StringChainDecryptor decryptor = new StringChainDecryptor(REMOVE_LAST, REMOVE_LAST);
+
+		assertEquals("foo", decryptor.decrypt("foo12"));
+	}
+
+	/**
+	 * Test method for {@link ChainableDecryptor#getDecryptors()}, the chained decryptors are
+	 * answered in the given order
+	 */
+	@Test
+	public void getDecryptors_answersTheChainedDecryptors()
+	{
+		StringChainDecryptor decryptor = new StringChainDecryptor(REMOVE_LAST, REMOVE_LAST);
+
+		assertArrayEquals(new Object[] { REMOVE_LAST, REMOVE_LAST }, decryptor.getDecryptors());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
@@ -25,13 +25,16 @@
 package io.github.astrapi69.mystic.crypt.decorator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
 
@@ -365,4 +368,160 @@ public class CryptObjectDecoratorExtensionsTest
 		assertEquals(actual, expected);
 	}
 
+
+	/**
+	 * A scenario for undecorating with a character decorator
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param input
+	 *            the decorated input
+	 * @param prefix
+	 *            the prefix character
+	 * @param suffix
+	 *            the suffix character
+	 * @param expected
+	 *            the expected undecorated result
+	 */
+	record CharacterUndecorateCase(String description, String input, char prefix, char suffix,
+		String expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<CharacterUndecorateCase> characterUndecorateCases()
+	{
+		return Stream.of(new CharacterUndecorateCase("prefix and suffix", "[abc]", '[', ']', "abc"),
+			new CharacterUndecorateCase("only the prefix", "[abc", '[', ']', "abc"),
+			new CharacterUndecorateCase("only the suffix", "abc]", '[', ']', "abc"),
+			new CharacterUndecorateCase("neither prefix nor suffix", "abc", '[', ']', "abc"),
+			new CharacterUndecorateCase("same character as prefix and suffix", "sabcs", 's', 's',
+				"abc"));
+	}
+
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateWithCharacterDecorator(String, CryptObjectDecorator)}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("characterUndecorateCases")
+	void undecorateWithCharacterDecorator_removesOnlyThePresentDecorations(
+		final CharacterUndecorateCase testCase)
+	{
+		CryptObjectDecorator<Character> characterDecorator = CryptObjectDecorator
+			.<Character> builder().prefix(testCase.prefix()).suffix(testCase.suffix()).build();
+
+		assertEquals(testCase.expected(), CryptObjectDecoratorExtensions
+			.undecorateWithCharacterDecorator(testCase.input(), characterDecorator));
+	}
+
+	/**
+	 * A scenario for undecorating with a byte array decorator
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param input
+	 *            the decorated input
+	 * @param prefix
+	 *            the prefix
+	 * @param suffix
+	 *            the suffix
+	 * @param expected
+	 *            the expected undecorated result
+	 */
+	record ByteArrayUndecorateCase(String description, String input, String prefix, String suffix,
+		String expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<ByteArrayUndecorateCase> byteArrayUndecorateCases()
+	{
+		return Stream.of(
+			new ByteArrayUndecorateCase("prefix and suffix", "<<abc>>", "<<", ">>", "abc"),
+			new ByteArrayUndecorateCase("only the suffix", "abc>>", "<<", ">>", "abc"),
+			new ByteArrayUndecorateCase("suffix that only partially matches", "abc=>", "<<", ">>",
+				"abc=>"),
+			new ByteArrayUndecorateCase("suffix longer than the input", "a", "<<", ">>>>", "a"),
+			new ByteArrayUndecorateCase("empty suffix is never removed", "abc", "<<", "", "abc"),
+			new ByteArrayUndecorateCase("neither prefix nor suffix", "abc", "<<", ">>", "abc"),
+			new ByteArrayUndecorateCase(
+				"prefix bytes that appear elsewhere are removed from the input once", "a<b<c", "<<",
+				">>", "abc"),
+			new ByteArrayUndecorateCase("a doubled prefix is removed completely", "<<<<abc", "<<",
+				">>", "abc"),
+			new ByteArrayUndecorateCase("a prefix that only partially matches is kept", "<=abc",
+				"<<", ">>", "=abc"));
+	}
+
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateWithBytearrayDecorator(String, CryptObjectDecorator)}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("byteArrayUndecorateCases")
+	void undecorateWithBytearrayDecorator_removesOnlyThePresentDecorations(
+		final ByteArrayUndecorateCase testCase)
+	{
+		CryptObjectDecorator<byte[]> byteArrayDecorator = CryptObjectDecorator.<byte[]> builder()
+			.prefix(testCase.prefix().getBytes(StandardCharsets.UTF_8))
+			.suffix(testCase.suffix().getBytes(StandardCharsets.UTF_8)).build();
+
+		assertEquals(testCase.expected(), CryptObjectDecoratorExtensions
+			.undecorateWithBytearrayDecorator(testCase.input(), byteArrayDecorator));
+	}
+
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateWithBytearrayDecorator(String, CryptObjectDecorator)}
+	 * with an input that is shorter than the suffix but matches its tail
+	 * <p>
+	 * Note: this test documents a known defect. The suffix check runs out of input bytes before it
+	 * runs out of suffix bytes and answers true, so the removal of the suffix tries to copy a
+	 * negative number of bytes.
+	 */
+	@Test
+	void undecorateWithBytearrayDecorator_currentlyFailsForAnInputShorterThanAMatchingSuffix()
+	{
+		CryptObjectDecorator<byte[]> byteArrayDecorator = CryptObjectDecorator.<byte[]> builder()
+			.prefix(new byte[0]).suffix(">>".getBytes(StandardCharsets.UTF_8)).build();
+
+		assertThrows(NegativeArraySizeException.class, () -> CryptObjectDecoratorExtensions
+			.undecorateWithBytearrayDecorator(">", byteArrayDecorator));
+	}
+
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#decorateFile(java.io.File, CryptObjectDecorator)}: the
+	 * file content must be wrapped with the decorator's prefix and suffix. Guards against a mutant
+	 * that returns an empty string.
+	 *
+	 * @throws java.io.IOException
+	 *             if an I/O error occurs
+	 */
+	@Test
+	void decorateFile_wrapsTheFileContentWithThePrefixAndSuffix() throws java.io.IOException
+	{
+		java.io.File file = java.io.File.createTempFile("decorate-file-test", ".txt");
+		file.deleteOnExit();
+		java.nio.file.Files.write(file.toPath(), "payload".getBytes(StandardCharsets.UTF_8));
+
+		CryptObjectDecorator<String> decorator = CryptObjectDecorator.<String> builder()
+			.prefix("<<").suffix(">>").build();
+
+		String result = CryptObjectDecoratorExtensions.decorateFile(file, decorator);
+		assertEquals("<<payload>>", result);
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/FileCryptorEdgeCasesTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/FileCryptorEdgeCasesTest.java
@@ -1,0 +1,256 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.file;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.util.List;
+
+import javax.crypto.Cipher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.astrapi69.collection.list.ListFactory;
+import io.github.astrapi69.crypt.api.algorithm.SunJCEAlgorithm;
+import io.github.astrapi69.crypt.data.model.CryptModel;
+import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
+import io.github.astrapi69.file.read.ReadFileExtensions;
+import io.github.astrapi69.file.write.StoreFileExtensions;
+
+/**
+ * The unit test class for the edge cases of the file based cryptors {@link FileEncryptor},
+ * {@link FileDecryptor}, {@link PBEFileEncryptor}, {@link PBEFileDecryptor} and
+ * {@link GenericObjectEncryptor}
+ */
+public class FileCryptorEdgeCasesTest
+{
+
+	private static final String KEY = "D1D15ED36B887AF1";
+
+	/** a fixed salt so that separately built encryptor and decryptor models derive the same key */
+	private static final byte[] SALT = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+	private static final String CONTENT = "the quick brown fox jumps over the lazy dog";
+
+	private static CryptModel<Cipher, String, String> newCryptModel(
+		final List<CryptObjectDecorator<String>> decorators)
+	{
+		var builder = CryptModel.<Cipher, String, String> builder().key(KEY)
+			.algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(SALT);
+		if (decorators != null)
+		{
+			builder.decorators(decorators);
+		}
+		return builder.build();
+	}
+
+	private static List<CryptObjectDecorator<String>> newDecorators()
+	{
+		return ListFactory.newArrayList(
+			CryptObjectDecorator.<String> builder().prefix("<<").suffix(">>").build());
+	}
+
+	private static File newFileToEncrypt(final File parent) throws Exception
+	{
+		File toEncrypt = new File(parent, "secret-message.txt");
+		StoreFileExtensions.toFile(toEncrypt, CONTENT);
+		return toEncrypt;
+	}
+
+	/**
+	 * Test method for {@link FileEncryptor#encrypt(byte[])}, a file encryptor can not encrypt a
+	 * byte array
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void fileEncryptor_canNotEncryptAByteArray() throws Exception
+	{
+		FileEncryptor encryptor = new FileEncryptor(newCryptModel(null));
+
+		assertThrows(UnsupportedOperationException.class,
+			() -> encryptor.encrypt(new byte[] { 1, 2, 3 }));
+	}
+
+	/**
+	 * Test method for {@link PBEFileEncryptor#encrypt(byte[])}, a file encryptor can not encrypt a
+	 * byte array
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void pbeFileEncryptor_canNotEncryptAByteArray() throws Exception
+	{
+		PBEFileEncryptor encryptor = new PBEFileEncryptor(newCryptModel(null));
+
+		assertThrows(UnsupportedOperationException.class,
+			() -> encryptor.encrypt(new byte[] { 1, 2, 3 }));
+	}
+
+	/**
+	 * Test method for {@link GenericObjectEncryptor#encrypt(byte[])} and
+	 * {@link GenericObjectEncryptor#newEncryptedFile(String, String)}
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void genericObjectEncryptor_byteArrayEncryptionIsEmptyAndNewEncryptedFileIsResolved(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		GenericObjectEncryptor<String, String> encryptor = new GenericObjectEncryptor<>(
+			newCryptModel(null), new File(temporaryDirectory, "encrypted.enc"));
+
+		assertArrayEquals(new byte[0], encryptor.encrypt(new byte[] { 1, 2, 3 }));
+
+		File newEncryptedFile = encryptor.newEncryptedFile(temporaryDirectory.getAbsolutePath(),
+			"other.enc");
+		assertEquals("other.enc", newEncryptedFile.getName());
+		assertEquals(temporaryDirectory.getAbsolutePath(),
+			newEncryptedFile.getParentFile().getAbsolutePath());
+	}
+
+	/**
+	 * Test method for {@link FileEncryptor#encrypt(File)} and {@link FileDecryptor#decrypt(File)},
+	 * a configured decorator must not break the round trip of the file content
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void fileEncryptorAndDecryptor_withDecorators_roundTripTheFileContent(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File toEncrypt = newFileToEncrypt(temporaryDirectory);
+		File encryptedFile = new File(temporaryDirectory, "encrypted.enc");
+		File decryptedFile = new File(temporaryDirectory, "decrypted.txt");
+
+		FileEncryptor encryptor = new FileEncryptor(newCryptModel(newDecorators()), encryptedFile);
+		FileDecryptor decryptor = new FileDecryptor(newCryptModel(newDecorators()), decryptedFile);
+
+		File encrypted = encryptor.encrypt(toEncrypt);
+		File decrypted = decryptor.decrypt(encrypted);
+
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(decrypted));
+	}
+
+	/**
+	 * Test method for the file cryptors with an empty decorator list, the empty list must be
+	 * treated like no decorators at all
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void fileCryptors_withAnEmptyDecoratorList_roundTripTheFileContent(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File toEncrypt = newFileToEncrypt(temporaryDirectory);
+		List<CryptObjectDecorator<String>> noDecorators = ListFactory.newArrayList();
+
+		File encrypted = new FileEncryptor(newCryptModel(noDecorators),
+			new File(temporaryDirectory, "plain.enc")).encrypt(toEncrypt);
+		File decrypted = new FileDecryptor(newCryptModel(noDecorators),
+			new File(temporaryDirectory, "plain.txt")).decrypt(encrypted);
+		File pbeEncrypted = new PBEFileEncryptor(newCryptModel(noDecorators),
+			new File(temporaryDirectory, "pbe.enc")).encrypt(toEncrypt);
+		File pbeDecrypted = new PBEFileDecryptor(newCryptModel(noDecorators),
+			new File(temporaryDirectory, "pbe.txt")).decrypt(pbeEncrypted);
+
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(decrypted));
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(pbeDecrypted));
+	}
+
+	/**
+	 * Test method for the file cryptors with the decorators explicitly set to null, which must be
+	 * treated like no decorators at all
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void fileCryptors_withNullDecorators_roundTripTheFileContent(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File toEncrypt = newFileToEncrypt(temporaryDirectory);
+		CryptModel<Cipher, String, String> model = newCryptModel(null);
+		model.setDecorators(null);
+
+		File encrypted = new FileEncryptor(model, new File(temporaryDirectory, "plain.enc"))
+			.encrypt(toEncrypt);
+		File decrypted = new FileDecryptor(model, new File(temporaryDirectory, "plain.txt"))
+			.decrypt(encrypted);
+		File pbeEncrypted = new PBEFileEncryptor(model, new File(temporaryDirectory, "pbe.enc"))
+			.encrypt(toEncrypt);
+		File pbeDecrypted = new PBEFileDecryptor(model, new File(temporaryDirectory, "pbe.txt"))
+			.decrypt(pbeEncrypted);
+
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(decrypted));
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(pbeDecrypted));
+	}
+
+	/**
+	 * Test method for {@link PBEFileEncryptor#encrypt(File)} and
+	 * {@link PBEFileDecryptor#decrypt(File)}, a configured decorator must not break the round trip
+	 * of the file content
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void pbeFileEncryptorAndDecryptor_withDecorators_roundTripTheFileContent(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File toEncrypt = newFileToEncrypt(temporaryDirectory);
+		File encryptedFile = new File(temporaryDirectory, "encrypted.enc");
+		File decryptedFile = new File(temporaryDirectory, "decrypted.txt");
+
+		PBEFileEncryptor encryptor = new PBEFileEncryptor(newCryptModel(newDecorators()),
+			encryptedFile);
+		PBEFileDecryptor decryptor = new PBEFileDecryptor(newCryptModel(newDecorators()),
+			decryptedFile);
+
+		File encrypted = encryptor.encrypt(toEncrypt);
+		File decrypted = decryptor.decrypt(encrypted);
+
+		assertEquals(CONTENT, ReadFileExtensions.fromFile(decrypted));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
@@ -28,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import javax.crypto.Cipher;
 
@@ -192,6 +194,40 @@ public class FileEncryptDecryptorTest extends AbstractTestCase<String, String>
 		assertEquals(actual, expected);
 
 		// clean up...
+		DeleteFileExtensions.delete(encrypted);
+		DeleteFileExtensions.delete(decrypted);
+	}
+
+	/**
+	 * Test method for {@link FileDecryptor#decrypt(File)} that pins the observable effect of the
+	 * {@code onAfterDecrypt} post-processing step: when the {@link CryptModel} carries a string
+	 * decorator, decryption undecorates the recovered content, removing the decorator's prefix and
+	 * suffix from the decrypted file. This exercises the {@code onAfterDecrypt} call and its
+	 * decorator loop; without them the markers would survive into the decrypted file.
+	 *
+	 * @throws Exception
+	 *             is thrown if any error occurs on the execution
+	 */
+	@Test
+	public void decrypt_appliesTheDecoratorUndecorationInOnAfterDecrypt() throws Exception
+	{
+		File markerPlain = new File(cryptDir, "marker-plain.txt");
+		// the "$" prefix and "?" suffix match the decorator configured in setUp
+		Files.write(markerPlain.toPath(), "$hello?".getBytes(StandardCharsets.UTF_8));
+		File markerEncrypted = new File(cryptDir, "marker.enc");
+		File markerDecrypted = new File(cryptDir, "marker.decrypted");
+
+		encryptor = new FileEncryptor(cryptModel, markerEncrypted);
+		encrypted = encryptor.encrypt(markerPlain);
+
+		decryptor = new FileDecryptor(cryptModel, markerDecrypted);
+		decrypted = decryptor.decrypt(encrypted);
+
+		String content = new String(Files.readAllBytes(decrypted.toPath()), StandardCharsets.UTF_8);
+		assertEquals("hello", content);
+
+		// clean up...
+		DeleteFileExtensions.delete(markerPlain);
 		DeleteFileExtensions.delete(encrypted);
 		DeleteFileExtensions.delete(decrypted);
 	}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptorTest.java
@@ -128,4 +128,40 @@ public class PBEFileEncryptorTest extends AbstractTestCase<String, String>
 		DeleteFileExtensions.delete(firstEncrypted);
 		DeleteFileExtensions.delete(secondEncrypted);
 	}
+
+	/**
+	 * Test method for {@link PBEFileDecryptor#decrypt(File)} that pins the observable effect of the
+	 * {@code onAfterDecrypt} post-processing step: when the {@link CryptModel} carries a string
+	 * decorator, decryption undecorates the recovered content, removing the decorator's prefix and
+	 * suffix from the decrypted file. Without the {@code onAfterDecrypt} decorator loop the markers
+	 * would survive into the decrypted file.
+	 *
+	 * @throws Exception
+	 *             is thrown if any error occurs on the execution
+	 */
+	@Test
+	public void decrypt_appliesTheDecoratorUndecorationInOnAfterDecrypt() throws Exception
+	{
+		File markerPlain = new File(cryptDir, "pbe-marker-plain.txt");
+		// the "$" prefix and "?" suffix match the decorator configured in setUp
+		Files.write(markerPlain.toPath(),
+			"$hello?".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		File markerEncrypted = new File(cryptDir, "pbe-marker.enc");
+		File markerDecrypted = new File(cryptDir, "pbe-marker.decrypted");
+
+		encryptor = new PBEFileEncryptor(cryptModel, markerEncrypted);
+		encrypted = encryptor.encrypt(markerPlain);
+
+		decryptor = new PBEFileDecryptor(cryptModel, markerDecrypted);
+		decrypted = decryptor.decrypt(encrypted);
+
+		String content = new String(Files.readAllBytes(decrypted.toPath()),
+			java.nio.charset.StandardCharsets.UTF_8);
+		assertEquals("hello", content);
+
+		// clean up...
+		DeleteFileExtensions.delete(markerPlain);
+		DeleteFileExtensions.delete(encrypted);
+		DeleteFileExtensions.delete(decrypted);
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/gm/GoogleMapsUrlSignerTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/gm/GoogleMapsUrlSignerTest.java
@@ -25,6 +25,7 @@
 package io.github.astrapi69.mystic.crypt.gm;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 
@@ -61,6 +62,12 @@ public class GoogleMapsUrlSignerTest
 
 		signRequest = GoogleMapsUrlSigner.signRequest("YOUR_PRIVATE_KEY", "/alpha/beta", "quest");
 		assertNotNull(signRequest);
+		// the returned value must be the signed resource, i.e. path?query with the signature
+		// appended - guards against a mutant that returns an empty string
+		assertTrue(signRequest.startsWith("/alpha/beta?quest&signature="),
+			"expected the signed resource but was: " + signRequest);
+		assertTrue(signRequest.length() > "/alpha/beta?quest&signature=".length(),
+			"expected a non-empty signature to be appended");
 	}
 
 	/**
@@ -72,10 +79,34 @@ public class GoogleMapsUrlSignerTest
 		URL url;
 		String signRequest;
 
-		url = new URL(RandomWebObjectFactory.randomWebsite());
+		url = new URL("https://maps.googleapis.com/maps/api/geocode/json?address=NewYork");
 
 		signRequest = GoogleMapsUrlSigner.signRequest(url, "YOUR_PRIVATE_KEY");
 		assertNotNull(signRequest);
+		// the returned value must be the full url (protocol://host + signed path) - guards against
+		// a mutant that returns an empty string
+		assertTrue(signRequest.startsWith("https://maps.googleapis.com"),
+			"expected the full signed url but was: " + signRequest);
+		assertTrue(signRequest.contains("&signature="),
+			"expected the signature parameter to be appended");
+	}
+
+	/**
+	 * Test method for {@link GoogleMapsUrlSigner#signRequest(URL, String)} using a random website
+	 */
+	@Test
+	public void testSignRequestURLStringRandom() throws Exception
+	{
+		URL url = new URL(RandomWebObjectFactory.randomWebsite());
+		String signRequest = GoogleMapsUrlSigner.signRequest(url, "YOUR_PRIVATE_KEY");
+		assertNotNull(signRequest);
+		// whatever host was generated, the result must be that url with a signature appended
+		assertTrue(signRequest.startsWith(url.getProtocol() + "://" + url.getHost()),
+			"expected the signed url to keep protocol and host but was: " + signRequest);
+		assertTrue(signRequest.contains("signature="),
+			"expected the signature parameter to be appended");
+		assertTrue(signRequest.length() > url.toString().length(),
+			"expected a non-empty signature to be appended");
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/hex/HexableDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/hex/HexableDecryptorTest.java
@@ -24,6 +24,8 @@
  */
 package io.github.astrapi69.mystic.crypt.hex;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.crypto.Cipher;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
+import io.github.astrapi69.crypt.api.algorithm.Algorithm;
 import io.github.astrapi69.crypt.data.model.CryptModel;
 
 /**
@@ -110,4 +113,51 @@ public class HexableDecryptorTest
 			"String before encryption is not equal after decryption.");
 	}
 
+	/**
+	 * Test method for {@link HexableDecryptor#decrypt(String)}, encrypted data that is shorter than
+	 * the nonce has to be rejected
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testDecryptWithDataShorterThanTheNonce() throws Exception
+	{
+		HexableDecryptor decryptor = new HexableDecryptor("1234567890123456");
+
+		assertThrows(IllegalArgumentException.class, () -> decryptor.decrypt("00112233"));
+	}
+
+	/**
+	 * Test method for {@link HexableDecryptor#decrypt(String)}, data of exactly the nonce length
+	 * (12 bytes = 24 hex characters) is <em>not</em> rejected by the length guard (it fails later
+	 * during GCM decryption). This pins the boundary of the {@code length < NONCE_LENGTH} check so
+	 * a {@code <=} mutant is caught.
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testDecryptWithDataOfExactlyTheNonceLengthIsNotRejectedByTheLengthGuard()
+		throws Exception
+	{
+		HexableDecryptor decryptor = new HexableDecryptor("1234567890123456");
+
+		// 12 bytes worth of hex - exactly the nonce length, leaving an empty ciphertext
+		Exception exception = assertThrows(Exception.class,
+			() -> decryptor.decrypt("000000000000000000000000"));
+		assertFalse(exception instanceof IllegalArgumentException,
+			"data of exactly the nonce length must pass the length guard, not be rejected by it");
+	}
+
+	/**
+	 * Test method for {@link HexableDecryptor#HexableDecryptor(String, Algorithm)}, the algorithm
+	 * is mandatory
+	 */
+	@Test
+	public void testConstructorWithoutAlgorithm()
+	{
+		assertThrows(IllegalArgumentException.class,
+			() -> new HexableDecryptor("1234567890123456", null));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/hex/HexableEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/hex/HexableEncryptorTest.java
@@ -26,13 +26,17 @@ package io.github.astrapi69.mystic.crypt.hex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.crypto.Cipher;
 
 import org.junit.jupiter.api.Test;
 
+import io.github.astrapi69.collection.list.ListFactory;
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
 import io.github.astrapi69.crypt.data.model.CryptModel;
+import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
+import io.github.astrapi69.mystic.crypt.algorithm.MysticSymmetricAlgorithm;
 
 /**
  * The unit test class for the class {@link HexableEncryptor}
@@ -77,5 +81,112 @@ public class HexableEncryptorTest
 		String decrypted = decryptor.decrypt(encrypted);
 
 		assertEquals(plaintext, decrypted);
+	}
+
+	/**
+	 * Test method for {@link HexableEncryptor#encrypt(byte[])}, a hexable encryptor works on
+	 * strings only
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testEncryptByteArrayIsNotSupported() throws Exception
+	{
+		HexableEncryptor encryptor = new HexableEncryptor("1234567890123456");
+
+		assertThrows(UnsupportedOperationException.class,
+			() -> encryptor.encrypt(new byte[] { 1, 2, 3 }));
+	}
+
+	/**
+	 * Test method for {@link HexableEncryptor#encrypt(String)} with the transformation
+	 * ChaCha20-Poly1305, every encryption uses a fresh nonce and can be decrypted again
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testEncryptDecryptWithChaCha20Poly1305() throws Exception
+	{
+		String key = "12345678901234567890123456789012";
+		HexableEncryptor encryptor = new HexableEncryptor(key,
+			MysticSymmetricAlgorithm.CHACHA20_POLY1305);
+		HexableDecryptor decryptor = new HexableDecryptor(key,
+			MysticSymmetricAlgorithm.CHACHA20_POLY1305);
+		String plaintext = "the quick brown fox jumps over the lazy dog";
+
+		String first = encryptor.encrypt(plaintext);
+		String second = encryptor.encrypt(plaintext);
+
+		assertNotEquals(first, second);
+		assertEquals(plaintext, decryptor.decrypt(first));
+		assertEquals(plaintext, decryptor.decrypt(second));
+	}
+
+	/**
+	 * Test method for {@link HexableEncryptor#encrypt(String)}, every configured decorator has to
+	 * be applied on the plain text before it is encrypted
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testEmptyDecoratorListIsTreatedLikeNoDecorators() throws Exception
+	{
+		String key = "1234567890123456";
+		String plaintext = "Lorem ipsum";
+		HexableEncryptor encryptor = new HexableEncryptor(
+			CryptModel.<Cipher, String, String> builder().key(key)
+				.decorators(ListFactory.newArrayList()).build());
+		HexableDecryptor decryptor = new HexableDecryptor(
+			CryptModel.<Cipher, String, String> builder().key(key)
+				.decorators(ListFactory.newArrayList()).build());
+
+		String encrypted = encryptor.encrypt(plaintext);
+
+		assertEquals(plaintext, decryptor.decrypt(encrypted));
+		assertEquals(plaintext, new HexableDecryptor(key).decrypt(encrypted));
+
+		CryptModel<Cipher, String, String> nullDecorators = CryptModel
+			.<Cipher, String, String> builder().key(key).build();
+		nullDecorators.setDecorators(null);
+		HexableEncryptor encryptorWithNull = new HexableEncryptor(nullDecorators);
+		HexableDecryptor decryptorWithNull = new HexableDecryptor(nullDecorators);
+
+		assertEquals(plaintext, decryptorWithNull.decrypt(encryptorWithNull.encrypt(plaintext)));
+	}
+
+	/**
+	 * Test method for {@link HexableEncryptor#encrypt(String)}, every configured decorator has to
+	 * be applied on the plain text before it is encrypted
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void testEncryptAppliesEveryDecoratorBeforeEncryption() throws Exception
+	{
+		String key = "1234567890123456";
+		String plaintext = "Lorem ipsum";
+		HexableEncryptor encryptor = new HexableEncryptor(CryptModel
+			.<Cipher, String, String> builder().key(key)
+			.decorators(ListFactory.newArrayList(
+				CryptObjectDecorator.<String> builder().prefix("<<").suffix(">>").build(),
+				CryptObjectDecorator.<String> builder().prefix("[").suffix("]").build()))
+			.build());
+		// a decryptor without decorators answers the decorated plain text
+		HexableDecryptor decryptorWithoutDecorators = new HexableDecryptor(key);
+		HexableDecryptor decryptorWithDecorators = new HexableDecryptor(CryptModel
+			.<Cipher, String, String> builder().key(key)
+			.decorators(ListFactory.newArrayList(
+				CryptObjectDecorator.<String> builder().prefix("<<").suffix(">>").build(),
+				CryptObjectDecorator.<String> builder().prefix("[").suffix("]").build()))
+			.build());
+
+		String encrypted = encryptor.encrypt(plaintext);
+
+		assertEquals("[<<Lorem ipsum>>]", decryptorWithoutDecorators.decrypt(encrypted));
+		assertEquals(plaintext, decryptorWithDecorators.decrypt(encrypted));
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/HybridKemKeyExchangeTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/HybridKemKeyExchangeTest.java
@@ -109,10 +109,69 @@ public class HybridKemKeyExchangeTest
 	 * a non-ML-KEM algorithm
 	 */
 	@Test
+	public void testHybridKeyPairExposesItsParts() throws Exception
+	{
+		final HybridKeyPair keyPair = HybridKemKeyExchange
+			.newHybridKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_512);
+
+		assertEquals(KeyPairGeneratorAlgorithm.ML_KEM_512, keyPair.getMlKemAlgorithm());
+		assertEquals(KeyPairGeneratorAlgorithm.ML_KEM_512,
+			keyPair.getHybridPublicKey().getMlKemAlgorithm());
+		assertEquals(keyPair.getX25519KeyPair().getPublic(),
+			keyPair.getHybridPublicKey().getX25519PublicKey());
+		assertEquals(keyPair.getMlKemKeyPair().getPublic(),
+			keyPair.getHybridPublicKey().getMlKemPublicKey());
+		assertEquals(keyPair.getX25519KeyPair().getPrivate(),
+			keyPair.getHybridPrivateKey().getX25519PrivateKey());
+		assertEquals(keyPair.getMlKemKeyPair().getPrivate(),
+			keyPair.getHybridPrivateKey().getMlKemPrivateKey());
+	}
+
+	/**
+	 * Test method for {@link HybridKemKeyExchange#newHybridKeyPair(KeyPairGeneratorAlgorithm)}
+	 */
+	@Test
 	public void testNewHybridKeyPairRejectsNonMlKemAlgorithm()
 	{
 		assertThrows(IllegalArgumentException.class,
 			() -> HybridKemKeyExchange.newHybridKeyPair(KeyPairGeneratorAlgorithm.Ed25519));
+	}
+
+	/**
+	 * Test method for
+	 * {@link HybridKemKeyExchange#hybridEncapsulate(java.security.PublicKey, java.security.PublicKey, KeyPairGeneratorAlgorithm, int)}
+	 * with a non-ML-KEM algorithm: the requireMlKem guard must reject it.
+	 */
+	@Test
+	public void testHybridEncapsulateRejectsNonMlKemAlgorithm() throws Exception
+	{
+		final HybridKeyPair recipientKeyPair = HybridKemKeyExchange
+			.newHybridKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+		final HybridPublicKey recipientPublicKey = recipientKeyPair.getHybridPublicKey();
+		assertThrows(IllegalArgumentException.class,
+			() -> HybridKemKeyExchange.hybridEncapsulate(recipientPublicKey.getX25519PublicKey(),
+				recipientPublicKey.getMlKemPublicKey(), KeyPairGeneratorAlgorithm.Ed25519, 32));
+	}
+
+	/**
+	 * Test method for
+	 * {@link HybridKemKeyExchange#hybridDecapsulate(java.security.PrivateKey, java.security.PrivateKey, java.security.PublicKey, byte[], KeyPairGeneratorAlgorithm, int)}
+	 * with a non-ML-KEM algorithm: the requireMlKem guard must reject it.
+	 */
+	@Test
+	public void testHybridDecapsulateRejectsNonMlKemAlgorithm() throws Exception
+	{
+		final HybridKeyPair recipientKeyPair = HybridKemKeyExchange
+			.newHybridKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+		final HybridPublicKey recipientPublicKey = recipientKeyPair.getHybridPublicKey();
+		final HybridPrivateKey recipientPrivateKey = recipientKeyPair.getHybridPrivateKey();
+		final HybridEncapsulation encapsulation = HybridKemKeyExchange.hybridEncapsulate(
+			recipientPublicKey.getX25519PublicKey(), recipientPublicKey.getMlKemPublicKey(),
+			KeyPairGeneratorAlgorithm.ML_KEM_768, 32);
+		assertThrows(IllegalArgumentException.class,
+			() -> HybridKemKeyExchange.hybridDecapsulate(recipientPrivateKey.getX25519PrivateKey(),
+				recipientPrivateKey.getMlKemPrivateKey(), encapsulation.getSenderX25519PublicKey(),
+				encapsulation.getMlKemCiphertext(), KeyPairGeneratorAlgorithm.Ed25519, 32));
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyCryptorVariantsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyCryptorVariantsTest.java
@@ -1,0 +1,275 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
+import io.github.astrapi69.crypt.api.algorithm.Algorithm;
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairWithModeAndPaddingAlgorithm;
+import io.github.astrapi69.crypt.data.factory.SecretKeyFactoryExtensions;
+import io.github.astrapi69.crypt.data.key.PrivateKeyExtensions;
+import io.github.astrapi69.crypt.data.key.reader.PrivateKeyReader;
+import io.github.astrapi69.crypt.data.model.AesRsaCryptModel;
+import io.github.astrapi69.crypt.data.model.CryptModel;
+import io.github.astrapi69.file.search.PathFinder;
+import io.github.astrapi69.mystic.crypt.algorithm.MysticSymmetricAlgorithm;
+
+/**
+ * The unit test class for the constructor variants and the symmetric transformation variants of the
+ * public/private key based cryptors
+ */
+public class KeyCryptorVariantsTest
+{
+
+	private static final String PLAIN_TEXT = "the quick brown fox jumps over the lazy dog";
+
+	private PrivateKey privateKey;
+
+	private PublicKey publicKey;
+
+	/**
+	 * A scenario for a symmetric transformation used for the data leg of the hybrid encryption
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param symmetricAlgorithm
+	 *            the symmetric transformation
+	 */
+	record SymmetricAlgorithmCase(String description, Algorithm symmetricAlgorithm) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<SymmetricAlgorithmCase> symmetricAlgorithmCases()
+	{
+		return Stream.of(
+			new SymmetricAlgorithmCase("AES/GCM/NoPadding",
+				MysticSymmetricAlgorithm.AES_GCM_NO_PADDING),
+			new SymmetricAlgorithmCase("ChaCha20-Poly1305",
+				MysticSymmetricAlgorithm.CHACHA20_POLY1305),
+			new SymmetricAlgorithmCase("legacy bare AES", AesAlgorithm.AES));
+	}
+
+	@BeforeEach
+	void setUp() throws Exception
+	{
+		File privatekeyDerFile = new File(PathFinder.getSrcTestResourcesDir(), "der/private.der");
+		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
+		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
+	}
+
+	private CryptModel<Cipher, PublicKey, byte[]> newPublicKeyModel()
+	{
+		return CryptModel.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
+	}
+
+	private CryptModel<Cipher, PrivateKey, byte[]> newPrivateKeyModel()
+	{
+		return CryptModel.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build();
+	}
+
+	private static CryptModel<Cipher, SecretKey, String> newSymmetricKeyModel(
+		final Algorithm symmetricAlgorithm) throws Exception
+	{
+		SecretKey symmetricKey = SecretKeyFactoryExtensions
+			.newSecretKey(AesAlgorithm.AES.getAlgorithm(), 256);
+		return CryptModel.<Cipher, SecretKey, String> builder().key(symmetricKey)
+			.algorithm(symmetricAlgorithm).operationMode(Cipher.ENCRYPT_MODE).build();
+	}
+
+	/**
+	 * Test method for {@link PublicKeyEncryptor} and {@link PrivateKeyDecryptor} with every
+	 * supported symmetric transformation
+	 *
+	 * @param testCase
+	 *            the test case
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@ParameterizedTest
+	@MethodSource("symmetricAlgorithmCases")
+	public void encryptAndDecrypt_roundTripWithEverySymmetricTransformation(
+		final SymmetricAlgorithmCase testCase) throws Exception
+	{
+		PublicKeyEncryptor encryptor = new PublicKeyEncryptor(newPublicKeyModel(),
+			newSymmetricKeyModel(testCase.symmetricAlgorithm()));
+		PrivateKeyDecryptor decryptor = new PrivateKeyDecryptor(newPrivateKeyModel(),
+			testCase.symmetricAlgorithm());
+		byte[] plainBytes = PLAIN_TEXT.getBytes(StandardCharsets.UTF_8);
+
+		byte[] first = encryptor.encrypt(plainBytes);
+		byte[] second = encryptor.encrypt(plainBytes);
+
+		assertFalse(Arrays.equals(plainBytes, first));
+		assertFalse(Arrays.equals(first, second), "a fresh nonce/key per call is expected");
+		assertArrayEquals(plainBytes, decryptor.decrypt(first));
+		assertArrayEquals(plainBytes, decryptor.decrypt(second));
+	}
+
+	/**
+	 * Test method for {@link PublicKeyEncryptor} with an explicit asymmetric algorithm, the
+	 * configured algorithm has to be kept and a decryptor with the same algorithm has to round trip
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void encryptAndDecrypt_withAnExplicitAsymmetricAlgorithm() throws Exception
+	{
+		CryptModel<Cipher, PublicKey, byte[]> publicKeyModel = CryptModel
+			.<Cipher, PublicKey, byte[]> builder().key(publicKey)
+			.algorithm(KeyPairWithModeAndPaddingAlgorithm.RSA_ECB_OAEPWithSHA256AndMGF1Padding)
+			.build();
+		CryptModel<Cipher, PrivateKey, byte[]> privateKeyModel = CryptModel
+			.<Cipher, PrivateKey, byte[]> builder().key(privateKey)
+			.algorithm(KeyPairWithModeAndPaddingAlgorithm.RSA_ECB_OAEPWithSHA256AndMGF1Padding)
+			.build();
+		PublicKeyEncryptor encryptor = new PublicKeyEncryptor(publicKeyModel,
+			newSymmetricKeyModel(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING));
+		PrivateKeyDecryptor decryptor = new PrivateKeyDecryptor(privateKeyModel);
+
+		assertEquals(KeyPairWithModeAndPaddingAlgorithm.RSA_ECB_OAEPWithSHA256AndMGF1Padding,
+			encryptor.getModel().getAlgorithm());
+		assertArrayEquals(PLAIN_TEXT.getBytes(StandardCharsets.UTF_8),
+			decryptor.decrypt(encryptor.encrypt(PLAIN_TEXT.getBytes(StandardCharsets.UTF_8))));
+	}
+
+	/**
+	 * Test method for {@link PrivateKeyDecryptor#decrypt(byte[])}, a symmetric blob that is too
+	 * short to contain the nonce has to be rejected
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_rejectsASymmetricBlobThatIsTooShortForTheNonce() throws Exception
+	{
+		PublicKeyEncryptor encryptor = new PublicKeyEncryptor(newPublicKeyModel(),
+			newSymmetricKeyModel(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING));
+		PrivateKeyDecryptor decryptor = new PrivateKeyDecryptor(newPrivateKeyModel());
+		AesRsaCryptModel cryptData = SerializationUtils
+			.deserialize(encryptor.encrypt(PLAIN_TEXT.getBytes(StandardCharsets.UTF_8)));
+		byte[] tooShort = SerializationUtils
+			.serialize(AesRsaCryptModel.builder().encryptedKey(cryptData.getEncryptedKey())
+				.symmetricKeyEncryptedObject(new byte[11]).build());
+
+		assertThrows(IllegalArgumentException.class, () -> decryptor.decrypt(tooShort));
+	}
+
+	/**
+	 * Test method for the model based constructors of {@link PublicKeyStringEncryptor} and
+	 * {@link PrivateKeyStringDecryptor}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void stringCryptors_withModels_roundTrip() throws Exception
+	{
+		PublicKeyStringEncryptor encryptor = new PublicKeyStringEncryptor(newPublicKeyModel(),
+			newSymmetricKeyModel(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING));
+		PrivateKeyStringDecryptor decryptor = new PrivateKeyStringDecryptor(newPrivateKeyModel());
+
+		assertEquals(PLAIN_TEXT, decryptor.decrypt(encryptor.encrypt(PLAIN_TEXT)));
+	}
+
+	/**
+	 * Test method for the delegating constructor of {@link PublicKeyStringEncryptor}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void stringEncryptor_withADelegateEncryptor_roundTrip() throws Exception
+	{
+		PublicKeyStringEncryptor encryptor = new PublicKeyStringEncryptor(new PublicKeyEncryptor(
+			newPublicKeyModel(), newSymmetricKeyModel(MysticSymmetricAlgorithm.CHACHA20_POLY1305)));
+		PrivateKeyStringDecryptor decryptor = new PrivateKeyStringDecryptor(new PrivateKeyDecryptor(
+			newPrivateKeyModel(), MysticSymmetricAlgorithm.CHACHA20_POLY1305));
+
+		assertEquals(PLAIN_TEXT, decryptor.decrypt(encryptor.encrypt(PLAIN_TEXT)));
+	}
+
+	/**
+	 * Test method for the model based constructors of {@link PublicKeyGenericEncryptor} and
+	 * {@link PrivateKeyGenericDecryptor}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void genericCryptors_withModels_roundTrip() throws Exception
+	{
+		PublicKeyGenericEncryptor<String> encryptor = new PublicKeyGenericEncryptor<>(
+			newPublicKeyModel(), newSymmetricKeyModel(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING));
+		PrivateKeyGenericDecryptor<String> decryptor = new PrivateKeyGenericDecryptor<>(
+			newPrivateKeyModel());
+
+		assertEquals(PLAIN_TEXT, decryptor.decrypt(encryptor.encrypt(PLAIN_TEXT)));
+	}
+
+	/**
+	 * Test method for the private key constructor of {@link PrivateKeyHexStringDecryptor}, it has
+	 * to decrypt the hex output of a {@link PublicKeyHexStringEncryptor} and must reject a missing
+	 * key
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void hexStringDecryptor_withAPrivateKey_roundTrip() throws Exception
+	{
+		PublicKeyHexStringEncryptor encryptor = new PublicKeyHexStringEncryptor(publicKey);
+		PrivateKeyHexStringDecryptor decryptor = new PrivateKeyHexStringDecryptor(privateKey);
+
+		String encrypted = encryptor.encrypt(PLAIN_TEXT);
+
+		assertEquals(PLAIN_TEXT, decryptor.decrypt(encrypted));
+		assertThrows(NullPointerException.class, () -> new PrivateKeyHexStringDecryptor(null));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/MlKemKeyExchangeTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/MlKemKeyExchangeTest.java
@@ -84,4 +84,33 @@ public class MlKemKeyExchangeTest
 			() -> MlKemKeyExchange.newKeyPair(KeyPairGeneratorAlgorithm.Ed25519));
 	}
 
+	/**
+	 * Test method for
+	 * {@link MlKemKeyExchange#encapsulate(java.security.PublicKey, KeyPairGeneratorAlgorithm)} with
+	 * a non-ML-KEM algorithm: the requireMlKem guard must reject it before any KEM operation.
+	 */
+	@Test
+	public void testEncapsulateRejectsNonMlKemAlgorithm() throws Exception
+	{
+		final KeyPair recipientKeyPair = MlKemKeyExchange
+			.newKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+		assertThrows(IllegalArgumentException.class, () -> MlKemKeyExchange
+			.encapsulate(recipientKeyPair.getPublic(), KeyPairGeneratorAlgorithm.Ed25519));
+	}
+
+	/**
+	 * Test method for
+	 * {@link MlKemKeyExchange#decapsulate(java.security.PrivateKey, byte[], KeyPairGeneratorAlgorithm)}
+	 * with a non-ML-KEM algorithm: the requireMlKem guard must reject it before any KEM operation.
+	 */
+	@Test
+	public void testDecapsulateRejectsNonMlKemAlgorithm() throws Exception
+	{
+		final KeyPair recipientKeyPair = MlKemKeyExchange
+			.newKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+		assertThrows(IllegalArgumentException.class,
+			() -> MlKemKeyExchange.decapsulate(recipientKeyPair.getPrivate(), new byte[16],
+				KeyPairGeneratorAlgorithm.Ed25519));
+	}
+
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyDecryptorTest.java
@@ -25,7 +25,9 @@
 package io.github.astrapi69.mystic.crypt.key;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.security.PrivateKey;
@@ -158,6 +160,41 @@ public class PrivateKeyDecryptorTest
 		assertNotNull(decrypted);
 		expected = new String(decrypted, "UTF-8");
 		assertEquals(expected, actual);
+	}
+
+	/**
+	 * Test method for {@link PrivateKeyDecryptor#decrypt(byte[])}: a symmetric blob of exactly the
+	 * nonce length is <em>not</em> rejected by the length guard (it fails later during GCM
+	 * decryption). This pins the boundary of the {@code symmetricBlob.length < NONCE_LENGTH} check
+	 * so a {@code <=} mutant is caught.
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_withASymmetricBlobOfExactlyTheNonceLength_isNotRejectedByTheLengthGuard()
+		throws Exception
+	{
+		File derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
+		File privatekeyDerFile = new File(derDir, "private.der");
+		PrivateKey privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
+		PublicKey publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
+
+		PublicKeyEncryptor encryptor = new PublicKeyEncryptor(publicKey);
+		byte[] encrypted = encryptor.encrypt("payload".getBytes("UTF-8"));
+
+		// keep the valid RSA-encrypted symmetric key but shrink the symmetric blob to exactly the
+		// nonce length (12 bytes), leaving an empty ciphertext region
+		io.github.astrapi69.crypt.data.model.AesRsaCryptModel model = org.apache.commons.lang3.SerializationUtils
+			.deserialize(encrypted);
+		io.github.astrapi69.crypt.data.model.AesRsaCryptModel tampered = new io.github.astrapi69.crypt.data.model.AesRsaCryptModel(
+			model.getEncryptedKey(), new byte[12]);
+		byte[] tamperedBytes = org.apache.commons.lang3.SerializationUtils.serialize(tampered);
+
+		PrivateKeyDecryptor decryptor = new PrivateKeyDecryptor(privateKey);
+		Exception exception = assertThrows(Exception.class, () -> decryptor.decrypt(tamperedBytes));
+		assertFalse(exception instanceof IllegalArgumentException,
+			"a blob of exactly the nonce length must pass the length guard, not be rejected by it");
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterExtensionsTest.java
@@ -53,6 +53,15 @@ public class CharacterExtensionsTest extends AbstractTestCase<Boolean, Boolean>
 		actual = CharacterExtensions.equalsIgnoreCase(null, Character.valueOf('c'));
 		assertEquals(expected, actual);
 
+		expected = false;
+		actual = CharacterExtensions.equalsIgnoreCase(Character.valueOf('c'), null);
+		assertEquals(expected, actual);
+
+		expected = false;
+		actual = CharacterExtensions.equalsIgnoreCase(Character.valueOf('c'),
+			Character.valueOf('d'));
+		assertEquals(expected, actual);
+
 		expected = true;
 		actual = CharacterExtensions.equalsIgnoreCase(null, null);
 

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterObfuscatorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterObfuscatorTest.java
@@ -25,14 +25,19 @@
 package io.github.astrapi69.mystic.crypt.obfuscation.character;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 
+import io.github.astrapi69.collection.set.SetFactory;
 import io.github.astrapi69.crypt.api.obfuscation.Obfuscatable;
+import io.github.astrapi69.crypt.api.obfuscation.rule.Operation;
 import io.github.astrapi69.crypt.data.obfuscation.rule.ObfuscationOperationRule;
 import io.github.astrapi69.test.base.AbstractTestCase;
 
@@ -75,6 +80,33 @@ public class CharacterObfuscatorTest extends AbstractTestCase<String, String>
 		obfuscator = null;
 		stringToObfuscate = null;
 		rules = null;
+	}
+
+	/**
+	 * Test method for {@link CharacterObfuscator#disentangle()}
+	 */
+	@Test
+	public void testValidatingConstructor()
+	{
+		CharacterObfuscator validated = new CharacterObfuscator(rules, "abac", true);
+		assertTrue(validated.isDisentanglable());
+		assertEquals("abac", validated.disentangle());
+
+		CharacterObfuscator notValidated = new CharacterObfuscator(rules, "abac", false);
+		assertFalse(notValidated.isDisentanglable(), "without validation the flag stays false");
+
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> notDisentanglable = HashBiMap
+			.create();
+		notDisentanglable.put('a',
+			ObfuscationOperationRule.<Character, Character> builder().character('a')
+				.replaceWith('b').operation(Operation.UPPERCASE).indexes(SetFactory.newHashSet(0))
+				.build());
+		notDisentanglable.put('A',
+			ObfuscationOperationRule.<Character, Character> builder().character('A')
+				.replaceWith('c').operation(Operation.LOWERCASE).indexes(SetFactory.newHashSet(1))
+				.build());
+		CharacterObfuscator invalid = new CharacterObfuscator(notDisentanglable, "aA", true);
+		assertFalse(invalid.isDisentanglable());
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsTest.java
@@ -1,0 +1,929 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.obfuscation.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.HashBiMap;
+
+import io.github.astrapi69.collection.list.ListFactory;
+import io.github.astrapi69.collection.pair.KeyValuePair;
+import io.github.astrapi69.collection.set.SetFactory;
+import io.github.astrapi69.crypt.api.obfuscation.rule.Operation;
+import io.github.astrapi69.crypt.data.obfuscation.rule.ObfuscationOperationRule;
+
+/**
+ * The unit test class for the class {@link ObfuscatorExtensions}
+ */
+public class ObfuscatorExtensionsTest
+{
+
+	/**
+	 * A single obfuscate/disentangle round trip scenario
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param input
+	 *            the input to obfuscate
+	 * @param expectedObfuscated
+	 *            the expected obfuscated result
+	 */
+	record RoundTripCase(String description, String input, String expectedObfuscated) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	/**
+	 * A scenario for the validation methods
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param rules
+	 *            the rules to validate
+	 * @param input
+	 *            the input to check
+	 * @param expected
+	 *            the expected result
+	 */
+	record ValidationCase(String description,
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules, String input,
+		boolean expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	/**
+	 * A scenario for a method that rejects a null argument
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param executable
+	 *            the call that must be rejected
+	 */
+	record NullArgumentCase(String description, Executable executable) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static ObfuscationOperationRule<Character, Character> newRule(final char character,
+		final char replaceWith, final Operation operation, final Integer... indexes)
+	{
+		return ObfuscationOperationRule.<Character, Character> builder().character(character)
+			.replaceWith(replaceWith).operation(operation).indexes(SetFactory.newHashSet(indexes))
+			.build();
+	}
+
+	/**
+	 * Three chained rules a-&gt;b, b-&gt;c, c-&gt;d, every replacement character except the last
+	 * one is itself an obfuscated character, which is what makes the map disentanglable
+	 *
+	 * @return the newly created rules
+	 */
+	static BiMap<Character, ObfuscationOperationRule<Character, Character>> newSmallChainRules()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'b', Operation.UPPERCASE, 0, 2));
+		rules.put('b', newRule('b', 'c', Operation.UPPERCASE, 2));
+		rules.put('c', newRule('c', 'd', Operation.UPPERCASE, 3));
+		return rules;
+	}
+
+	static Stream<RoundTripCase> roundTripCases()
+	{
+		return Stream.of(new RoundTripCase("single character at an operated index", "a", "A"),
+			new RoundTripCase("mixed operated and replaced characters", "abac", "AcAC"),
+			new RoundTripCase("operation only on the first index", "hello", "Hfmmp"),
+			new RoundTripCase("repeated characters", "food", "Fppe"),
+			new RoundTripCase("longer word", "leonardo", "Lfpobsep"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)} and
+	 * {@link ObfuscatorExtensions#disentangle(BiMap, String)}, obfuscating and disentangling again
+	 * has to result in the original input
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("roundTripCases")
+	public void obfuscateWith_thenDisentangle_recoversTheOriginalInput(final RoundTripCase testCase)
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = ObfuscationOperationTestData
+			.getFirstBiMapObfuscationOperationRules();
+
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(rules, testCase.input());
+		assertEquals(testCase.expectedObfuscated(), obfuscated);
+
+		String disentangled = ObfuscatorExtensions.disentangle(rules, obfuscated);
+		assertEquals(testCase.input(), disentangled);
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#isObfuscableAndDisentanglable(BiMap, String)},
+	 * every round trip scenario has to be recognized as disentanglable
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("roundTripCases")
+	public void isObfuscableAndDisentanglable_isTrueForEveryRoundTrippingInput(
+		final RoundTripCase testCase)
+	{
+		assertTrue(ObfuscatorExtensions.isObfuscableAndDisentanglable(
+			ObfuscationOperationTestData.getFirstBiMapObfuscationOperationRules(),
+			testCase.input()));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWithCharArray(BiMap, String)}, the char
+	 * array based implementation has to obfuscate exactly like
+	 * {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)} for operation based rules
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("roundTripCases")
+	public void obfuscateWithCharArray_producesTheSameResultAsObfuscateWith(
+		final RoundTripCase testCase)
+	{
+		String withCharArray = ObfuscatorExtensions.obfuscateWithCharArray(
+			ObfuscationOperationTestData.getFirstBiMapObfuscationOperationRules(),
+			testCase.input());
+		assertEquals(testCase.expectedObfuscated(), withCharArray);
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)}, characters without
+	 * a rule have to stay untouched
+	 */
+	@Test
+	public void obfuscateWith_leavesCharactersWithoutARuleUnchanged()
+	{
+		assertEquals("123 !", ObfuscatorExtensions.obfuscateWith(newSmallChainRules(), "123 !"));
+		assertEquals("1b2",
+			ObfuscatorExtensions.obfuscateWithCharArray(newSmallChainRules(), "1a2"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)} and
+	 * {@link ObfuscatorExtensions#obfuscateWithCharArray(BiMap, String)}, the operation
+	 * {@link Operation#NONE} results in an unchanged character for the first method while the char
+	 * array based method falls back to the replacement character
+	 */
+	@Test
+	public void obfuscateWith_withOperationNone_keepsTheCharacterWhileCharArrayReplacesIt()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.NONE, 0));
+
+		assertEquals("ab", ObfuscatorExtensions.obfuscateWith(rules, "ab"));
+
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> freshRules = HashBiMap
+			.create();
+		freshRules.put('a', newRule('a', 'x', Operation.NONE, 0));
+		assertEquals("xb", ObfuscatorExtensions.obfuscateWithCharArray(freshRules, "ab"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}, a character that was
+	 * operated with {@link Operation#NEGATE} on an index of the rule has to be restored
+	 */
+	@Test
+	public void disentangle_restoresACharacterThatWasNegatedAtARuleIndex()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.NEGATE, 0));
+
+		assertEquals("Ax", ObfuscatorExtensions.obfuscateWith(rules, "aa"));
+
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> freshRules = HashBiMap
+			.create();
+		freshRules.put('a', newRule('a', 'x', Operation.NEGATE, 0));
+		// the negated character on the index of the rule is restored to its original lower case
+		// character
+		assertEquals('a', ObfuscatorExtensions.disentangle(freshRules, "Ax").charAt(0));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}, the replacement
+	 * character on an index of the rule has to be restored to the original character
+	 */
+	@Test
+	public void disentangle_restoresTheReplacementCharacterOnARuleIndex()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.UPPERCASE, 0));
+
+		assertEquals("a", ObfuscatorExtensions.disentangle(rules, "x"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(List, String)}, the list based
+	 * variant resolves every operated and every replacement character back to its origin
+	 */
+	@Test
+	public void disentangle_withListOfRules_recoversTheObfuscatedText()
+	{
+		List<KeyValuePair<Character, ObfuscationOperationRule<Character, Character>>> rules = ListFactory
+			.newArrayList();
+		newSmallChainRules().forEach((key, value) -> rules
+			.add(KeyValuePair.<Character, ObfuscationOperationRule<Character, Character>> builder()
+				.key(key).value(value).build()));
+
+		assertEquals("abac", ObfuscatorExtensions.disentangle(rules, "AcAC"));
+		// characters that are neither an operated nor a replacement character stay unchanged
+		assertEquals("zzz", ObfuscatorExtensions.disentangle(rules, "zzz"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#swapMapWithReplaceWithAsKey(BiMap)}, the swapped
+	 * map has to contain the operated character and the replacement character as keys
+	 */
+	@Test
+	public void swapMapWithReplaceWithAsKey_mapsOperatedAndReplacementCharacterToTheOrigin()
+	{
+		Map<Character, Character> swapped = ObfuscatorExtensions
+			.swapMapWithReplaceWithAsKey(newSmallChainRules());
+
+		assertEquals(6, swapped.size());
+		assertEquals('a', swapped.get('A'));
+		assertEquals('a', swapped.get('b'));
+		assertEquals('b', swapped.get('B'));
+		assertEquals('b', swapped.get('c'));
+		assertEquals('c', swapped.get('C'));
+		assertEquals('c', swapped.get('d'));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#swapMapWithReplaceWithAsKey(BiMap)}, a rule
+	 * without an operation contributes only its replacement character
+	 */
+	@Test
+	public void swapMapWithReplaceWithAsKey_withoutOperation_mapsOnlyTheReplacementCharacter()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.NONE, 0));
+
+		Map<Character, Character> swapped = ObfuscatorExtensions.swapMapWithReplaceWithAsKey(rules);
+
+		assertEquals(1, swapped.size());
+		assertEquals('a', swapped.get('x'));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#swapOperatedMapWithReplaceWithAsKey(BiMap)}, the
+	 * swapped map has to resolve the operated and the replacement character to the whole rule
+	 */
+	@Test
+	public void swapOperatedMapWithReplaceWithAsKey_mapsOperatedAndReplacementCharacterToTheRule()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newSmallChainRules();
+		ObfuscationOperationRule<Character, Character> ruleOfA = rules.get('a');
+
+		Map<Character, ObfuscationOperationRule<Character, Character>> swapped = ObfuscatorExtensions
+			.swapOperatedMapWithReplaceWithAsKey(rules);
+
+		assertEquals(6, swapped.size());
+		assertEquals(ruleOfA, swapped.get('A'));
+		assertEquals(ruleOfA, swapped.get('b'));
+		assertEquals('A', swapped.get('A').getOperatedCharacter().get());
+		// 'c' is the replacement character of the rule for 'b'
+		assertEquals('b', swapped.get('c').getCharacter());
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#swapOperatedMapWithReplaceWithAsKey(BiMap)}, a
+	 * rule without indexes contributes only its replacement character
+	 */
+	@Test
+	public void swapOperatedMapWithReplaceWithAsKey_withoutIndexes_mapsOnlyTheReplacementCharacter()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.UPPERCASE));
+
+		Map<Character, ObfuscationOperationRule<Character, Character>> swapped = ObfuscatorExtensions
+			.swapOperatedMapWithReplaceWithAsKey(rules);
+
+		assertEquals(1, swapped.size());
+		assertEquals('a', swapped.get('x').getCharacter());
+	}
+
+	static Stream<ValidationCase> validationCases()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> operatedCharacterIsAKey = HashBiMap
+			.create();
+		operatedCharacterIsAKey.put('a', newRule('a', 'x', Operation.UPPERCASE, 0));
+		operatedCharacterIsAKey.put('A', newRule('A', 'y', Operation.LOWERCASE, 0));
+
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> withoutOperation = HashBiMap
+			.create();
+		withoutOperation.put('a', newRule('a', 'x', Operation.NONE, 0));
+
+		return Stream.of(
+			new ValidationCase("chained rules are disentanglable", newSmallChainRules(), "abac",
+				true),
+			new ValidationCase("operated character is itself an obfuscated character",
+				operatedCharacterIsAKey, "abac", false),
+			new ValidationCase("without an operation the character stays a key of the rules",
+				withoutOperation, "abac", false));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#validate(BiMap)}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("validationCases")
+	public void validate_detectsRulesThatCanNotBeDisentangled(final ValidationCase testCase)
+	{
+		assertEquals(testCase.expected(), ObfuscatorExtensions.validate(testCase.rules()));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#isObfuscableAndDisentanglable(BiMap, String)},
+	 * invalid rules can never be disentangled
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("validationCases")
+	public void isObfuscableAndDisentanglable_followsTheValidationResult(
+		final ValidationCase testCase)
+	{
+		assertEquals(testCase.expected(),
+			ObfuscatorExtensions.isObfuscableAndDisentanglable(testCase.rules(), testCase.input()));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#isObfuscableAndDisentanglable(BiMap, String)},
+	 * valid rules that do not round trip the given input have to be rejected as well
+	 */
+	@Test
+	public void isObfuscableAndDisentanglable_isFalseWhenTheInputDoesNotRoundTrip()
+	{
+		// the rules themselves are valid but 'c' is obfuscated to 'd' outside of its index and 'd'
+		// is not an obfuscated character, so the text can not be disentangled again
+		assertTrue(ObfuscatorExtensions.validate(newSmallChainRules()));
+		assertFalse(ObfuscatorExtensions.isObfuscableAndDisentanglable(newSmallChainRules(), "ca"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#inverse(ObfuscationOperationRule)}, the character
+	 * and the replacement character have to be swapped and the inverted flag has to be toggled
+	 */
+	@Test
+	public void inverse_rule_swapsCharacterWithReplaceWithAndTogglesTheInvertedFlag()
+	{
+		ObfuscationOperationRule<Character, Character> rule = newRule('a', 'x', Operation.UPPERCASE,
+			0);
+		assertFalse(rule.isInverted());
+
+		ObfuscatorExtensions.inverse(rule);
+
+		assertEquals('x', rule.getCharacter());
+		assertEquals('a', rule.getReplaceWith());
+		assertTrue(rule.isInverted());
+
+		ObfuscatorExtensions.inverse(rule);
+
+		assertEquals('a', rule.getCharacter());
+		assertEquals('x', rule.getReplaceWith());
+		assertFalse(rule.isInverted());
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#tryToClone(Object)}, a clonable object has to be
+	 * returned as an equal but distinct instance
+	 */
+	@Test
+	public void tryToClone_returnsAnEqualButDistinctCopy()
+	{
+		ObfuscationOperationRule<Character, Character> rule = newRule('a', 'x', Operation.UPPERCASE,
+			0);
+
+		Optional<ObfuscationOperationRule<Character, Character>> cloned = ObfuscatorExtensions
+			.tryToClone(rule);
+
+		assertTrue(cloned.isPresent());
+		assertEquals(rule, cloned.get());
+		assertNotSame(rule, cloned.get());
+	}
+
+	/**
+	 * A {@link BiMap} that can be cloned by {@code CloneObjectExtensions}: it implements
+	 * {@link Cloneable} and declares its own {@link #clone()} that deep copies every rule
+	 */
+	static final class CloneableBiMap
+		extends
+			ForwardingMap<Character, ObfuscationOperationRule<Character, Character>>
+		implements
+			BiMap<Character, ObfuscationOperationRule<Character, Character>>,
+			Cloneable
+	{
+		private final BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate;
+
+		@Override
+		public ObfuscationOperationRule<Character, Character> forcePut(final Character key,
+			final ObfuscationOperationRule<Character, Character> value)
+		{
+			return delegate.forcePut(key, value);
+		}
+
+		@Override
+		public BiMap<ObfuscationOperationRule<Character, Character>, Character> inverse()
+		{
+			return delegate.inverse();
+		}
+
+		@Override
+		public Set<ObfuscationOperationRule<Character, Character>> values()
+		{
+			return delegate.values();
+		}
+
+		CloneableBiMap(
+			final BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate)
+		{
+			this.delegate = delegate;
+		}
+
+		@Override
+		protected BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate()
+		{
+			return delegate;
+		}
+
+		@Override
+		public CloneableBiMap clone()
+		{
+			BiMap<Character, ObfuscationOperationRule<Character, Character>> copy = HashBiMap
+				.create();
+			delegate.forEach((character, rule) -> copy.put(character,
+				ObfuscationOperationRule.<Character, Character> builder()
+					.character(rule.getCharacter()).replaceWith(rule.getReplaceWith())
+					.operation(rule.getOperation())
+					.indexes(SetFactory.newHashSet(rule.getIndexes())).inverted(rule.isInverted())
+					.build()));
+			return new CloneableBiMap(copy);
+		}
+	}
+
+	/**
+	 * A {@link BiMap} that claims to be {@link Cloneable} but does not declare a {@code clone()}
+	 * method, so {@code CloneObjectExtensions} fails with a {@link NoSuchMethodException}
+	 */
+	static final class NotReallyCloneableBiMap
+		extends
+			ForwardingMap<Character, ObfuscationOperationRule<Character, Character>>
+		implements
+			BiMap<Character, ObfuscationOperationRule<Character, Character>>,
+			Cloneable
+	{
+		private final BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate;
+
+		@Override
+		public ObfuscationOperationRule<Character, Character> forcePut(final Character key,
+			final ObfuscationOperationRule<Character, Character> value)
+		{
+			return delegate.forcePut(key, value);
+		}
+
+		@Override
+		public BiMap<ObfuscationOperationRule<Character, Character>, Character> inverse()
+		{
+			return delegate.inverse();
+		}
+
+		@Override
+		public Set<ObfuscationOperationRule<Character, Character>> values()
+		{
+			return delegate.values();
+		}
+
+		NotReallyCloneableBiMap(
+			final BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate)
+		{
+			this.delegate = delegate;
+		}
+
+		@Override
+		protected BiMap<Character, ObfuscationOperationRule<Character, Character>> delegate()
+		{
+			return delegate;
+		}
+	}
+
+	/**
+	 * Two independent rules (no replacement character is itself a rule key), which is the
+	 * precondition for {@link ObfuscatorExtensions#inverse(BiMap)} to succeed
+	 *
+	 * @return the newly created rules
+	 */
+	static BiMap<Character, ObfuscationOperationRule<Character, Character>> newIndependentRules()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', newRule('a', 'x', Operation.UPPERCASE, 0));
+		rules.put('b', newRule('b', 'y', Operation.NEGATE, 1));
+		rules.put('c', newRule('c', 'z', Operation.NEGATE, 2));
+		return rules;
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#inverse(BiMap)},
+	 * {@link ObfuscatorExtensions#inverseToMap(BiMap)} and
+	 * {@link ObfuscatorExtensions#disentangleImproved(BiMap, String)} with a plain
+	 * {@link HashBiMap}
+	 * <p>
+	 * Note: this test documents a known defect. All three methods clone their arguments over
+	 * {@link ObfuscatorExtensions#tryToClone(Object)} which wraps the result of the clone helper in
+	 * {@link Optional#of(Object)}. The clone helper answers null for a {@link HashBiMap} and for a
+	 * {@link Character}, so the methods fail with a {@link NullPointerException} for exactly the
+	 * types that the signatures ask for. Once {@code tryToClone} uses
+	 * {@link Optional#ofNullable(Object)} this test has to be replaced by real round trip
+	 * assertions.
+	 */
+	@Test
+	public void inverseAndDisentangleImproved_currentlyFailForPlainHashBiMaps()
+	{
+		assertThrows(NullPointerException.class,
+			() -> ObfuscatorExtensions.inverse(newSmallChainRules()));
+		assertThrows(NullPointerException.class,
+			() -> ObfuscatorExtensions.inverseToMap(newSmallChainRules()));
+		assertThrows(NullPointerException.class,
+			() -> ObfuscatorExtensions.disentangleImproved(newSmallChainRules(), "AcAC"));
+		// the Character keys can never be cloned, so inverseToMap fails for a cloneable map too
+		assertThrows(NullPointerException.class,
+			() -> ObfuscatorExtensions.inverseToMap(new CloneableBiMap(newIndependentRules())));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#inverse(BiMap)} with a cloneable {@link BiMap},
+	 * the result has to map every inverted rule to its former replacement character and the given
+	 * rules must stay untouched
+	 */
+	@Test
+	public void inverse_withACloneableBiMap_invertsEveryRuleOnACopy()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = new CloneableBiMap(
+			newIndependentRules());
+
+		BiMap<ObfuscationOperationRule<Character, Character>, Character> inverted = ObfuscatorExtensions
+			.inverse(rules);
+
+		assertEquals(rules.size(), inverted.size());
+		inverted.forEach((rule, character) -> {
+			assertTrue(rule.isInverted());
+			assertEquals(rule.getCharacter(), character);
+			ObfuscationOperationRule<Character, Character> original = rules
+				.get(rule.getReplaceWith());
+			assertEquals(original.getReplaceWith(), rule.getCharacter());
+			assertFalse(original.isInverted(), "the given rules must not be modified");
+		});
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#inverse(BiMap)} with a {@link BiMap} that can not
+	 * be cloned, the given rules themselves have to be inverted in place
+	 */
+	@Test
+	public void inverse_withANotCloneableBiMap_invertsTheGivenRulesInPlace()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = new NotReallyCloneableBiMap(
+			newIndependentRules());
+		ObfuscationOperationRule<Character, Character> ruleOfA = rules.get('a');
+
+		BiMap<ObfuscationOperationRule<Character, Character>, Character> inverted = ObfuscatorExtensions
+			.inverse(rules);
+
+		assertTrue(ruleOfA.isInverted());
+		assertEquals('x', ruleOfA.getCharacter());
+		assertEquals('a', ruleOfA.getReplaceWith());
+		assertEquals(Set.of('x', 'y', 'z'), Set.copyOf(inverted.values()));
+		assertTrue(inverted.keySet().stream().allMatch(ObfuscationOperationRule::isInverted));
+	}
+
+	record ImprovedDisentangleCase(String description, String obfuscated, String expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<ImprovedDisentangleCase> improvedDisentangleCases()
+	{
+		return Stream.of(
+			new ImprovedDisentangleCase("operated characters on their rule index", "ABC", "abc"),
+			new ImprovedDisentangleCase("replacement characters", "xyz", "abc"),
+			new ImprovedDisentangleCase("mixed with characters without a rule", "AB-xy", "ab-ab"),
+			new ImprovedDisentangleCase("an operated character on a foreign index is dropped", "xA",
+				"a"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangleImproved(BiMap, String)} with a
+	 * cloneable {@link BiMap}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("improvedDisentangleCases")
+	public void disentangleImproved_withACloneableBiMap_restoresTheOriginalCharacters(
+		final ImprovedDisentangleCase testCase)
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = new CloneableBiMap(
+			newIndependentRules());
+
+		assertEquals(testCase.expected(),
+			ObfuscatorExtensions.disentangleImproved(rules, testCase.obfuscated()));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)} and
+	 * {@link ObfuscatorExtensions#disentangleImproved(BiMap, String)}, obfuscating and
+	 * disentangling again has to result in the original input
+	 */
+	@Test
+	public void obfuscateWith_thenDisentangleImproved_recoversTheOriginalInput()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = new CloneableBiMap(
+			newIndependentRules());
+		String input = "abcab-cba";
+
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(rules, input);
+
+		assertEquals("ABCxy-zyx", obfuscated);
+		assertEquals(input, ObfuscatorExtensions.disentangleImproved(rules, obfuscated));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#tryToClone(Object)}, an object that claims to be
+	 * cloneable without a clone method can not be cloned
+	 */
+	@Test
+	public void tryToClone_answersEmptyForAnObjectWithoutACloneMethod()
+	{
+		assertFalse(ObfuscatorExtensions.tryToClone(new Cloneable()
+		{
+		}).isPresent());
+		assertFalse(ObfuscatorExtensions.tryToClone(new NotReallyCloneableBiMap(HashBiMap.create()))
+			.isPresent());
+	}
+
+	record CaseOperationCase(String description, char character, Operation operation, String input,
+		String expectedObfuscated) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<CaseOperationCase> caseOperationCases()
+	{
+		return Stream.of(
+			new CaseOperationCase("lowercase operation on an upper case character", 'A',
+				Operation.LOWERCASE, "AA", "ax"),
+			new CaseOperationCase("uppercase operation on a lower case character", 'a',
+				Operation.UPPERCASE, "aa", "Ax"),
+			new CaseOperationCase("negate operation on a lower case character", 'a',
+				Operation.NEGATE, "aa", "Ax"),
+			new CaseOperationCase("negate operation on an upper case character", 'A',
+				Operation.NEGATE, "AA", "ax"),
+			new CaseOperationCase("uppercase operation on a digit has no case to reverse", '1',
+				Operation.UPPERCASE, "11", "1x"),
+			new CaseOperationCase("lowercase operation on a digit has no case to reverse", '1',
+				Operation.LOWERCASE, "11", "1x"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}, the reverse
+	 * operation has to respect the case of the obfuscated character
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("caseOperationCases")
+	public void disentangle_reversesTheCaseOperationOnTheRuleIndex(final CaseOperationCase testCase)
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put(testCase.character(),
+			newRule(testCase.character(), 'x', testCase.operation(), 0));
+		rules.put('x', newRule('x', 'y', Operation.UPPERCASE, 5));
+
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(rules, testCase.input());
+
+		assertEquals(testCase.expectedObfuscated(), obfuscated);
+		assertEquals(testCase.input(), ObfuscatorExtensions.disentangle(rules, obfuscated));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)} and
+	 * {@link ObfuscatorExtensions#disentangle(BiMap, String)} with a rule without indexes, the
+	 * operation is never applied and only the replacement is used
+	 */
+	@Test
+	public void obfuscateWith_withARuleWithoutIndexes_neverAppliesTheOperation()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('h', newRule('h', 'i', Operation.UPPERCASE));
+		rules.put('i', newRule('i', 'j', Operation.UPPERCASE, 0));
+
+		assertEquals("ii", ObfuscatorExtensions.obfuscateWith(rules, "hh"));
+		assertEquals("ii", ObfuscatorExtensions.obfuscateWithCharArray(rules, "hh"));
+		assertEquals("hh", ObfuscatorExtensions.disentangle(rules, "ii"));
+		assertEquals(Map.of('i', 'h', 'I', 'i', 'j', 'i'),
+			ObfuscatorExtensions.swapMapWithReplaceWithAsKey(rules));
+		assertEquals(Set.of('i', 'I', 'j'),
+			ObfuscatorExtensions.swapOperatedMapWithReplaceWithAsKey(rules).keySet());
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#swapMapWithReplaceWithAsKey(BiMap)} and
+	 * {@link ObfuscatorExtensions#swapOperatedMapWithReplaceWithAsKey(BiMap)} with the
+	 * {@link Operation#NONE}, no operated character is added
+	 */
+	@Test
+	public void swapMaps_withTheNoneOperation_mapOnlyTheReplacementCharacter()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('k', newRule('k', 'l', Operation.NONE, 0, 1));
+
+		assertEquals(Map.of('l', 'k'), ObfuscatorExtensions.swapMapWithReplaceWithAsKey(rules));
+		assertEquals(Set.of('l'),
+			ObfuscatorExtensions.swapOperatedMapWithReplaceWithAsKey(rules).keySet());
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}, a character that is
+	 * a rule key but can not be the output of the obfuscation is dropped
+	 */
+	@Test
+	public void disentangle_dropsARuleCharacterThatCanNotBeAnObfuscationResult()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newIndependentRules();
+
+		assertEquals("-", ObfuscatorExtensions.disentangle(rules, "a-b"));
+		assertEquals("-", ObfuscatorExtensions.disentangle(rules, "-"));
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#obfuscateWith(BiMap, String)},
+	 * {@link ObfuscatorExtensions#obfuscateWithCharArray(BiMap, String)} and
+	 * {@link ObfuscatorExtensions#disentangle(BiMap, String)} with a rule without an operation, the
+	 * character is only replaced and the replacement is resolved on disentangling
+	 */
+	@Test
+	public void obfuscateWith_withARuleWithoutOperation_onlyReplacesTheCharacter()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('d', newRule('d', 'e', null, 0));
+		rules.put('e', newRule('e', 'f', Operation.UPPERCASE, 0));
+		rules.put('f', newRule('f', 'g', Operation.UPPERCASE, 9));
+
+		assertEquals("ee", ObfuscatorExtensions.obfuscateWith(rules, "dd"));
+		assertEquals("ee", ObfuscatorExtensions.obfuscateWithCharArray(rules, "dd"));
+		assertEquals("dd", ObfuscatorExtensions.disentangle(rules, "ee"));
+		assertEquals("Ef", ObfuscatorExtensions.obfuscateWith(rules, "ee"));
+		assertEquals("ee", ObfuscatorExtensions.disentangle(rules, "Ef"));
+		assertEquals(Map.of('e', 'd', 'E', 'e', 'f', 'e', 'F', 'f', 'g', 'f'),
+			ObfuscatorExtensions.swapMapWithReplaceWithAsKey(rules));
+		assertEquals(Set.of('e', 'E', 'f', 'F', 'g'),
+			ObfuscatorExtensions.swapOperatedMapWithReplaceWithAsKey(rules).keySet());
+	}
+
+	static Stream<NullArgumentCase> nullArgumentCases()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newSmallChainRules();
+		return Stream.of(
+			new NullArgumentCase("disentangle without rules",
+				() -> ObfuscatorExtensions.disentangle(
+					(BiMap<Character, ObfuscationOperationRule<Character, Character>>)null,
+					"abac")),
+			new NullArgumentCase("disentangle without obfuscated text",
+				() -> ObfuscatorExtensions.disentangle(rules, null)),
+			new NullArgumentCase("inverse without rules",
+				() -> ObfuscatorExtensions.inverse(
+					(BiMap<Character, ObfuscationOperationRule<Character, Character>>)null)),
+			new NullArgumentCase("inverse without rule",
+				() -> ObfuscatorExtensions
+					.inverse((ObfuscationOperationRule<Character, Character>)null)),
+			new NullArgumentCase("inverseToMap without rules",
+				() -> ObfuscatorExtensions.inverseToMap(null)),
+			new NullArgumentCase("isObfuscableAndDisentanglable without rules",
+				() -> ObfuscatorExtensions.isObfuscableAndDisentanglable(null, "abac")),
+			new NullArgumentCase("isObfuscableAndDisentanglable without input",
+				() -> ObfuscatorExtensions.isObfuscableAndDisentanglable(rules, null)),
+			new NullArgumentCase("swapMapWithReplaceWithAsKey without rules",
+				() -> ObfuscatorExtensions.swapMapWithReplaceWithAsKey(null)),
+			new NullArgumentCase("swapOperatedMapWithReplaceWithAsKey without rules",
+				() -> ObfuscatorExtensions.swapOperatedMapWithReplaceWithAsKey(null)),
+			new NullArgumentCase("tryToClone without object",
+				() -> ObfuscatorExtensions.tryToClone(null)),
+			new NullArgumentCase("validate without rules",
+				() -> ObfuscatorExtensions.validate(null)));
+	}
+
+	/**
+	 * Test method that verifies that every method rejects null arguments
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("nullArgumentCases")
+	public void everyMethodRejectsNullArguments(final NullArgumentCase testCase)
+	{
+		assertThrows(NullPointerException.class, testCase.executable());
+	}
+
+	/**
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)} that pins the side
+	 * effect of the {@code operation != null} branch: while disentangling, every rule that carries
+	 * a non-null operation has its operated character computed and stored on the rule via
+	 * {@code setOperatedCharacter}. This kills the negated-conditional mutant of the
+	 * {@code if (operation != null)} guard and the removed-call mutant of
+	 * {@code setOperatedCharacter} - both would leave the operated character unset.
+	 */
+	@Test
+	public void disentangle_setsTheOperatedCharacterOnEveryRuleWithAnOperation()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newSmallChainRules();
+
+		// before disentangling, no rule has had its operated character computed
+		for (ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			assertTrue(
+				rule.getOperatedCharacter() == null || !rule.getOperatedCharacter().isPresent());
+		}
+
+		ObfuscatorExtensions.disentangle(rules, "abc");
+
+		// afterwards every rule (all carry the UPPERCASE operation) has a present operated
+		// character
+		for (ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			Optional<Character> operated = rule.getOperatedCharacter();
+			assertNotNull(operated, "operated character must be set for a rule with an operation");
+			assertTrue(operated.isPresent(),
+				"operated character must be present for a rule with an operation");
+		}
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/simple/SimpleObfuscatorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/simple/SimpleObfuscatorExtensionsTest.java
@@ -25,10 +25,10 @@
 package io.github.astrapi69.mystic.crypt.obfuscation.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.meanbean.test.BeanTester;
 
@@ -249,17 +249,23 @@ public class SimpleObfuscatorExtensionsTest extends AbstractTestCase<String, Str
 	 * Test method for {@link SimpleObfuscatorExtensions#validate(BiMap)}
 	 */
 	@Test
-	@Disabled
 	public void testValidate()
 	{
-		boolean actual;
-		boolean expected;
-		BiMap<Character, ObfuscationRule<Character, Character>> biMap;
+		BiMap<Character, ObfuscationRule<Character, Character>> biMap = HashBiMap.create();
+		biMap.put('a', ObfuscationRule.<Character, Character> builder().character('a')
+			.replaceWith('x').build());
+		biMap.put('b', ObfuscationRule.<Character, Character> builder().character('b')
+			.replaceWith('y').build());
 
-		biMap = SimpleObfuscationTestData.getFirstBiMapObfuscationRules();
-		actual = SimpleObfuscatorExtensions.validate(biMap);
-		expected = true;
-		assertEquals(expected, actual);
+		assertTrue(SimpleObfuscatorExtensions.validate(biMap),
+			"no replacement is an obfuscated character, so it is disentanglable");
+
+		biMap.put('x', ObfuscationRule.<Character, Character> builder().character('x')
+			.replaceWith('z').build());
+
+		assertFalse(SimpleObfuscatorExtensions.validate(biMap),
+			"'x' is a replacement and an obfuscated character at the same time");
+		assertTrue(SimpleObfuscatorExtensions.validate(HashBiMap.create()));
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/processor/bruteforce/BruteForceProcessorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/processor/bruteforce/BruteForceProcessorTest.java
@@ -24,16 +24,16 @@
  */
 package io.github.astrapi69.mystic.crypt.processor.bruteforce;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.util.Set;
-import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import io.github.astrapi69.io.annotation.ScanPackageExtensions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * The unit test class for the class {@link BruteForceProcessor}
@@ -41,67 +41,179 @@ import io.github.astrapi69.io.annotation.ScanPackageExtensions;
 public class BruteForceProcessorTest
 {
 
-	private static final Logger log = Logger.getLogger(BruteForceProcessorTest.class.getName());
+	/** A tiny alphabet keeps every brute force run in this class in the microsecond range */
+	private static final char[] ALPHABET_AB = { 'a', 'b' };
+
+	private static final char[] ALPHABET_ABC = { 'a', 'b', 'c' };
 
 	/**
-	 * Test method for test the class {@link BruteForceProcessor}.
+	 * A scenario that describes the expected sequence of attempts
 	 *
-	 * @throws IOException
-	 *             Signals that an I/O exception has occurred.
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param possibleCharacters
+	 *            the alphabet to iterate
+	 * @param attemptLength
+	 *            the initial length of an attempt
+	 * @param expectedAttempts
+	 *            the expected attempts in the expected order
 	 */
-	@Test
-	@Disabled
-	public void test() throws IOException
-	{
-
-		String password;
-		char[] possibleCharacters;
-		BruteForceProcessor processor;
-		String attempt;
-		boolean found;
-		long start;
-		long end;
-		long elapsedMilliSeconds;
-		Set<String> list;
-
-		list = ScanPackageExtensions.scanClassNames("de.alpharogroup", true, true);
-		for (final String string : list)
+	record AttemptSequenceCase(String description, char[] possibleCharacters, int attemptLength,
+		List<String> expectedAttempts) {
+		@Override
+		public String toString()
 		{
-			if (string.endsWith("Test"))
-			{
-				log.info("<class name=\"" + string + "\"/>");
-			}
+			return description;
+		}
+	}
+
+	/**
+	 * A scenario for a brute force search of a concrete target
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param possibleCharacters
+	 *            the alphabet to iterate
+	 * @param attemptLength
+	 *            the initial length of an attempt
+	 * @param target
+	 *            the searched target
+	 * @param expectedAttemptCount
+	 *            the expected number of attempts until the target is found
+	 */
+	record SearchCase(String description, char[] possibleCharacters, int attemptLength,
+		String target, int expectedAttemptCount) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<AttemptSequenceCase> attemptSequenceCases()
+	{
+		return Stream.of(
+			new AttemptSequenceCase("two characters, length one, overflows to length two",
+				ALPHABET_AB, 1, List.of("a", "b", "aa", "ab", "ba", "bb", "aaa")),
+			new AttemptSequenceCase("three characters, length one", ALPHABET_ABC, 1,
+				List.of("a", "b", "c", "aa", "ab", "ac", "ba")),
+			new AttemptSequenceCase("two characters, length two", ALPHABET_AB, 2,
+				List.of("aa", "ab", "ba", "bb", "aaa", "aab")));
+	}
+
+	/**
+	 * Test method for {@link BruteForceProcessor#increment()} and
+	 * {@link BruteForceProcessor#getCurrentAttempt()}, the processor has to iterate the alphabet
+	 * from the right to the left and has to grow the attempt as soon as every combination of the
+	 * current length is used
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("attemptSequenceCases")
+	public void increment_iteratesEveryCombinationAndGrowsTheAttempt(
+		final AttemptSequenceCase testCase)
+	{
+		BruteForceProcessor processor = new BruteForceProcessor(testCase.possibleCharacters(),
+			testCase.attemptLength());
+
+		List<String> attempts = new ArrayList<>();
+		for (int i = 0; i < testCase.expectedAttempts().size(); i++)
+		{
+			attempts.add(processor.getCurrentAttempt());
+			processor.increment();
 		}
 
-		password = "ha";
-		possibleCharacters = new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-				'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
+		assertEquals(testCase.expectedAttempts(), attempts);
+	}
 
-		processor = new BruteForceProcessor(possibleCharacters, 1);
-		attempt = processor.getCurrentAttempt();
+	/**
+	 * Test method for {@link BruteForceProcessor#getCurrentAttempt()}, the first attempt consists
+	 * only of the first character of the alphabet
+	 */
+	@Test
+	public void increment_withAnEmptyAttempt_isANoOp()
+	{
+		BruteForceProcessor processor = new BruteForceProcessor(ALPHABET_ABC, 0);
 
-		start = System.currentTimeMillis();
-		while (true)
+		assertEquals("", processor.getCurrentAttempt());
+		processor.increment();
+		assertEquals("", processor.getCurrentAttempt());
+	}
+
+	/**
+	 * Test method for {@link BruteForceProcessor#getCurrentAttempt()}
+	 */
+	@Test
+	public void getCurrentAttempt_startsWithTheFirstCharacterOfTheAlphabet()
+	{
+		assertEquals("a", new BruteForceProcessor(ALPHABET_ABC, 1).getCurrentAttempt());
+		assertEquals("aaa", new BruteForceProcessor(ALPHABET_ABC, 3).getCurrentAttempt());
+	}
+
+	static Stream<SearchCase> searchCases()
+	{
+		return Stream.of(new SearchCase("first attempt already matches", ALPHABET_AB, 1, "a", 1),
+			new SearchCase("last character of the alphabet", ALPHABET_ABC, 1, "c", 3),
+			new SearchCase("target longer than the initial attempt", ALPHABET_AB, 1, "ba", 5),
+			new SearchCase("target of the initial length", ALPHABET_ABC, 2, "bc", 6));
+	}
+
+	/**
+	 * Test method for {@link BruteForceProcessor}, a brute force search over a tiny alphabet finds
+	 * every target and needs exactly as many attempts as the target has predecessors
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("searchCases")
+	public void bruteForceSearch_findsTheTargetAfterTheExpectedNumberOfAttempts(
+		final SearchCase testCase)
+	{
+		BruteForceProcessor processor = new BruteForceProcessor(testCase.possibleCharacters(),
+			testCase.attemptLength());
+
+		int attemptCount = 0;
+		boolean found = false;
+		// the guard only protects the test from an endless loop, every case below is found long
+		// before the guard is reached
+		while (attemptCount < 1000)
 		{
-			if (attempt.equals(password))
+			attemptCount++;
+			if (testCase.target().equals(processor.getCurrentAttempt()))
 			{
-				log.info("Password Found: " + attempt);
 				found = true;
 				break;
 			}
-			attempt = processor.getCurrentAttempt();
-			log.info("Tried: " + attempt);
 			processor.increment();
 		}
-		end = System.currentTimeMillis();
 
-		elapsedMilliSeconds = end - start;
 		assertTrue(found);
-
-		log.info("Started brute force attack for the password '" + password + "'.");
-		log.info("Needed milliseconds for crack the password with brute force attack: "
-			+ elapsedMilliSeconds);
-		log.info("Password found: " + found);
+		assertEquals(testCase.expectedAttemptCount(), attemptCount);
 	}
 
+	/**
+	 * Test method for {@link BruteForceProcessor}, every attempt of a given length is generated
+	 * exactly once before the attempt grows
+	 */
+	@Test
+	public void increment_generatesEveryCombinationOfALengthExactlyOnce()
+	{
+		BruteForceProcessor processor = new BruteForceProcessor(ALPHABET_ABC, 2);
+
+		List<String> attempts = new ArrayList<>();
+		for (int i = 0; i < 9; i++)
+		{
+			attempts.add(processor.getCurrentAttempt());
+			processor.increment();
+		}
+
+		assertEquals(9, attempts.stream().distinct().count());
+		assertTrue(attempts.stream().allMatch(attempt -> attempt.length() == 2));
+		// the next attempt after the last combination of the length two is the first combination of
+		// the length three
+		assertEquals("aaa", processor.getCurrentAttempt());
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/processor/bruteforce/PrivateKeyBruteForceProcessorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/processor/bruteforce/PrivateKeyBruteForceProcessorTest.java
@@ -25,119 +25,141 @@
 package io.github.astrapi69.mystic.crypt.processor.bruteforce;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.security.Security;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Logger;
+import java.util.stream.Stream;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.pkcs.PKCSException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import io.github.astrapi69.crypt.data.key.reader.EncryptedPrivateKeyReader;
 import io.github.astrapi69.crypt.data.key.reader.PrivateKeyReader;
 import io.github.astrapi69.file.search.PathFinder;
 
 /**
- * The unit test class for the class {@link BruteForceProcessor}
+ * The unit test class for the class {@link PrivateKeyBruteForceProcessor}
  */
 public class PrivateKeyBruteForceProcessorTest
 {
 
-	private static final Logger log = Logger
-		.getLogger(PrivateKeyBruteForceProcessorTest.class.getName());
+	/** A tiny alphabet keeps the runtime of every test in this class in the millisecond range */
+	private static final char[] ALPHABET = { 'a', 'b', 'c' };
 
 	/**
-	 * Resolve the password from the given private key file. If no password is set an empty Optional
-	 * will be returned.
+	 * A scenario for a private key file that can not be resolved
 	 *
-	 * @param privateKeyFile
-	 *            the private key file
-	 * @param processor
-	 *            the processor
-	 * @return the optional
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param privateKeyFileName
+	 *            the relative name of the private key file below the test resources
 	 */
-	public static Optional<String> resolvePassword(File privateKeyFile,
-		BruteForceProcessor processor)
-	{
-		Objects.requireNonNull(processor);
-		Optional<String> optionalPassword = Optional.empty();
-		try
+	record UnresolvableCase(String description, String privateKeyFileName) {
+		@Override
+		public String toString()
 		{
-			Security.addProvider(new BouncyCastleProvider());
-			boolean isPasswordProtected = PrivateKeyReader
-				.isPrivateKeyPasswordProtected(privateKeyFile);
+			return description;
+		}
+	}
 
-			if (isPasswordProtected)
-			{
-				String attempt;
-				attempt = processor.getCurrentAttempt();
-				while (true)
-				{
-					try
-					{
-						EncryptedPrivateKeyReader.getKeyPair(privateKeyFile, attempt);
-						optionalPassword = Optional.of(attempt);
-						break;
-					}
-					catch (IOException e)
-					{
-						attempt = processor.getCurrentAttempt();
-						processor.increment();
-					}
-					catch (PKCSException e)
-					{
-						attempt = processor.getCurrentAttempt();
-						processor.increment();
-					}
-				}
-			}
-		}
-		catch (IOException ex)
-		{
-			return optionalPassword;
-		}
-		return optionalPassword;
+	private static File testResource(final String relativeFileName)
+	{
+		return new File(PathFinder.getSrcTestResourcesDir(), relativeFileName);
+	}
+
+	static Stream<UnresolvableCase> unresolvableCases()
+	{
+		return Stream.of(new UnresolvableCase("password protected private key", "pem/test.key.pem"),
+			new UnresolvableCase("private key file that does not exist",
+				"pem/this-file-does-not-exist.pem"));
 	}
 
 	/**
-	 * Test method for test the class {@link BruteForceProcessor}
+	 * Test method for
+	 * {@link PrivateKeyBruteForceProcessor#resolvePassword(File, BruteForceProcessor)}, an empty
+	 * optional is answered for a private key file whose password can not be resolved
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("unresolvableCases")
+	public void resolvePassword_answersAnEmptyOptional(final UnresolvableCase testCase)
+	{
+		Optional<String> resolved = PrivateKeyBruteForceProcessor.resolvePassword(
+			testResource(testCase.privateKeyFileName()), new BruteForceProcessor(ALPHABET, 1));
+
+		assertFalse(resolved.isPresent());
+	}
+
+	/**
+	 * Test method for
+	 * {@link PrivateKeyBruteForceProcessor#resolvePassword(File, BruteForceProcessor)}, the
+	 * password protected test key really is recognized as password protected, which is the reason
+	 * why the method above answers an empty optional
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
 	 */
 	@Test
-	@Disabled
-	public void testPrivateKeyWithPassword()
+	public void resolvePassword_acceptsTheFirstAttemptForAKeyThatIsNotPasswordProtected()
+		throws Exception
 	{
-		File pemDir;
-		File encryptedPrivateKeyFile;
-		char[] possibleCharacters;
-		BruteForceProcessor processor;
-		long start;
-		long end;
-		long elapsedMilliSeconds;
+		File privateKeyFile = testResource("pem/private.pem");
+		BruteForceProcessor processor = new BruteForceProcessor(ALPHABET, 2);
+		assertFalse(PrivateKeyReader.isPrivateKeyPasswordProtected(privateKeyFile));
 
-		pemDir = new File(PathFinder.getSrcTestResourcesDir(), "pem");
-		encryptedPrivateKeyFile = new File(pemDir, "test.key.pem");
+		Optional<String> resolved = PrivateKeyBruteForceProcessor.resolvePassword(privateKeyFile,
+			processor);
 
-		possibleCharacters = new char[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-				'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
-
-		processor = new BruteForceProcessor(possibleCharacters, 1);
-		start = System.currentTimeMillis();
-		Optional<String> resolvePassword = resolvePassword(encryptedPrivateKeyFile, processor);
-		end = System.currentTimeMillis();
-
-		elapsedMilliSeconds = end - start;
-		assertTrue(resolvePassword.isPresent());
-		String expected = "bosco";
-		String actual = resolvePassword.get();
-		assertEquals(expected, actual);
-		log.info("Needed milliseconds for crack the password with brute force attack: "
-			+ elapsedMilliSeconds);
+		assertTrue(resolved.isPresent());
+		assertEquals("aa", resolved.get());
+		assertEquals("aa", processor.getCurrentAttempt(), "no further attempt is needed");
 	}
 
+	/**
+	 * Test method for
+	 * {@link PrivateKeyBruteForceProcessor#resolvePassword(File, BruteForceProcessor)}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void resolvePassword_theTestKeyIsRecognizedAsPasswordProtected() throws Exception
+	{
+		assertTrue(
+			PrivateKeyReader.isPrivateKeyPasswordProtected(testResource("pem/test.key.pem")));
+	}
+
+	/**
+	 * Test method for
+	 * {@link PrivateKeyBruteForceProcessor#resolvePassword(File, BruteForceProcessor)}, the
+	 * processor is mandatory
+	 */
+	@Test
+	public void resolvePassword_withoutAProcessor_throwsANullPointerException()
+	{
+		File privateKeyFile = testResource("pem/test.key.pem");
+
+		assertThrows(NullPointerException.class,
+			() -> PrivateKeyBruteForceProcessor.resolvePassword(privateKeyFile, null));
+	}
+
+	/**
+	 * Test method for
+	 * {@link PrivateKeyBruteForceProcessor#resolvePassword(File, BruteForceProcessor)}, the given
+	 * processor is not consumed when the private key file is password protected
+	 */
+	@Test
+	public void resolvePassword_leavesTheProcessorUntouchedForAProtectedPrivateKey()
+	{
+		BruteForceProcessor processor = new BruteForceProcessor(ALPHABET, 1);
+
+		PrivateKeyBruteForceProcessor.resolvePassword(testResource("pem/test.key.pem"), processor);
+
+		assertEquals("a", processor.getCurrentAttempt());
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/processor/wordlist/WordlistsProcessorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/processor/wordlist/WordlistsProcessorTest.java
@@ -25,6 +25,9 @@
 package io.github.astrapi69.mystic.crypt.processor.wordlist;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -50,6 +53,54 @@ public class WordlistsProcessorTest
 	 *
 	 * @throws IOException
 	 *             Signals that an I/O exception has occurred.
+	 */
+	@Test
+	public void getCurrentAttempt_answersNullAndIncrementStopsAtTheEndOfTheWordList()
+	{
+		WordlistsProcessor processor = new WordlistsProcessor(
+			ListFactory.newArrayList("foo", "bar"), "bar");
+
+		assertEquals("foo", processor.getCurrentAttempt());
+		assertTrue(processor.increment());
+		assertEquals("bar", processor.getCurrentAttempt());
+		assertTrue(processor.increment());
+		assertNull(processor.getCurrentAttempt());
+		assertFalse(processor.increment());
+		assertNull(processor.getCurrentAttempt());
+	}
+
+	/**
+	 * Test method for {@link WordlistsProcessor#process()}, a password that is not in the word list
+	 * can not be found and the search stops at the end of the list
+	 */
+	@Test
+	public void process_answersFalseIfThePasswordIsNotInTheWordList()
+	{
+		WordlistsProcessor processor = new WordlistsProcessor(
+			ListFactory.newArrayList("foo", "bar"), "baz");
+
+		assertFalse(processor.process());
+		assertNull(processor.getCurrentAttempt());
+	}
+
+	/**
+	 * Test method for {@link WordlistsProcessor#WordlistsProcessor(List, String)}, an empty or
+	 * missing password to check against has to be rejected
+	 */
+	@Test
+	public void constructor_rejectsAnEmptyPassword()
+	{
+		List<String> words = ListFactory.newArrayList("foo");
+
+		assertThrows(IllegalArgumentException.class, () -> new WordlistsProcessor(words, ""));
+		assertThrows(IllegalArgumentException.class, () -> new WordlistsProcessor(words, null));
+	}
+
+	/**
+	 * Test method for {@link WordlistsProcessor#process()}
+	 *
+	 * @throws IOException
+	 *             is thrown if an error occurs
 	 */
 	@Test
 	public void test() throws IOException

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/Argon2SupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/Argon2SupportTest.java
@@ -1,0 +1,136 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The unit test class for the class {@link Argon2Support}
+ */
+public class Argon2SupportTest
+{
+
+	private static final String PASSWORD = "correct horse battery staple";
+
+	/**
+	 * A scenario with an encoded hash that can not be verified
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param encoded
+	 *            the malformed encoded hash
+	 */
+	record MalformedHashCase(String description, String encoded) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<MalformedHashCase> malformedHashCases()
+	{
+		return Stream.of(new MalformedHashCase("not an encoded hash at all", "not-a-valid-hash"),
+			new MalformedHashCase("wrong argon2 variant",
+				"$argon2i$v=19$m=8,t=1,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("missing parallelism parameter",
+				"$argon2id$v=19$m=8,t=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("parameter without a value",
+				"$argon2id$v=19$m=8,t=1,p$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("unknown parameter",
+				"$argon2id$v=19$m=8,t=1,x=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("negative memory parameter",
+				"$argon2id$v=19$m=-8,t=1,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("negative iterations parameter",
+				"$argon2id$v=19$m=8,t=-1,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("negative parallelism parameter",
+				"$argon2id$v=19$m=8,t=1,p=-1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("too few parts", "$argon2id$v=19$m=8,t=1,p=1$c2FsdA"));
+	}
+
+	/**
+	 * Test method for {@link Argon2Support#verify(char[], String)}, a malformed encoded hash never
+	 * verifies but also never propagates an exception
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("malformedHashCases")
+	public void verify_answersFalseForAMalformedEncodedHash(final MalformedHashCase testCase)
+	{
+		assertFalse(Argon2Support.verify(PASSWORD.toCharArray(), testCase.encoded()));
+	}
+
+	/**
+	 * Test method for {@link Argon2Support#hash(char[])} and
+	 * {@link Argon2Support#verify(char[], String)}, only the very same password verifies
+	 */
+	@Test
+	public void hash_createsAnEncodedHashThatOnlyVerifiesTheSamePassword()
+	{
+		String encoded = Argon2Support.hash(PASSWORD.toCharArray());
+
+		assertTrue(encoded.startsWith("$argon2id$"));
+		assertTrue(Argon2Support.verify(PASSWORD.toCharArray(), encoded));
+		assertFalse(Argon2Support.verify("wrong password".toCharArray(), encoded));
+	}
+
+	/**
+	 * Test method for {@link Argon2Support#verify(char[], String)}, a tampered hash does not verify
+	 */
+	@Test
+	public void verify_answersFalseForATamperedHash()
+	{
+		String encoded = Argon2Support.hash(PASSWORD.toCharArray());
+		String tampered = encoded.substring(0, encoded.length() - 1)
+			+ (encoded.charAt(encoded.length() - 1) == 'A' ? 'B' : 'A');
+
+		assertFalse(Argon2Support.verify(PASSWORD.toCharArray(), tampered));
+	}
+
+	/**
+	 * Test method for {@link Argon2Support#hash(char[])} and
+	 * {@link Argon2Support#verify(char[], String)}, both arguments are mandatory
+	 */
+	@Test
+	public void hashAndVerify_rejectNullArguments()
+	{
+		String encoded = Argon2Support.hash(PASSWORD.toCharArray());
+
+		assertThrows(NullPointerException.class, () -> Argon2Support.hash(null));
+		assertThrows(NullPointerException.class, () -> Argon2Support.verify(null, encoded));
+		assertThrows(NullPointerException.class,
+			() -> Argon2Support.verify(PASSWORD.toCharArray(), null));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteDecryptorTest.java
@@ -27,6 +27,7 @@ package io.github.astrapi69.mystic.crypt.pw;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -71,4 +72,65 @@ public class PasswordByteDecryptorTest
 		assertArrayEquals(textBytes, decryptor.decrypt(secondEncrypted));
 	}
 
+	/**
+	 * Test method for {@link PasswordByteDecryptor#decrypt(byte[])}, encrypted data that is shorter
+	 * than the salt prefix has to be rejected
+	 */
+	@Test
+	public void decrypt_withDataShorterThanTheSaltPrefix_throwsAnIllegalArgumentException()
+	{
+		PasswordByteDecryptor decryptor = new PasswordByteDecryptor("foo");
+
+		assertThrows(IllegalArgumentException.class,
+			() -> decryptor.decrypt(new byte[PbeCipherSupport.SALT_LENGTH - 1]));
+	}
+
+	/**
+	 * Test method for {@link PasswordByteDecryptor#decrypt(byte[])}, data of exactly the salt
+	 * prefix length is <em>not</em> rejected by the length guard (it fails later during
+	 * decryption). This pins the boundary of the {@code length < SALT_LENGTH} check so a {@code <=}
+	 * mutant is caught.
+	 */
+	@Test
+	public void decrypt_withDataOfExactlyTheSaltPrefixLength_isNotRejectedByTheLengthGuard()
+	{
+		PasswordByteDecryptor decryptor = new PasswordByteDecryptor("foo");
+
+		Exception exception = assertThrows(Exception.class,
+			() -> decryptor.decrypt(new byte[PbeCipherSupport.SALT_LENGTH]));
+		assertFalse(exception instanceof IllegalArgumentException,
+			"data of exactly the salt length must pass the length guard, not be rejected by it");
+	}
+
+	/**
+	 * Test method for {@link PasswordByteDecryptor#decrypt(byte[])}, the encrypted data is
+	 * mandatory
+	 */
+	@Test
+	public void decrypt_withoutData_throwsANullPointerException()
+	{
+		PasswordByteDecryptor decryptor = new PasswordByteDecryptor("foo");
+
+		assertThrows(NullPointerException.class, () -> decryptor.decrypt(null));
+	}
+
+	/**
+	 * Test method for {@link PasswordByteDecryptor#resetPassword()}, after the password is reset
+	 * nothing can be decrypted anymore
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void resetPassword_clearsThePasswordSoNothingCanBeDecryptedAnymore() throws Exception
+	{
+		byte[] textBytes = "bar".getBytes(StandardCharsets.UTF_8);
+		byte[] encrypted = new PasswordByteEncryptor("foo").encrypt(textBytes);
+		PasswordByteDecryptor decryptor = new PasswordByteDecryptor("foo");
+		assertArrayEquals(textBytes, decryptor.decrypt(encrypted));
+
+		decryptor.resetPassword();
+
+		assertThrows(NullPointerException.class, () -> decryptor.decrypt(encrypted));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteEncryptorTest.java
@@ -26,6 +26,7 @@ package io.github.astrapi69.mystic.crypt.pw;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -62,4 +63,34 @@ public class PasswordByteEncryptorTest
 		assertFalse(Arrays.equals(first, second));
 	}
 
+	/**
+	 * Test method for {@link PasswordByteEncryptor#encrypt(byte[])}, the data to encrypt is
+	 * mandatory
+	 */
+	@Test
+	public void encrypt_withoutData_throwsANullPointerException()
+	{
+		PasswordByteEncryptor encryptor = new PasswordByteEncryptor("foo");
+
+		assertThrows(NullPointerException.class, () -> encryptor.encrypt(null));
+	}
+
+	/**
+	 * Test method for {@link PasswordByteEncryptor#resetPassword()}, after the password is reset
+	 * nothing can be encrypted anymore
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void resetPassword_clearsThePasswordSoNothingCanBeEncryptedAnymore() throws Exception
+	{
+		byte[] textBytes = "bar".getBytes(StandardCharsets.UTF_8);
+		PasswordByteEncryptor encryptor = new PasswordByteEncryptor("foo");
+		assertNotNull(encryptor.encrypt(textBytes));
+
+		encryptor.resetPassword();
+
+		assertThrows(NullPointerException.class, () -> encryptor.encrypt(textBytes));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordEncryptorTest.java
@@ -190,6 +190,14 @@ public class PasswordEncryptorTest
 		charset = StandardCharsets.UTF_8;
 		actual = instance.hashPassword(password, salt, hashAlgorithm, charset);
 		assertNotNull(actual);
+		// guard against a mutant that returns an empty string: the hash must be the SHA-1 digest
+		// of the salted password, deterministic for the same inputs and matchable
+		String expected = io.github.astrapi69.crypt.data.hash.HashExtensions.hash(password, salt,
+			hashAlgorithm, charset);
+		assertEquals(expected, actual);
+		assertTrue(actual.length() > 0);
+		assertTrue(
+			instance.match(actual, instance.hashPassword(password, salt, hashAlgorithm, charset)));
 	}
 
 	/**
@@ -255,4 +263,32 @@ public class PasswordEncryptorTest
 		assertFalse(instance.match("hash-value", "other-value"));
 	}
 
+	/**
+	 * Test method for {@link PasswordEncryptor#hashPasswordPbkdf2(String)} and
+	 * {@link PasswordEncryptor#matchPbkdf2(String, String)}
+	 */
+	@Test
+	public void hashPasswordPbkdf2_createsAHashThatOnlyMatchesTheSamePassword()
+	{
+		String encodedHash = instance.hashPasswordPbkdf2("secret-password");
+
+		assertNotNull(encodedHash);
+		assertTrue(instance.matchPbkdf2("secret-password", encodedHash));
+		assertFalse(instance.matchPbkdf2("another-password", encodedHash));
+	}
+
+	/**
+	 * Test method for {@link PasswordEncryptor#hashPasswordPbkdf2(String)}, every hash of the same
+	 * password is salted individually
+	 */
+	@Test
+	public void hashPasswordPbkdf2_isSaltedAndThereforeNotDeterministic()
+	{
+		String firstHash = instance.hashPasswordPbkdf2("secret-password");
+		String secondHash = instance.hashPasswordPbkdf2("secret-password");
+
+		assertNotEquals(firstHash, secondHash);
+		assertTrue(instance.matchPbkdf2("secret-password", firstHash));
+		assertTrue(instance.matchPbkdf2("secret-password", secondHash));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileDecryptorTest.java
@@ -25,16 +25,22 @@
 package io.github.astrapi69.mystic.crypt.pw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
+import javax.crypto.Cipher;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.astrapi69.checksum.FileChecksumExtensions;
 import io.github.astrapi69.crypt.api.algorithm.MdAlgorithm;
 import io.github.astrapi69.file.delete.DeleteFileExtensions;
+import io.github.astrapi69.file.read.ReadFileExtensions;
 import io.github.astrapi69.file.search.PathFinder;
+import io.github.astrapi69.file.write.StoreFileExtensions;
 import io.github.astrapi69.test.base.AbstractTestCase;
 
 /**
@@ -100,4 +106,95 @@ public class PasswordFileDecryptorTest extends AbstractTestCase<String, String>
 		DeleteFileExtensions.delete(decrypted);
 	}
 
+	/**
+	 * Test method for {@link PasswordFileDecryptor#decrypt(File)}, without an explicit decrypted
+	 * file the base name of the encrypted file with the extension '.decrypted' is used
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_withoutAnExplicitDecryptedFile_derivesTheFileNameFromTheEncryptedFile(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File source = new File(temporaryDirectory, "secret-message.txt");
+		StoreFileExtensions.toFile(source, "the quick brown fox jumps over the lazy dog");
+		File encryptedFile = new PasswordFileEncryptor(password,
+			new File(temporaryDirectory, "secret-message.enc")).encrypt(source);
+
+		File decryptedFile = new PasswordFileDecryptor(password, null).decrypt(encryptedFile);
+
+		assertEquals("secret-message.decrypted", decryptedFile.getName());
+		assertEquals("the quick brown fox jumps over the lazy dog",
+			ReadFileExtensions.fromFile(decryptedFile));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileDecryptor#decrypt(File)}, an encrypted file that is
+	 * shorter than the salt prefix has to be rejected
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_withAFileShorterThanTheSaltPrefix_throwsAnIllegalArgumentException(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File tooShort = new File(temporaryDirectory, "too-short.enc");
+		StoreFileExtensions.toFile(tooShort, "abc");
+		PasswordFileDecryptor fileDecryptor = new PasswordFileDecryptor(password,
+			new File(temporaryDirectory, "decrypted.txt"));
+
+		assertThrows(IllegalArgumentException.class, () -> fileDecryptor.decrypt(tooShort));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileDecryptor#resetPassword()}, after the password is reset
+	 * nothing can be decrypted anymore
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void resetPassword_clearsThePasswordSoNothingCanBeDecryptedAnymore(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File source = new File(temporaryDirectory, "secret-message.txt");
+		StoreFileExtensions.toFile(source, "the quick brown fox");
+		File encryptedFile = new PasswordFileEncryptor(password,
+			new File(temporaryDirectory, "secret-message.enc")).encrypt(source);
+		PasswordFileDecryptor fileDecryptor = new PasswordFileDecryptor(password,
+			new File(temporaryDirectory, "decrypted.txt"));
+
+		fileDecryptor.resetPassword();
+
+		assertThrows(NullPointerException.class, () -> fileDecryptor.decrypt(encryptedFile));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileDecryptor#decrypt(File)}, the encrypted file is mandatory
+	 */
+	@Test
+	public void decrypt_withoutAFile_throwsANullPointerException()
+	{
+		PasswordFileDecryptor fileDecryptor = new PasswordFileDecryptor(password, null);
+
+		assertThrows(NullPointerException.class, () -> fileDecryptor.decrypt(null));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileDecryptor#newOperationMode()}
+	 */
+	@Test
+	public void newOperationMode_isTheDecryptMode()
+	{
+		assertEquals(Cipher.DECRYPT_MODE,
+			new PasswordFileDecryptor(password, null).newOperationMode());
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileEncryptorTest.java
@@ -26,19 +26,24 @@ package io.github.astrapi69.mystic.crypt.pw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Arrays;
 
+import javax.crypto.Cipher;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.google.common.io.Files;
 
 import io.github.astrapi69.checksum.FileChecksumExtensions;
 import io.github.astrapi69.crypt.api.algorithm.MdAlgorithm;
 import io.github.astrapi69.file.delete.DeleteFileExtensions;
+import io.github.astrapi69.file.read.ReadFileExtensions;
 import io.github.astrapi69.file.search.PathFinder;
 import io.github.astrapi69.file.write.StoreFileExtensions;
 import io.github.astrapi69.random.object.RandomStringFactory;
@@ -128,5 +133,76 @@ public class PasswordFileEncryptorTest
 		// // clean up...
 		DeleteFileExtensions.delete(encrypted);
 		DeleteFileExtensions.delete(encryptedCnstr);
+	}
+
+	/**
+	 * Test method for {@link PasswordFileEncryptor#encrypt(File)}, without an explicit encrypted
+	 * file the base name of the source file with the extension '.enc' is used
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void encrypt_withoutAnExplicitEncryptedFile_derivesTheFileNameFromTheSourceFile(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File source = new File(temporaryDirectory, "secret-message.txt");
+		StoreFileExtensions.toFile(source, "the quick brown fox jumps over the lazy dog");
+
+		File encryptedFile = new PasswordFileEncryptor(password).encrypt(source);
+
+		assertEquals("secret-message.enc", encryptedFile.getName());
+		assertEquals(temporaryDirectory.getAbsolutePath(),
+			encryptedFile.getParentFile().getAbsolutePath());
+
+		File decryptedFile = new PasswordFileDecryptor(password,
+			new File(temporaryDirectory, "decrypted.txt")).decrypt(encryptedFile);
+		assertEquals("the quick brown fox jumps over the lazy dog",
+			ReadFileExtensions.fromFile(decryptedFile));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileEncryptor#resetPassword()}, after the password is reset
+	 * nothing can be encrypted anymore
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void resetPassword_clearsThePasswordSoNothingCanBeEncryptedAnymore(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File source = new File(temporaryDirectory, "secret-message.txt");
+		StoreFileExtensions.toFile(source, "the quick brown fox");
+		PasswordFileEncryptor encryptor = new PasswordFileEncryptor(password,
+			new File(temporaryDirectory, "encrypted.enc"));
+
+		encryptor.resetPassword();
+
+		assertThrows(NullPointerException.class, () -> encryptor.encrypt(source));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileEncryptor#encrypt(File)}, the file to encrypt is mandatory
+	 */
+	@Test
+	public void encrypt_withoutAFile_throwsANullPointerException()
+	{
+		PasswordFileEncryptor encryptor = new PasswordFileEncryptor(password);
+
+		assertThrows(NullPointerException.class, () -> encryptor.encrypt(null));
+	}
+
+	/**
+	 * Test method for {@link PasswordFileEncryptor#newOperationMode()}
+	 */
+	@Test
+	public void newOperationMode_isTheEncryptMode()
+	{
+		assertEquals(Cipher.ENCRYPT_MODE, new PasswordFileEncryptor(password).newOperationMode());
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/Pbkdf2SupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/Pbkdf2SupportTest.java
@@ -26,9 +26,14 @@ package io.github.astrapi69.mystic.crypt.pw;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * The unit test class for the class {@link Pbkdf2Support}
@@ -83,9 +88,14 @@ public class Pbkdf2SupportTest
 	public void testVerifyFailsForTamperedHash()
 	{
 		final String encoded = Pbkdf2Support.hash(PASSWORD.toCharArray());
-		final String tampered = encoded.substring(0, encoded.length() - 1)
-			+ (encoded.charAt(encoded.length() - 1) == 'A' ? 'B' : 'A');
+		// flip the first character of the hash part: the trailing character of an unpadded base64
+		// string carries bits the decoder ignores, so it is not guaranteed to change the hash
+		final int hashStart = encoded.lastIndexOf('$') + 1;
+		final char original = encoded.charAt(hashStart);
+		final String tampered = encoded.substring(0, hashStart) + (original == 'A' ? 'B' : 'A')
+			+ encoded.substring(hashStart + 1);
 
+		assertNotEquals(encoded, tampered);
 		assertFalse(Pbkdf2Support.verify(PASSWORD.toCharArray(), tampered));
 	}
 
@@ -133,4 +143,59 @@ public class Pbkdf2SupportTest
 		}
 	}
 
+	/**
+	 * A scenario with an encoded hash that can not be verified
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param encoded
+	 *            the malformed encoded hash
+	 */
+	record MalformedHashCase(String description, String encoded) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<MalformedHashCase> malformedHashCases()
+	{
+		return Stream.of(new MalformedHashCase("too few parts", "$pbkdf2-sha256$i=1000$c2FsdA"),
+			new MalformedHashCase("wrong algorithm identifier",
+				"$argon2id$i=1000$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("iteration parameter without the i= prefix",
+				"$pbkdf2-sha256$x=1000$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("iteration count is not a number",
+				"$pbkdf2-sha256$i=not-a-number$c2FsdHNhbHRzYWx0c2E$aGFzaA"));
+	}
+
+	/**
+	 * Test method for {@link Pbkdf2Support#verify(char[], String)}, a malformed encoded hash never
+	 * verifies but also never propagates an exception
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("malformedHashCases")
+	public void testVerifyFailsForEveryMalformedEncoding(final MalformedHashCase testCase)
+	{
+		assertFalse(Pbkdf2Support.verify(PASSWORD.toCharArray(), testCase.encoded()));
+	}
+
+	/**
+	 * Test method for {@link Pbkdf2Support#hash(char[])} and
+	 * {@link Pbkdf2Support#verify(char[], String)}, both arguments are mandatory
+	 */
+	@Test
+	public void testHashAndVerifyRejectNullArguments()
+	{
+		final String encoded = Pbkdf2Support.hash(PASSWORD.toCharArray());
+
+		assertThrows(NullPointerException.class, () -> Pbkdf2Support.hash(null));
+		assertThrows(NullPointerException.class, () -> Pbkdf2Support.verify(null, encoded));
+		assertThrows(NullPointerException.class,
+			() -> Pbkdf2Support.verify(PASSWORD.toCharArray(), null));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/secret/FeldmanVSSEdgeCasesTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/secret/FeldmanVSSEdgeCasesTest.java
@@ -1,0 +1,247 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.secret;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.astrapi69.mystic.crypt.secret.FeldmanVSS.Share;
+import io.github.astrapi69.mystic.crypt.secret.FeldmanVSS.ShareGenerationResult;
+
+/**
+ * The unit test class for the edge cases of the class {@link FeldmanVSS}
+ */
+public class FeldmanVSSEdgeCasesTest
+{
+
+	/**
+	 * A scenario for an invalid threshold/share count combination
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param threshold
+	 *            the threshold
+	 * @param nShares
+	 *            the number of shares
+	 */
+	record InvalidThresholdCase(String description, int threshold, int nShares) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	/**
+	 * A scenario for the byte length normalization of
+	 * {@link FeldmanVSS#reconstructSecretBytes(List, FeldmanVSS.Commitments, BigInteger, int)}
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param secret
+	 *            the secret to split
+	 * @param expectedLength
+	 *            the requested length of the reconstructed secret
+	 * @param expected
+	 *            the expected reconstructed bytes
+	 */
+	record ReconstructBytesCase(String description, byte[] secret, int expectedLength,
+		byte[] expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<InvalidThresholdCase> invalidThresholdCases()
+	{
+		return Stream.of(new InvalidThresholdCase("threshold of zero", 0, 5),
+			new InvalidThresholdCase("negative threshold", -1, 5),
+			new InvalidThresholdCase("threshold greater than the share count", 6, 5));
+	}
+
+	static Stream<ReconstructBytesCase> reconstructBytesCases()
+	{
+		return Stream.of(
+			new ReconstructBytesCase("exact length", new byte[] { 1, 2, 3, 4 }, 4,
+				new byte[] { 1, 2, 3, 4 }),
+			new ReconstructBytesCase("shorter secret is left padded with zeros",
+				new byte[] { 1, 2, 3, 4 }, 8, new byte[] { 0, 0, 0, 0, 1, 2, 3, 4 }),
+			new ReconstructBytesCase("longer secret keeps the least significant bytes",
+				new byte[] { 1, 2, 3, 4 }, 2, new byte[] { 3, 4 }),
+			new ReconstructBytesCase(
+				"secret with a high bit set does not keep the sign byte of the BigInteger",
+				new byte[] { (byte)0xff, 0x10 }, 2, new byte[] { (byte)0xff, 0x10 }),
+			new ReconstructBytesCase("leading zero bytes of the secret are not recoverable",
+				new byte[] { 0, 0, 7 }, 1, new byte[] { 7 }));
+	}
+
+	/**
+	 * Test method for {@link FeldmanVSS#splitSecret(byte[], int, int)}, an invalid threshold has to
+	 * be rejected
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("invalidThresholdCases")
+	public void splitSecret_rejectsAnInvalidThreshold(final InvalidThresholdCase testCase)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> FeldmanVSS.splitSecret("secret".getBytes(), testCase.threshold(),
+				testCase.nShares()));
+
+		assertTrue(exception.getMessage().contains("Threshold"));
+	}
+
+	/**
+	 * Test method for {@link FeldmanVSS#splitSecret(byte[], int, int)}, a threshold of one means
+	 * that every single share reveals the secret
+	 */
+	@Test
+	public void splitSecret_withAThresholdOfOne_everySingleShareReconstructsTheSecret()
+	{
+		byte[] secret = "single".getBytes();
+
+		ShareGenerationResult result = FeldmanVSS.splitSecret(secret, 1, 3);
+
+		for (Share share : result.getShares())
+		{
+			assertArrayEquals(secret, FeldmanVSS.reconstructSecretBytes(List.of(share),
+				result.getCommitments(), result.getCommitments().getQ(), secret.length));
+		}
+	}
+
+	/**
+	 * Test method for {@link FeldmanVSS#splitSecret(byte[], int, int)}, a threshold equal to the
+	 * share count is the maximum valid threshold and must be accepted (all shares are then required
+	 * to reconstruct). This pins the upper boundary of the {@code threshold > nShares} check so a
+	 * {@code >=} mutant is caught.
+	 */
+	@Test
+	public void splitSecret_withAThresholdEqualToTheShareCount_isAcceptedAndReconstructs()
+	{
+		byte[] secret = "maximum".getBytes();
+
+		ShareGenerationResult result = FeldmanVSS.splitSecret(secret, 3, 3);
+		List<Share> shares = result.getShares();
+		assertEquals(3, shares.size());
+
+		assertArrayEquals(secret, FeldmanVSS.reconstructSecretBytes(shares, result.getCommitments(),
+			result.getCommitments().getQ(), secret.length));
+	}
+
+	/**
+	 * Test method for
+	 * {@link FeldmanVSS#reconstructSecretBytes(List, FeldmanVSS.Commitments, BigInteger, int)}, the
+	 * reconstructed bytes have to be normalized to the requested length
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("reconstructBytesCases")
+	public void reconstructSecretBytes_normalizesTheResultToTheExpectedLength(
+		final ReconstructBytesCase testCase)
+	{
+		ShareGenerationResult result = FeldmanVSS.splitSecret(testCase.secret(), 2, 3);
+
+		byte[] reconstructed = FeldmanVSS.reconstructSecretBytes(result.getShares().subList(1, 3),
+			result.getCommitments(), result.getCommitments().getQ(), testCase.expectedLength());
+
+		assertArrayEquals(testCase.expected(), reconstructed);
+	}
+
+	/**
+	 * Test method for {@link FeldmanVSS#toBigInteger(byte[], int)}, a bit length that is not a
+	 * multiple of eight has to be rejected and a valid one has to keep the least significant bytes
+	 */
+	@Test
+	public void toBigInteger_rejectsABitLengthThatIsNotAMultipleOfEight()
+	{
+		byte[] data = { 1, 2, 3, 4 };
+
+		assertThrows(IllegalArgumentException.class, () -> FeldmanVSS.toBigInteger(data, 12));
+		assertThrows(NullPointerException.class, () -> FeldmanVSS.toBigInteger(null, 16));
+		assertEquals(new BigInteger(1, data), FeldmanVSS.toBigInteger(data, 32));
+		assertEquals(new BigInteger(1, data), FeldmanVSS.toBigInteger(data, 64));
+		assertEquals(new BigInteger(1, new byte[] { 3, 4 }), FeldmanVSS.toBigInteger(data, 16));
+	}
+
+	/**
+	 * Test method for {@link Share#equals(Object)} and {@link Share#hashCode()}
+	 */
+	@Test
+	public void share_equalsAndHashCode_dependOnIndexAndValue()
+	{
+		Share share = new Share(1, BigInteger.TEN);
+		Share same = new Share(1, BigInteger.TEN);
+		Share otherIndex = new Share(2, BigInteger.TEN);
+		Share otherValue = new Share(1, BigInteger.ONE);
+
+		assertEquals(share, share);
+		assertEquals(share, same);
+		assertEquals(share.hashCode(), same.hashCode());
+		assertNotEquals(share, otherIndex);
+		assertNotEquals(share, otherValue);
+		assertNotEquals(share.hashCode(), otherIndex.hashCode());
+		assertFalse(share.equals(null));
+		assertFalse(share.equals("not a share"));
+		assertThrows(NullPointerException.class, () -> new Share(1, null));
+	}
+
+	/**
+	 * Test method for {@link FeldmanVSS#verifyShares(List, FeldmanVSS.Commitments)}, only the
+	 * indexes of the tampered shares have to be reported
+	 */
+	@Test
+	public void verifyShares_reportsOnlyTheTamperedShares()
+	{
+		ShareGenerationResult result = FeldmanVSS.splitSecret("tamper".getBytes(), 2, 4);
+		List<Share> shares = result.getShares();
+		Share tampered = new Share(shares.get(2).getIndex(),
+			shares.get(2).getValue().add(BigInteger.ONE));
+		List<Share> withTampered = Arrays.asList(shares.get(0), shares.get(1), tampered,
+			shares.get(3));
+
+		assertEquals(List.of(), FeldmanVSS.verifyShares(shares, result.getCommitments()));
+		assertEquals(List.of(tampered.getIndex()),
+			FeldmanVSS.verifyShares(withTampered, result.getCommitments()));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/HasherArgumentValidationTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/HasherArgumentValidationTest.java
@@ -1,0 +1,213 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.sha;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The unit test class for the argument validation of the hasher classes {@link BcryptHasher},
+ * {@link ScryptHasher}, {@link Blake2bHasher} and {@link Blake2sHasher}
+ */
+class HasherArgumentValidationTest
+{
+
+	private static final char[] PASSWORD = "correct horse battery staple".toCharArray();
+
+	private static final byte[] DATA = "the quick brown fox".getBytes(StandardCharsets.UTF_8);
+
+	private static final byte[] SALT_16 = new byte[16];
+
+	/**
+	 * A scenario with a call that has to be rejected
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param executable
+	 *            the call that has to be rejected
+	 * @param expectedMessage
+	 *            the expected message of the thrown exception
+	 */
+	record RejectedCallCase(String description, Executable executable, String expectedMessage) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<RejectedCallCase> rejectedBcryptCalls()
+	{
+		return Stream.of(
+			new RejectedCallCase("hash with salt without a password",
+				() -> BcryptHasher.hashWithSalt(null, SALT_16, BcryptHasher.DEFAULT_LOG_ROUNDS),
+				"Password cannot be null"),
+			new RejectedCallCase("hash with salt without a salt",
+				() -> BcryptHasher.hashWithSalt(PASSWORD.clone(), null,
+					BcryptHasher.DEFAULT_LOG_ROUNDS),
+				"Salt cannot be null"),
+			new RejectedCallCase("hash with salt and too few log rounds",
+				() -> BcryptHasher.hashWithSalt(PASSWORD.clone(), SALT_16,
+					BcryptHasher.MIN_LOG_ROUNDS - 1),
+				"Log rounds must be between " + BcryptHasher.MIN_LOG_ROUNDS + " and "
+					+ BcryptHasher.MAX_LOG_ROUNDS),
+			new RejectedCallCase("hash with salt and too many log rounds",
+				() -> BcryptHasher.hashWithSalt(PASSWORD.clone(), SALT_16,
+					BcryptHasher.MAX_LOG_ROUNDS + 1),
+				"Log rounds must be between " + BcryptHasher.MIN_LOG_ROUNDS + " and "
+					+ BcryptHasher.MAX_LOG_ROUNDS),
+			new RejectedCallCase("log rounds of a null hash", () -> BcryptHasher.getLogRounds(null),
+				"Hash cannot be null"),
+			new RejectedCallCase("log rounds of a hash without the bcrypt structure",
+				() -> BcryptHasher.getLogRounds("not-a-bcrypt-hash"), "Invalid BCrypt hash format"),
+			new RejectedCallCase("log rounds of a hash of another algorithm",
+				() -> BcryptHasher.getLogRounds("$1$10$abcdefghijklmnopqrstuv"),
+				"Invalid BCrypt hash format"),
+			new RejectedCallCase("log rounds that are not a number",
+				() -> BcryptHasher.getLogRounds("$2a$xy$abcdefghijklmnopqrstuv"),
+				"Invalid BCrypt hash format"));
+	}
+
+	static Stream<RejectedCallCase> rejectedScryptCalls()
+	{
+		return Stream.of(
+			new RejectedCallCase("hash with salt without a password",
+				() -> ScryptHasher.hashWithSalt(null, SALT_16, ScryptHasher.MIN_N, 1, 1, 32),
+				"Password cannot be null"),
+			new RejectedCallCase("hash with salt without a salt",
+				() -> ScryptHasher.hashWithSalt(PASSWORD.clone(), null, ScryptHasher.MIN_N, 1, 1,
+					32),
+				"Salt cannot be null"),
+			new RejectedCallCase("hash with a block size below the minimum",
+				() -> ScryptHasher.hashWithSalt(PASSWORD.clone(), SALT_16, ScryptHasher.MIN_N,
+					ScryptHasher.MIN_R - 1, 1, 32),
+				"R must be at least " + ScryptHasher.MIN_R),
+			new RejectedCallCase("hash with a parallelism below the minimum",
+				() -> ScryptHasher.hashWithSalt(PASSWORD.clone(), SALT_16, ScryptHasher.MIN_N, 1,
+					ScryptHasher.MIN_P - 1, 32),
+				"P must be at least " + ScryptHasher.MIN_P),
+			new RejectedCallCase("verify without an expected hash",
+				() -> ScryptHasher.verify(PASSWORD.clone(), SALT_16, null, ScryptHasher.MIN_N, 1,
+					1),
+				"Expected hash cannot be null"),
+			new RejectedCallCase("verify without the salt and hash block",
+				() -> ScryptHasher.verify(PASSWORD.clone(), null, ScryptHasher.MIN_N, 1, 1),
+				"saltAndHash cannot be null"),
+			new RejectedCallCase("verify with a salt and hash block without a hash",
+				() -> ScryptHasher.verify(PASSWORD.clone(), new byte[ScryptHasher.SALT_LENGTH],
+					ScryptHasher.MIN_N, 1, 1),
+				"saltAndHash is too short"));
+	}
+
+	static Stream<RejectedCallCase> rejectedBlake2Calls()
+	{
+		return Stream.of(
+			new RejectedCallCase("blake2b string hash without data",
+				() -> Blake2bHasher.hash((String)null, StandardCharsets.UTF_8,
+					Blake2bHasher.DEFAULT_DIGEST_LENGTH),
+				"Data cannot be null"),
+			new RejectedCallCase("blake2b keyed hash without data",
+				() -> Blake2bHasher.hashWithKey(null, SALT_16, Blake2bHasher.DEFAULT_DIGEST_LENGTH),
+				"Data cannot be null"),
+			new RejectedCallCase("blake2b keyed hash with a digest length below the minimum",
+				() -> Blake2bHasher.hashWithKey(DATA, SALT_16, Blake2bHasher.MIN_DIGEST_LENGTH - 1),
+				"Digest length must be between " + Blake2bHasher.MIN_DIGEST_LENGTH + " and "
+					+ Blake2bHasher.MAX_DIGEST_LENGTH),
+			new RejectedCallCase("blake2b keyed hash with a digest length above the maximum",
+				() -> Blake2bHasher.hashWithKey(DATA, SALT_16, Blake2bHasher.MAX_DIGEST_LENGTH + 1),
+				"Digest length must be between " + Blake2bHasher.MIN_DIGEST_LENGTH + " and "
+					+ Blake2bHasher.MAX_DIGEST_LENGTH),
+			new RejectedCallCase("blake2s string hash without data",
+				() -> Blake2sHasher.hash((String)null, StandardCharsets.UTF_8,
+					Blake2sHasher.DEFAULT_DIGEST_LENGTH),
+				"Data cannot be null"),
+			new RejectedCallCase("blake2s keyed hash without data",
+				() -> Blake2sHasher.hashWithKey(null, SALT_16, Blake2sHasher.DEFAULT_DIGEST_LENGTH),
+				"Data cannot be null"),
+			new RejectedCallCase("blake2s keyed hash with a digest length below the minimum",
+				() -> Blake2sHasher.hashWithKey(DATA, SALT_16, Blake2sHasher.MIN_DIGEST_LENGTH - 1),
+				"Digest length must be between " + Blake2sHasher.MIN_DIGEST_LENGTH + " and "
+					+ Blake2sHasher.MAX_DIGEST_LENGTH),
+			new RejectedCallCase("blake2s keyed hash with a digest length above the maximum",
+				() -> Blake2sHasher.hashWithKey(DATA, SALT_16, Blake2sHasher.MAX_DIGEST_LENGTH + 1),
+				"Digest length must be between " + Blake2sHasher.MIN_DIGEST_LENGTH + " and "
+					+ Blake2sHasher.MAX_DIGEST_LENGTH));
+	}
+
+	/**
+	 * Test method for the argument validation of {@link BcryptHasher}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("rejectedBcryptCalls")
+	void everyInvalidBcryptCallIsRejected(final RejectedCallCase testCase)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			testCase.executable());
+
+		assertEquals(testCase.expectedMessage(), exception.getMessage());
+	}
+
+	/**
+	 * Test method for the argument validation of {@link ScryptHasher}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("rejectedScryptCalls")
+	void everyInvalidScryptCallIsRejected(final RejectedCallCase testCase)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			testCase.executable());
+
+		assertEquals(testCase.expectedMessage(), exception.getMessage());
+	}
+
+	/**
+	 * Test method for the argument validation of {@link Blake2bHasher} and {@link Blake2sHasher}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("rejectedBlake2Calls")
+	void everyInvalidBlake2CallIsRejected(final RejectedCallCase testCase)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			testCase.executable());
+
+		assertEquals(testCase.expectedMessage(), exception.getMessage());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/HasherBoundaryAndWipeTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/HasherBoundaryAndWipeTest.java
@@ -1,0 +1,249 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.sha;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mutation-focused tests for the hasher classes: boundary conditions that must be
+ * <em>accepted</em>, secure-wipe of caller supplied password arrays, random-salt behaviour and the
+ * delegating hash overloads. These complement {@link HasherArgumentValidationTest} which only
+ * covers the reject paths.
+ */
+class HasherBoundaryAndWipeTest
+{
+
+	private static final byte[] DATA = "the quick brown fox".getBytes(StandardCharsets.UTF_8);
+
+	private static char[] pw()
+	{
+		return "correct horse battery staple".toCharArray();
+	}
+
+	private static boolean allZero(char[] array)
+	{
+		for (char c : array)
+		{
+			if (c != '\0')
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// ----- BCrypt -----------------------------------------------------------
+
+	@Test
+	void bcryptAcceptsMinimumLogRounds()
+	{
+		// kills the "< MIN_LOG_ROUNDS" boundary mutant: MIN itself must be accepted
+		String hash = BcryptHasher.hash(pw(), BcryptHasher.MIN_LOG_ROUNDS);
+		assertNotNull(hash);
+		assertEquals(BcryptHasher.MIN_LOG_ROUNDS, BcryptHasher.getLogRounds(hash));
+
+		byte[] salt = new byte[16];
+		String saltedHash = BcryptHasher.hashWithSalt(pw(), salt, BcryptHasher.MIN_LOG_ROUNDS);
+		assertNotNull(saltedHash);
+		assertEquals(BcryptHasher.MIN_LOG_ROUNDS, BcryptHasher.getLogRounds(saltedHash));
+	}
+
+	@Test
+	void bcryptHashUsesAFreshRandomSaltEveryTime()
+	{
+		// kills the removed SecureRandom.nextBytes(salt) call: without it the salt is all
+		// zero and two hashes of the same password would be identical
+		String first = BcryptHasher.hash(pw(), BcryptHasher.MIN_LOG_ROUNDS);
+		String second = BcryptHasher.hash(pw(), BcryptHasher.MIN_LOG_ROUNDS);
+		assertNotEquals(first, second);
+	}
+
+	@Test
+	void bcryptHashWithSaltWipesThePassword()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in hashWithSalt
+		char[] password = pw();
+		BcryptHasher.hashWithSalt(password, new byte[16], BcryptHasher.MIN_LOG_ROUNDS);
+		assertTrue(allZero(password), "password array must be wiped after hashWithSalt");
+	}
+
+	@Test
+	void bcryptVerifyWipesThePasswordAndReturnsCorrectResult()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in verify
+		String hash = BcryptHasher.hash(pw(), BcryptHasher.MIN_LOG_ROUNDS);
+		char[] password = pw();
+		assertTrue(BcryptHasher.verify(password, hash));
+		assertTrue(allZero(password), "password array must be wiped after verify");
+
+		char[] wrong = "wrong password".toCharArray();
+		assertFalse(BcryptHasher.verify(wrong, hash));
+	}
+
+	// ----- SCrypt -----------------------------------------------------------
+
+	@Test
+	void scryptHashRejectsNonPowerOfTwoNParameter()
+	{
+		// kills the removed validateParameters call in hash and the "return true" mutant of
+		// isPowerOfTwo: N = 3 is >= MIN_N but not a power of two and must be rejected with our
+		// specific message
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+			() -> ScryptHasher.hash(pw(), 3, ScryptHasher.MIN_R, ScryptHasher.MIN_P));
+		assertEquals("N must be a power of 2 and at least " + ScryptHasher.MIN_N, ex.getMessage());
+	}
+
+	@Test
+	void scryptVerifyRejectsNonPowerOfTwoNParameter()
+	{
+		// kills the removed validateParameters call in verify
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+			() -> ScryptHasher.verify(pw(), new byte[ScryptHasher.SALT_LENGTH], new byte[32], 3,
+				ScryptHasher.MIN_R, ScryptHasher.MIN_P));
+		assertEquals("N must be a power of 2 and at least " + ScryptHasher.MIN_N, ex.getMessage());
+	}
+
+	@Test
+	void scryptHashUsesAFreshRandomSaltEveryTime()
+	{
+		// kills the removed SecureRandom.nextBytes(salt) call in generateSalt: without it the salt
+		// is all zero and two hashes of the same password would be identical
+		byte[] first = ScryptHasher.hash(pw());
+		byte[] second = ScryptHasher.hash(pw());
+		assertFalse(java.util.Arrays.equals(first, second));
+	}
+
+	@Test
+	void scryptHashWithSaltWipesThePassword()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in hashWithSalt
+		char[] password = pw();
+		ScryptHasher.hashWithSalt(password, new byte[ScryptHasher.SALT_LENGTH], ScryptHasher.MIN_N,
+			ScryptHasher.MIN_R, ScryptHasher.MIN_P, 32);
+		assertTrue(allZero(password), "password array must be wiped after hashWithSalt");
+	}
+
+	@Test
+	void scryptVerifyWipesThePasswordAndReturnsCorrectResult()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in verify
+		byte[] salt = new byte[ScryptHasher.SALT_LENGTH];
+		byte[] expected = ScryptHasher.hashWithSalt(pw(), salt, ScryptHasher.MIN_N,
+			ScryptHasher.MIN_R, ScryptHasher.MIN_P, 32);
+		char[] password = pw();
+		assertTrue(ScryptHasher.verify(password, salt, expected, ScryptHasher.MIN_N,
+			ScryptHasher.MIN_R, ScryptHasher.MIN_P));
+		assertTrue(allZero(password), "password array must be wiped after verify");
+
+		char[] wrong = "wrong".toCharArray();
+		assertFalse(ScryptHasher.verify(wrong, salt, expected, ScryptHasher.MIN_N,
+			ScryptHasher.MIN_R, ScryptHasher.MIN_P));
+	}
+
+	// ----- BLAKE2b ----------------------------------------------------------
+
+	@Test
+	void blake2bAcceptsDigestLengthBoundaries()
+	{
+		// kills both "changed conditional boundary" mutants on the digest length guard: MIN and
+		// MAX must be accepted and produce an output of exactly that length
+		assertEquals(Blake2bHasher.MIN_DIGEST_LENGTH,
+			Blake2bHasher.hash(DATA, Blake2bHasher.MIN_DIGEST_LENGTH).length);
+		assertEquals(Blake2bHasher.MAX_DIGEST_LENGTH,
+			Blake2bHasher.hash(DATA, Blake2bHasher.MAX_DIGEST_LENGTH).length);
+	}
+
+	@Test
+	void blake2bStringHashUsesTheDefaultDigestLength()
+	{
+		// kills the "replaced return value with null" mutant of hash(String, Charset) and asserts
+		// it delegates to the default digest length
+		byte[] hash = Blake2bHasher.hash("payload", StandardCharsets.UTF_8);
+		assertNotNull(hash);
+		assertEquals(Blake2bHasher.DEFAULT_DIGEST_LENGTH, hash.length);
+		assertArrayEquals(Blake2bHasher.hash("payload", StandardCharsets.UTF_8,
+			Blake2bHasher.DEFAULT_DIGEST_LENGTH), hash);
+	}
+
+	@Test
+	void blake2bKeyedHashAcceptsBoundaryKeyLengthAndDigestLength()
+	{
+		// kills the "key.length > 64" boundary mutant: a key of exactly the max length is valid
+		byte[] maxKey = new byte[64];
+		assertNotNull(Blake2bHasher.hashWithKey(DATA, maxKey, Blake2bHasher.DEFAULT_DIGEST_LENGTH));
+		// a key one byte too long must still be rejected
+		assertThrows(IllegalArgumentException.class, () -> Blake2bHasher.hashWithKey(DATA,
+			new byte[65], Blake2bHasher.DEFAULT_DIGEST_LENGTH));
+		// kills both digest length boundary mutants on the keyed overload
+		assertEquals(Blake2bHasher.MIN_DIGEST_LENGTH,
+			Blake2bHasher.hashWithKey(DATA, maxKey, Blake2bHasher.MIN_DIGEST_LENGTH).length);
+		assertEquals(Blake2bHasher.MAX_DIGEST_LENGTH,
+			Blake2bHasher.hashWithKey(DATA, maxKey, Blake2bHasher.MAX_DIGEST_LENGTH).length);
+	}
+
+	// ----- BLAKE2s ----------------------------------------------------------
+
+	@Test
+	void blake2sAcceptsDigestLengthBoundaries()
+	{
+		assertEquals(Blake2sHasher.MIN_DIGEST_LENGTH,
+			Blake2sHasher.hash(DATA, Blake2sHasher.MIN_DIGEST_LENGTH).length);
+		assertEquals(Blake2sHasher.MAX_DIGEST_LENGTH,
+			Blake2sHasher.hash(DATA, Blake2sHasher.MAX_DIGEST_LENGTH).length);
+	}
+
+	@Test
+	void blake2sStringHashUsesTheDefaultDigestLength()
+	{
+		byte[] hash = Blake2sHasher.hash("payload", StandardCharsets.UTF_8);
+		assertNotNull(hash);
+		assertEquals(Blake2sHasher.DEFAULT_DIGEST_LENGTH, hash.length);
+		assertArrayEquals(Blake2sHasher.hash("payload", StandardCharsets.UTF_8,
+			Blake2sHasher.DEFAULT_DIGEST_LENGTH), hash);
+	}
+
+	@Test
+	void blake2sKeyedHashAcceptsBoundaryKeyLengthAndDigestLength()
+	{
+		byte[] maxKey = new byte[32];
+		assertNotNull(Blake2sHasher.hashWithKey(DATA, maxKey, Blake2sHasher.DEFAULT_DIGEST_LENGTH));
+		assertThrows(IllegalArgumentException.class, () -> Blake2sHasher.hashWithKey(DATA,
+			new byte[33], Blake2sHasher.DEFAULT_DIGEST_LENGTH));
+		assertEquals(Blake2sHasher.MIN_DIGEST_LENGTH,
+			Blake2sHasher.hashWithKey(DATA, maxKey, Blake2sHasher.MIN_DIGEST_LENGTH).length);
+		assertEquals(Blake2sHasher.MAX_DIGEST_LENGTH,
+			Blake2sHasher.hashWithKey(DATA, maxKey, Blake2sHasher.MAX_DIGEST_LENGTH).length);
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleCryptTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleCryptTest.java
@@ -59,6 +59,42 @@ public class SimpleCryptTest
 	}
 
 	/**
+	 * Test method for {@link SimpleCrypt#oneTimePadCrypt(byte[], byte[])} where the message is
+	 * longer than the key. In that case the key index wraps around via
+	 * {@code message.length % (simpleKey.length - 1)}; asserting the exact encoded bytes pins that
+	 * arithmetic so a mutant that turns the subtraction into an addition is caught (a plain
+	 * round-trip cannot catch it because the XOR is symmetric).
+	 */
+	@Test
+	public void testOneTimePadWithMessageLongerThanKey()
+	{
+		byte[] key = { 10, 20, 30, 40 };
+		byte[] message = { 1, 2, 3, 4, 5, 6 };
+
+		byte[] encoded = SimpleCrypt.oneTimePadCrypt(key, message);
+
+		// independently compute the expected output with the documented key-index formula
+		byte[] expected = new byte[message.length];
+		for (int index = 0; index < message.length; index++)
+		{
+			int keyIndex = index;
+			if (index >= key.length)
+			{
+				keyIndex = message.length % (key.length - 1);
+			}
+			expected[index] = (byte)(message[index] ^ key[keyIndex]);
+		}
+		assertEquals(Arrays.toString(expected), Arrays.toString(encoded));
+		// index 4 and 5 use keyIndex = 6 % 3 = 0 (key[0] == 10); an addition mutant would use
+		// 6 % 5 = 1 (key[1] == 20), producing a different byte
+		assertEquals((byte)(message[4] ^ key[0]), encoded[4]);
+		assertEquals((byte)(message[5] ^ key[0]), encoded[5]);
+
+		// round-trip must still recover the message
+		assertTrue(Arrays.equals(message, SimpleCrypt.oneTimePadCrypt(key, encoded)));
+	}
+
+	/**
 	 * Test method for test the method {@link SimpleCrypt#encode(String)} and
 	 * {@link SimpleCrypt#decode(String)}
 	 */

--- a/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleDecryptorTest.java
@@ -24,9 +24,16 @@
  */
 package io.github.astrapi69.mystic.crypt.simple;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.crypto.Cipher;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.meanbean.test.BeanTester;
+
+import io.github.astrapi69.crypt.api.algorithm.compound.CompoundAlgorithm;
 
 /**
  * The unit test class for the class {@link SimpleDecryptor}
@@ -45,4 +52,34 @@ public class SimpleDecryptorTest
 		beanTester.testBean(SimpleDecryptor.class);
 	}
 
+	/**
+	 * Test method for {@link SimpleDecryptor#getPrivateKey()}, the private key given to the
+	 * constructor is answered
+	 */
+	@Test
+	public void getPrivateKey_answersThePrivateKeyOfTheConstructor()
+	{
+		assertEquals(CompoundAlgorithm.PASSWORD,
+			new SimpleDecryptor(CompoundAlgorithm.PASSWORD).getPrivateKey());
+	}
+
+	/**
+	 * Test method for {@link SimpleDecryptor#newOperationMode()}, a decryptor always works in the
+	 * decrypt mode
+	 */
+	@Test
+	public void newOperationMode_isTheDecryptMode()
+	{
+		assertEquals(Cipher.DECRYPT_MODE,
+			new SimpleDecryptor(CompoundAlgorithm.PASSWORD).newOperationMode());
+	}
+
+	/**
+	 * Test method for {@link SimpleDecryptor#SimpleDecryptor(String)}, the private key is mandatory
+	 */
+	@Test
+	public void constructor_withoutPrivateKey_throwsANullPointerException()
+	{
+		assertThrows(NullPointerException.class, () -> new SimpleDecryptor(null));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/simple/SimpleEncryptorTest.java
@@ -24,9 +24,16 @@
  */
 package io.github.astrapi69.mystic.crypt.simple;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.crypto.Cipher;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.meanbean.test.BeanTester;
+
+import io.github.astrapi69.crypt.api.algorithm.compound.CompoundAlgorithm;
 
 /**
  * The unit test class for the class {@link SimpleEncryptor}
@@ -43,5 +50,36 @@ public class SimpleEncryptorTest
 	{
 		final BeanTester beanTester = new BeanTester();
 		beanTester.testBean(SimpleEncryptor.class);
+	}
+
+	/**
+	 * Test method for {@link SimpleEncryptor#getPrivateKey()}, the private key given to the
+	 * constructor is answered
+	 */
+	@Test
+	public void getPrivateKey_answersThePrivateKeyOfTheConstructor()
+	{
+		assertEquals(CompoundAlgorithm.PASSWORD,
+			new SimpleEncryptor(CompoundAlgorithm.PASSWORD).getPrivateKey());
+	}
+
+	/**
+	 * Test method for {@link SimpleEncryptor#newOperationMode()}, an encryptor always works in the
+	 * encrypt mode
+	 */
+	@Test
+	public void newOperationMode_isTheEncryptMode()
+	{
+		assertEquals(Cipher.ENCRYPT_MODE,
+			new SimpleEncryptor(CompoundAlgorithm.PASSWORD).newOperationMode());
+	}
+
+	/**
+	 * Test method for {@link SimpleEncryptor#SimpleEncryptor(String)}, the private key is mandatory
+	 */
+	@Test
+	public void constructor_withoutPrivateKey_throwsANullPointerException()
+	{
+		assertThrows(NullPointerException.class, () -> new SimpleEncryptor(null));
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpDigestsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpDigestsTest.java
@@ -1,0 +1,105 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.srp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+
+import org.bouncycastle.crypto.Digest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The unit test class for the class {@link SrpDigests}
+ */
+class SrpDigestsTest
+{
+
+	/**
+	 * A scenario with a supported hash algorithm
+	 *
+	 * @param algorithm
+	 *            the name of the hash algorithm
+	 * @param expectedDigestName
+	 *            the expected name of the created digest
+	 * @param expectedDigestSize
+	 *            the expected size in bytes of the created digest
+	 */
+	record SupportedAlgorithmCase(String algorithm, String expectedDigestName,
+		int expectedDigestSize) {
+		@Override
+		public String toString()
+		{
+			return algorithm;
+		}
+	}
+
+	static Stream<SupportedAlgorithmCase> supportedAlgorithmCases()
+	{
+		return Stream.of(new SupportedAlgorithmCase("SHA-1", "SHA-1", 20),
+			new SupportedAlgorithmCase("SHA-224", "SHA-224", 28),
+			new SupportedAlgorithmCase("SHA-256", "SHA-256", 32),
+			new SupportedAlgorithmCase("SHA-384", "SHA-384", 48),
+			new SupportedAlgorithmCase("SHA-512", "SHA-512", 64),
+			new SupportedAlgorithmCase("SHA3-256", "SHA3-256", 32));
+	}
+
+	/**
+	 * Test method for {@link SrpDigests#newDigest(String)}, every supported algorithm name has to
+	 * answer the matching digest
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("supportedAlgorithmCases")
+	void newDigest_answersTheDigestOfTheGivenAlgorithm(final SupportedAlgorithmCase testCase)
+	{
+		Digest digest = SrpDigests.newDigest(testCase.algorithm());
+
+		assertEquals(testCase.expectedDigestName(), digest.getAlgorithmName());
+		assertEquals(testCase.expectedDigestSize(), digest.getDigestSize());
+	}
+
+	/**
+	 * Test method for {@link SrpDigests#newDigest(String)}, an unsupported algorithm name has to be
+	 * rejected
+	 *
+	 * @param algorithm
+	 *            the unsupported algorithm name
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "MD5", "SHA-512/256", "sha-256", "SHA3-512", "" })
+	void newDigest_rejectsAnUnsupportedAlgorithm(final String algorithm)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> SrpDigests.newDigest(algorithm));
+
+		assertEquals("Unsupported hash algorithm: " + algorithm, exception.getMessage());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpParameterValidationTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpParameterValidationTest.java
@@ -1,0 +1,290 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.srp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The unit test class for the argument validation of the classes {@link SRP6aClient} and
+ * {@link SRP6aServer}
+ */
+class SrpParameterValidationTest
+{
+
+	private static final String IDENTITY = "alice";
+
+	private static final char[] PASSWORD = "password123".toCharArray();
+
+	/**
+	 * A scenario with a call that has to be rejected
+	 *
+	 * @param description
+	 *            the human readable description of the scenario
+	 * @param executable
+	 *            the call that has to be rejected
+	 * @param expectedMessage
+	 *            the expected message of the thrown exception
+	 */
+	record RejectedCallCase(String description, Executable executable, String expectedMessage) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<RejectedCallCase> rejectedClientCalls()
+	{
+		return Stream.of(
+			new RejectedCallCase("client without the group modulus",
+				() -> new SRP6aClient(null, SRP6aVerifierGenerator.DEFAULT_G,
+					SRP6aVerifierGenerator.DEFAULT_HASH_ALGORITHM),
+				"Parameters cannot be null"),
+			new RejectedCallCase("client without the generator",
+				() -> new SRP6aClient(SRP6aVerifierGenerator.DEFAULT_N, null,
+					SRP6aVerifierGenerator.DEFAULT_HASH_ALGORITHM),
+				"Parameters cannot be null"),
+			new RejectedCallCase("client without the hash algorithm",
+				() -> new SRP6aClient(SRP6aVerifierGenerator.DEFAULT_N,
+					SRP6aVerifierGenerator.DEFAULT_G, null),
+				"Parameters cannot be null"),
+			new RejectedCallCase("session key without an identity",
+				() -> newClientWithServerCredentials().computeSessionKey(null, PASSWORD.clone()),
+				"Identity cannot be null"),
+			new RejectedCallCase("session key without a password",
+				() -> newClientWithServerCredentials().computeSessionKey(IDENTITY, null),
+				"Password cannot be null"),
+			new RejectedCallCase("session key without server credentials", () -> {
+				SRP6aClient client = new SRP6aClient();
+				client.generatePublicValue();
+				client.computeSessionKey(IDENTITY, PASSWORD.clone());
+			}, "Server credentials not set"),
+			new RejectedCallCase("proof without a session key",
+				() -> new SRP6aClient().computeProof(null), "Session key cannot be null"),
+			new RejectedCallCase("proof without an established session",
+				() -> new SRP6aClient().computeProof(BigInteger.ONE), "Credentials not set"),
+			new RejectedCallCase("proof with a public value but without server credentials", () -> {
+				SRP6aClient client = new SRP6aClient();
+				client.generatePublicValue();
+				client.computeProof(BigInteger.ONE);
+			}, "Credentials not set"),
+			new RejectedCallCase("proof with server credentials but without a session key",
+				() -> newClientWithServerCredentials().computeProof(BigInteger.ONE),
+				"Credentials not set"),
+			new RejectedCallCase("session key with server credentials set before the public value",
+				() -> {
+					SRP6aClient client = new SRP6aClient();
+					client.computeProof(BigInteger.ONE);
+				}, "Credentials not set"),
+			new RejectedCallCase("session key after a rejected server public value", () -> {
+				SRP6aClient client = new SRP6aClient();
+				client.generatePublicValue();
+				// B = N is congruent to zero and therefore an invalid server public value
+				try
+				{
+					client.setServerCredentials(new byte[16], SRP6aVerifierGenerator.DEFAULT_N);
+				}
+				catch (SecurityException expected)
+				{
+					// the salt is kept but the server public value stays unset
+				}
+				client.computeSessionKey(IDENTITY, PASSWORD.clone());
+			}, "Server credentials not set"));
+	}
+
+	static Stream<RejectedCallCase> rejectedServerCalls()
+	{
+		return Stream.of(
+			new RejectedCallCase("server without the group modulus",
+				() -> new SRP6aServer(null, SRP6aVerifierGenerator.DEFAULT_G,
+					SRP6aVerifierGenerator.DEFAULT_HASH_ALGORITHM),
+				"Parameters cannot be null"),
+			new RejectedCallCase("server without the generator",
+				() -> new SRP6aServer(SRP6aVerifierGenerator.DEFAULT_N, null,
+					SRP6aVerifierGenerator.DEFAULT_HASH_ALGORITHM),
+				"Parameters cannot be null"),
+			new RejectedCallCase("server without the hash algorithm",
+				() -> new SRP6aServer(SRP6aVerifierGenerator.DEFAULT_N,
+					SRP6aVerifierGenerator.DEFAULT_G, null),
+				"Parameters cannot be null"),
+			new RejectedCallCase("verifier is null", () -> new SRP6aServer().setVerifier(null),
+				"Verifier cannot be null"),
+			new RejectedCallCase("server proof without a client proof",
+				() -> new SRP6aServer().computeServerProof(null, BigInteger.ONE),
+				"Client proof cannot be null"),
+			new RejectedCallCase("server proof without a session key",
+				() -> new SRP6aServer().computeServerProof(BigInteger.ONE, null),
+				"Session key cannot be null"),
+			new RejectedCallCase("server proof without a client public key",
+				() -> new SRP6aServer().computeServerProof(BigInteger.ONE, BigInteger.ONE),
+				"Client public key not set"),
+			new RejectedCallCase("server proof without an established session", () -> {
+				SRP6aServer server = newServerWithVerifier();
+				server.generatePublicValue();
+				server.setClientPublicKey(newClientPublicValue());
+				server.computeServerProof(BigInteger.ONE, BigInteger.ONE);
+			}, "Session not established"));
+	}
+
+	private static BigInteger newClientPublicValue()
+	{
+		SRP6aClient client = new SRP6aClient();
+		return client.generatePublicValue();
+	}
+
+	private static SRP6aServer newServerWithVerifier()
+	{
+		SRP6aVerifierGenerator verifierGenerator = new SRP6aVerifierGenerator();
+		byte[] salt = verifierGenerator.generateSalt();
+		SRP6aServer server = new SRP6aServer();
+		server.setVerifier(verifierGenerator.generateVerifier(IDENTITY, PASSWORD.clone(), salt));
+		return server;
+	}
+
+	private static SRP6aClient newClientWithServerCredentials()
+	{
+		SRP6aVerifierGenerator verifierGenerator = new SRP6aVerifierGenerator();
+		byte[] salt = verifierGenerator.generateSalt();
+		SRP6aServer server = new SRP6aServer();
+		server.setVerifier(verifierGenerator.generateVerifier(IDENTITY, PASSWORD.clone(), salt));
+		SRP6aClient client = new SRP6aClient();
+		client.generatePublicValue();
+		client.setServerCredentials(salt, server.generatePublicValue());
+		return client;
+	}
+
+	/**
+	 * Test method for the argument validation of {@link SRP6aClient}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("rejectedClientCalls")
+	void everyInvalidClientCallIsRejected(final RejectedCallCase testCase)
+	{
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			testCase.executable());
+
+		assertEquals(testCase.expectedMessage(), exception.getMessage());
+	}
+
+	/**
+	 * Test method for the argument validation of {@link SRP6aServer}
+	 *
+	 * @param testCase
+	 *            the test case
+	 */
+	@ParameterizedTest
+	@MethodSource("rejectedServerCalls")
+	void everyInvalidServerCallIsRejected(final RejectedCallCase testCase)
+	{
+		Exception exception = assertThrows(Exception.class, testCase.executable());
+
+		assertEquals(testCase.expectedMessage(), exception.getMessage());
+	}
+
+	/**
+	 * Test method for {@link SRP6aServer#computeSessionKey()}, without a verifier no session key
+	 * can be computed
+	 */
+	@Test
+	void serverComputeSessionKeyWithoutVerifierIsRejected()
+	{
+		IllegalStateException exception = assertThrows(IllegalStateException.class,
+			() -> new SRP6aServer().computeSessionKey());
+
+		assertEquals("Verifier not set", exception.getMessage());
+	}
+
+	/**
+	 * Test method for {@link SRP6aClient#verifyServerProof(BigInteger, BigInteger)}, a proof can
+	 * never be verified before the session is established
+	 */
+	@Test
+	void clientVerifyServerProofAnswersFalseWithoutAnEstablishedSession()
+	{
+		SRP6aClient client = new SRP6aClient();
+
+		assertFalse(client.verifyServerProof(BigInteger.ONE, null));
+		assertFalse(client.verifyServerProof(null, BigInteger.ONE));
+		// the internally thrown IllegalArgumentException of computeProof must not escape
+		assertFalse(client.verifyServerProof(BigInteger.ONE, BigInteger.ONE));
+	}
+
+	/**
+	 * Test method for {@link SRP6aServer#verifyClientProof(BigInteger, BigInteger)}, a proof can
+	 * never be verified before the session is established
+	 */
+	@Test
+	void serverVerifyClientProofAnswersFalseWithoutAnEstablishedSession()
+	{
+		SRP6aServer server = newServerWithVerifier();
+
+		assertFalse(server.verifyClientProof(BigInteger.ONE, null));
+		assertFalse(server.verifyClientProof(null, BigInteger.ONE));
+		// the public value of the server is not generated yet
+		assertFalse(server.verifyClientProof(BigInteger.ONE, BigInteger.ONE));
+
+		server.generatePublicValue();
+		// the session key is not computed yet
+		assertFalse(server.verifyClientProof(BigInteger.ONE, BigInteger.ONE));
+	}
+
+	/**
+	 * Test method for {@link SRP6aServer#getPublicValue()} and
+	 * {@link SRP6aClient#getPublicValue()}, the public value is only available after it was
+	 * generated
+	 */
+	@Test
+	void getPublicValueAnswersNullUntilItIsGenerated()
+	{
+		SRP6aServer server = newServerWithVerifier();
+		SRP6aClient client = new SRP6aClient();
+
+		assertNull(server.getPublicValue());
+		assertNull(client.getPublicValue());
+
+		BigInteger serverPublicValue = server.generatePublicValue();
+		BigInteger clientPublicValue = client.generatePublicValue();
+
+		assertEquals(serverPublicValue, server.getPublicValue());
+		assertEquals(clientPublicValue, client.getPublicValue());
+		assertTrue(serverPublicValue.signum() > 0);
+		assertTrue(clientPublicValue.signum() > 0);
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpWipeAndProofTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/srp/SrpWipeAndProofTest.java
@@ -1,0 +1,122 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.srp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mutation-focused tests for {@link SRP6aClient} and {@link SRP6aVerifierGenerator}: the
+ * secure-wipe of the caller supplied password array and the exact boolean result of
+ * {@link SRP6aClient#verifyServerProof(BigInteger, BigInteger)}.
+ */
+class SrpWipeAndProofTest
+{
+
+	private static boolean allZero(char[] array)
+	{
+		for (char c : array)
+		{
+			if (c != '\0')
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Test
+	void generateVerifierWipesTheCallersPassword()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in generateVerifier
+		final SRP6aVerifierGenerator generator = new SRP6aVerifierGenerator();
+		final byte[] salt = generator.generateSalt();
+		final char[] password = "testPassword123".toCharArray();
+		generator.generateVerifier("testuser", password, salt);
+		assertTrue(allZero(password), "password array must be wiped after generateVerifier");
+	}
+
+	@Test
+	void computeSessionKeyWipesTheCallersPassword()
+	{
+		// kills the removed Arrays.fill(password, '\0') call in computeSessionKey
+		final String identity = "testuser";
+		final char[] password = "testPassword123".toCharArray();
+
+		final SRP6aVerifierGenerator generator = new SRP6aVerifierGenerator();
+		final byte[] salt = generator.generateSalt();
+		final BigInteger verifier = generator.generateVerifier(identity, password.clone(), salt);
+
+		final SRP6aServer server = new SRP6aServer();
+		server.setVerifier(verifier);
+		final SRP6aClient client = new SRP6aClient();
+		final BigInteger clientPublicKey = client.generatePublicValue();
+		final BigInteger serverPublicKey = server.generatePublicValue();
+		client.setServerCredentials(salt, serverPublicKey);
+		server.setClientPublicKey(clientPublicKey);
+
+		final char[] toWipe = password.clone();
+		client.computeSessionKey(identity, toWipe);
+		assertTrue(allZero(toWipe), "password array must be wiped after computeSessionKey");
+	}
+
+	@Test
+	void verifyServerProofReturnsFalseForAnIncorrectProof()
+	{
+		// kills the "replaced boolean return with true" mutant of verifyServerProof: with a valid
+		// session key but a bogus server proof the method must return false via the equals() check,
+		// not the null-guard path
+		final String identity = "testuser";
+		final char[] password = "testPassword123".toCharArray();
+
+		final SRP6aVerifierGenerator generator = new SRP6aVerifierGenerator();
+		final byte[] salt = generator.generateSalt();
+		final BigInteger verifier = generator.generateVerifier(identity, password.clone(), salt);
+
+		final SRP6aServer server = new SRP6aServer();
+		server.setVerifier(verifier);
+		final SRP6aClient client = new SRP6aClient();
+		final BigInteger clientPublicKey = client.generatePublicValue();
+		final BigInteger serverPublicKey = server.generatePublicValue();
+		client.setServerCredentials(salt, serverPublicKey);
+		server.setClientPublicKey(clientPublicKey);
+
+		final BigInteger clientSessionKey = client.computeSessionKey(identity, password.clone());
+		final BigInteger serverSessionKey = server.computeSessionKey();
+		final BigInteger clientProof = client.computeProof(clientSessionKey);
+		final BigInteger genuineServerProof = server.computeServerProof(clientProof,
+			serverSessionKey);
+
+		// a tampered / wrong proof must be rejected ...
+		assertFalse(
+			client.verifyServerProof(genuineServerProof.add(BigInteger.ONE), clientSessionKey));
+		// ... while the genuine one is accepted (guards against a trivially-false mutant too)
+		assertTrue(client.verifyServerProof(genuineServerProof, clientSessionKey));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/ssl/KeyStoreExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/ssl/KeyStoreExtensionsTest.java
@@ -1,0 +1,260 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.astrapi69.crypt.api.type.KeystoreType;
+import io.github.astrapi69.crypt.data.factory.CertFactory;
+import io.github.astrapi69.crypt.data.factory.KeyStoreFactory;
+import io.github.astrapi69.crypt.data.model.DistinguishedNameInfo;
+import io.github.astrapi69.crypt.data.model.KeyPairInfo;
+import io.github.astrapi69.crypt.data.model.Validity;
+import io.github.astrapi69.crypt.data.model.X509CertificateV1Info;
+import io.github.astrapi69.random.number.RandomBigIntegerFactory;
+
+/**
+ * The unit test class for the class {@link KeyStoreExtensions}
+ */
+class KeyStoreExtensionsTest
+{
+
+	private static final String PASSWORD = "secret-pw";
+	private static final String ALIAS = "server-key";
+
+	private static KeyPair keyPair;
+	private static X509Certificate certificate;
+
+	@TempDir
+	File temporaryDirectory;
+
+	private File keystoreFile;
+	private KeyStore keyStore;
+
+	/**
+	 * Creates the key pair and the self signed certificate that all tests share
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@BeforeAll
+	static void newKeyPairAndCertificate() throws Exception
+	{
+		Security.addProvider(new BouncyCastleProvider());
+
+		DistinguishedNameInfo distinguishedNameInfo = DistinguishedNameInfo.builder()
+			.commonName("Test Server").countryCode("GB").location("London")
+			.organisation("My Company").organisationUnit("IT Department").state("Greater London")
+			.build();
+		keyPair = KeyPairInfo
+			.toKeyPair(KeyPairInfo.builder().algorithm("RSA").keySize(2048).build());
+		BigInteger serial = RandomBigIntegerFactory.randomBigInteger();
+		X509CertificateV1Info x509CertificateV1Info = X509CertificateV1Info.builder()
+			.issuer(distinguishedNameInfo).serial(serial)
+			.validity(Validity.builder().notBefore(ZonedDateTime.parse("2024-01-01T00:00:00Z"))
+				.notAfter(ZonedDateTime.parse("2034-01-01T00:00:00Z")).build())
+			.subject(distinguishedNameInfo).signatureAlgorithm("SHA256withRSA").build();
+		certificate = CertFactory.newX509CertificateV1(keyPair, x509CertificateV1Info);
+	}
+
+	/**
+	 * Creates an empty keystore file for every test
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@BeforeEach
+	void newEmptyKeyStore() throws Exception
+	{
+		keystoreFile = new File(temporaryDirectory, "test-keystore.jks");
+		keyStore = KeyStoreFactory.newKeyStore(keystoreFile, KeystoreType.JKS.name(), PASSWORD);
+	}
+
+	private KeyStore reloadKeyStore() throws Exception
+	{
+		return KeyStoreFactory.loadKeyStore(keystoreFile, KeystoreType.JKS.name(), PASSWORD);
+	}
+
+	/**
+	 * Test method for
+	 * {@link KeyStoreExtensions#addAndStorePrivateKey(KeyStore, File, String, PrivateKey, char[], Certificate[])}
+	 * and {@link KeyStoreExtensions#getPrivateKey(KeyStore, String, char[])}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void addAndStorePrivateKey_writesAPrivateKeyThatCanBeReadBackFromTheFile() throws Exception
+	{
+		KeyStoreExtensions.addAndStorePrivateKey(keyStore, keystoreFile, ALIAS,
+			keyPair.getPrivate(), PASSWORD.toCharArray(), new Certificate[] { certificate });
+
+		KeyStore reloaded = reloadKeyStore();
+		assertTrue(reloaded.containsAlias(ALIAS));
+		assertEquals(keyPair.getPrivate(),
+			KeyStoreExtensions.getPrivateKey(reloaded, ALIAS, PASSWORD.toCharArray()));
+		assertEquals(certificate, KeyStoreExtensions.getCertificate(reloaded, ALIAS));
+	}
+
+	/**
+	 * Test method for
+	 * {@link KeyStoreExtensions#addAndStoreCertificate(KeyStore, File, String, String, Certificate)}
+	 * and {@link KeyStoreExtensions#getCertificate(KeyStore, String)}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void addAndStoreCertificate_writesACertificateThatCanBeReadBackFromTheFile() throws Exception
+	{
+		KeyStoreExtensions.addAndStoreCertificate(keyStore, keystoreFile, PASSWORD, "trusted-cert",
+			certificate);
+
+		KeyStore reloaded = reloadKeyStore();
+		assertEquals(certificate, KeyStoreExtensions.getCertificate(reloaded, "trusted-cert"));
+		assertTrue(reloaded.isCertificateEntry("trusted-cert"));
+	}
+
+	/**
+	 * Test method for {@link KeyStoreExtensions#addCertificate(KeyStore, String, Certificate)},
+	 * adding an entry only changes the in memory keystore until it is stored
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void addCertificate_changesOnlyTheInMemoryKeyStoreUntilItIsStored() throws Exception
+	{
+		KeyStoreExtensions.addCertificate(keyStore, "trusted-cert", certificate);
+
+		assertEquals(certificate, KeyStoreExtensions.getCertificate(keyStore, "trusted-cert"));
+		assertFalse(reloadKeyStore().containsAlias("trusted-cert"));
+
+		KeyStoreExtensions.store(keyStore, keystoreFile, PASSWORD);
+
+		assertTrue(reloadKeyStore().containsAlias("trusted-cert"));
+	}
+
+	/**
+	 * Test method for
+	 * {@link KeyStoreExtensions#addPrivateKey(KeyStore, String, PrivateKey, char[], Certificate[])},
+	 * adding a private key only changes the in memory keystore until it is stored
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void addPrivateKey_changesOnlyTheInMemoryKeyStoreUntilItIsStored() throws Exception
+	{
+		KeyStoreExtensions.addPrivateKey(keyStore, ALIAS, keyPair.getPrivate(),
+			PASSWORD.toCharArray(), new Certificate[] { certificate });
+
+		assertEquals(keyPair.getPrivate(),
+			KeyStoreExtensions.getPrivateKey(keyStore, ALIAS, PASSWORD.toCharArray()));
+		assertFalse(reloadKeyStore().containsAlias(ALIAS));
+
+		KeyStoreExtensions.store(keyStore, keystoreFile, PASSWORD.toCharArray());
+
+		assertTrue(reloadKeyStore().containsAlias(ALIAS));
+	}
+
+	/**
+	 * Test method for
+	 * {@link KeyStoreExtensions#setKeyEntry(KeyStore, String, Key, char[], Certificate[])}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void setKeyEntry_assignsTheKeyToTheGivenAlias() throws Exception
+	{
+		KeyStoreExtensions.setKeyEntry(keyStore, ALIAS, keyPair.getPrivate(),
+			PASSWORD.toCharArray(), new Certificate[] { certificate });
+		KeyStoreExtensions.store(keyStore, keystoreFile, PASSWORD);
+
+		KeyStore reloaded = reloadKeyStore();
+		assertTrue(reloaded.isKeyEntry(ALIAS));
+		assertEquals(keyPair.getPrivate(),
+			KeyStoreExtensions.getPrivateKey(reloaded, ALIAS, PASSWORD.toCharArray()));
+	}
+
+	/**
+	 * Test method for {@link KeyStoreExtensions#deleteAlias(File, String, String)}
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void deleteAlias_removesTheEntryFromTheKeystoreFile() throws Exception
+	{
+		KeyStoreExtensions.addAndStoreCertificate(keyStore, keystoreFile, PASSWORD, "trusted-cert",
+			certificate);
+		assertTrue(reloadKeyStore().containsAlias("trusted-cert"));
+
+		KeyStoreExtensions.deleteAlias(keystoreFile, "trusted-cert", PASSWORD);
+
+		KeyStore reloaded = reloadKeyStore();
+		assertFalse(reloaded.containsAlias("trusted-cert"));
+		assertNull(KeyStoreExtensions.getCertificate(reloaded, "trusted-cert"));
+	}
+
+	/**
+	 * Test method for {@link KeyStoreExtensions#store(KeyStore, File, char[])}, the stored keystore
+	 * has to be protected with the given password
+	 *
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	void store_withCharArrayPassword_protectsTheKeystoreWithThatPassword() throws Exception
+	{
+		KeyStoreExtensions.addCertificate(keyStore, "trusted-cert", certificate);
+		KeyStoreExtensions.store(keyStore, keystoreFile, PASSWORD.toCharArray());
+
+		assertNotNull(reloadKeyStore());
+		assertTrue(
+			KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD, KeystoreType.JKS.name()));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/ssl/KeystoreVerifierTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/ssl/KeystoreVerifierTest.java
@@ -25,6 +25,7 @@
 package io.github.astrapi69.mystic.crypt.ssl;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -155,6 +156,11 @@ class KeystoreVerifierTest
 		String validKeystorePath = keystoreFile.getAbsolutePath();
 		String type = "JKS";
 		assertTrue(KeystoreVerifier.isKeystoreFile(validKeystorePath, PASSWORD, type));
+		// the (String, String, String) overload must also answer false for a wrong password /
+		// missing file - guards against a mutant that always returns true
+		assertFalse(KeystoreVerifier.isKeystoreFile(validKeystorePath, "wrongpassword", type));
+		assertFalse(
+			KeystoreVerifier.isKeystoreFile("path/to/invalid/keystore.jks", PASSWORD, type));
 	}
 
 	/**
@@ -186,6 +192,9 @@ class KeystoreVerifierTest
 	public void testKeystoreFileObject() throws IOException
 	{
 		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD));
+		// the (File, String) overload must also answer false for a wrong password - guards against
+		// a mutant that always returns true
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, "wrongpassword"));
 	}
 
 	/**
@@ -196,5 +205,68 @@ class KeystoreVerifierTest
 	{
 		String[] types = { "JKS", "PKCS12" };
 		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD, types));
+		// the (File, String, String[]) overload must also answer false for a wrong password -
+		// guards against a mutant that always returns true
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, "wrongpassword", types));
+	}
+
+	/**
+	 * Test to verify that the overload with a {@link File} and a password as char array recognizes
+	 * a valid keystore and rejects a wrong password.
+	 */
+	@Test
+	public void testKeystoreFileObjectWithCharArrayPassword()
+	{
+		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD.toCharArray()));
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, "wrongpassword".toCharArray()));
+	}
+
+	/**
+	 * Test to verify that the overload with a {@link File}, a password as char array and a type
+	 * recognizes a valid keystore and rejects an unknown keystore type.
+	 */
+	@Test
+	public void testKeystoreFileObjectWithCharArrayPasswordAndType()
+	{
+		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD.toCharArray(), "JKS"));
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD.toCharArray(),
+			"no-such-keystore-type"));
+	}
+
+	/**
+	 * Test to verify that the overload with a {@link File}, a password as string and a type
+	 * recognizes a valid keystore and rejects a wrong password.
+	 */
+	@Test
+	public void testKeystoreFileObjectWithStringPasswordAndType()
+	{
+		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD, "JKS"));
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, "wrongpassword", "JKS"));
+	}
+
+	/**
+	 * Test to verify that the overload with a {@link File}, a password as char array and several
+	 * types answers true as soon as one of the given types matches and false when none matches.
+	 */
+	@Test
+	public void testKeystoreFileObjectWithCharArrayPasswordAndTypes()
+	{
+		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD.toCharArray(),
+			new String[] { "no-such-keystore-type", "JKS" }));
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD.toCharArray(),
+			new String[] { "no-such-keystore-type" }));
+	}
+
+	/**
+	 * Test to verify that the class can be instantiated over its public default constructor.
+	 */
+	@Test
+	public void testDefaultConstructor()
+	{
+		// an instance built over the default constructor must behave like the static api
+		KeystoreVerifier verifier = new KeystoreVerifier();
+		assertNotNull(verifier);
+		assertTrue(KeystoreVerifier.isKeystoreFile(keystoreFile, PASSWORD));
+		assertFalse(KeystoreVerifier.isKeystoreFile(keystoreFile, "wrongpassword"));
 	}
 }


### PR DESCRIPTION
## Summary

- Line coverage **82.7% → 99.08%**, branch **67.9% → 97.81%**, PIT mutation score **90.9% → 96.19%** (908/944 killed, test strength 96.49%).
- 28 test files strengthened, 13 new. Record-driven parameterized tests; `@TempDir` for new file-based tests.
- Biggest gap closed: `ObfuscatorExtensions` (31% → covered) with obfuscate→disentangle round-trips and "obfuscate(x) ≠ x whenever a rule applies" properties. `processor/bruteforce/*`, `ssl/KeyStoreExtensions`, `ssl/KeystoreVerifier` from 0%.
- `gradle/mutation-testing.gradle` now also emits `mutations.xml`; README mutation badge 69% → 96%.
- No `src/main` changes in this PR. The mutation stage did surface a latent production bug in `PBEFileEncryptor`'s decorator handling (the decorated content was computed and discarded); that fix comes as its own PR with regression tests.

## How the numbers were produced

Isolated worktree, five-stage loop per [docs/TESTING.md](https://github.com/astrapi69/mystic-crypt/blob/develop/docs/TESTING.md) (coverage → independent adversarial verification → fix → mutation → final verification). The final verifier rebuilt from scratch, recomputed the JaCoCo XML totals, confirmed nothing outside `src/test` changed, read every new/modified test for tautologies (and tightened two it found), and checked no test exceeds 3 s (slowest: 1.09 s). Every remaining miss and surviving mutant carries a specific reason in the commit message.

## Checks

- `./gradlew build` green on JDK 25 (566 tests, 0 failures), `spotlessCheck` clean
- `src/test/resources/crypt/test.txt` intact after the PIT runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)