### PR TITLE
fix: PBEFileEncryptor never applied decorators; PBEFileDecryptor stripped only one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ CHANGED:
   updated to match. Published bytecode now targets JDK 25, so this is a breaking change for
   consumers still on JDK 21-24.
 
+FIXED:
+
+- PBEFileEncryptor/PBEFileDecryptor decorators: the encryptor computed the decorated file
+  content via CryptObjectDecoratorExtensions#decorateFile and then discarded it, encrypting the raw
+  file - CryptObjectDecorators configured on the CryptModel had no effect on file encryption at all.
+  The decryptor re-read the file on every loop iteration instead of chaining on the string, so with
+  more than one decorator only the innermost was ever stripped. Both went unnoticed because an
+  encrypt-then-decrypt round trip passes either way ("never added" and "never removed" agree);
+  found by a surviving PIT mutant on the decorator loop. The encryptor now decorates in memory
+  (the source file is never modified) and encrypts the decorated content, the decryptor strips all
+  decorators outermost-first.
+
 Version 10.2-SNAPSHOT
 -------------
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecryptor.java
@@ -30,7 +30,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -48,7 +49,6 @@ import io.github.astrapi69.crypt.data.factory.CipherFactory;
 import io.github.astrapi69.crypt.data.model.CryptModel;
 import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
 import io.github.astrapi69.file.delete.DeleteFileExtensions;
-import io.github.astrapi69.file.read.ReadFileExtensions;
 import io.github.astrapi69.file.write.StoreFileExtensions;
 import io.github.astrapi69.mystic.crypt.core.AbstractFileDecryptor;
 import io.github.astrapi69.mystic.crypt.decorator.CryptObjectDecoratorExtensions;
@@ -246,14 +246,18 @@ public class PBEFileDecryptor extends AbstractFileDecryptor
 		List<CryptObjectDecorator<String>> decorators = getModel().getDecorators();
 		if (decorators != null && !decorators.isEmpty())
 		{
-			String decryptedFileString = ReadFileExtensions.fromFile(decryptedFile);
+			// Strip the decorators outermost-first, chaining on the string. (Previously each
+			// iteration re-read the file via undecorateFile, so with more than one decorator only
+			// the innermost one was ever removed and the outer markers survived.)
+			String decryptedFileString = new String(Files.readAllBytes(decryptedFile.toPath()),
+				StandardCharsets.UTF_8);
 			for (int i = decorators.size() - 1; 0 <= i; i--)
 			{
-				decryptedFileString = CryptObjectDecoratorExtensions.undecorateFile(decryptedFile,
-					decorators.get(i));
+				decryptedFileString = CryptObjectDecoratorExtensions
+					.undecorateWithStringDecorator(decryptedFileString, decorators.get(i));
 			}
 			StoreFileExtensions.toFile(decryptedFile, decryptedFileString,
-				Charset.forName("UTF-8").name());
+				StandardCharsets.UTF_8.name());
 		}
 		if (this.deleteEncryptedFileAfterDecryption)
 		{

--- a/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptor.java
@@ -24,11 +24,15 @@
  */
 package io.github.astrapi69.mystic.crypt.file;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -218,16 +222,30 @@ public class PBEFileEncryptor extends AbstractFileEncryptor
 				filename + encryptedFileExtension);
 		}
 		List<CryptObjectDecorator<String>> decorators = getModel().getDecorators();
+		InputStream source;
 		if (decorators != null && !decorators.isEmpty())
 		{
-			for (int i = 0; i < decorators.size(); i++)
+			// Decorate in memory and encrypt the decorated content. The decorators are applied in
+			// list order, so the last one ends up outermost; PBEFileDecryptor#onAfterDecrypt strips
+			// them in reverse order. The source file itself is never modified.
+			// (Previously the decorated string returned by decorateFile was discarded and the raw
+			// file encrypted, so decorators silently had no effect on file encryption at all.)
+			String content = new String(Files.readAllBytes(toEncrypt.toPath()),
+				StandardCharsets.UTF_8);
+			for (CryptObjectDecorator<String> decorator : decorators)
 			{
-				CryptObjectDecoratorExtensions.decorateFile(toEncrypt, decorators.get(i));
+				content = CryptObjectDecoratorExtensions.decorateWithStringDecorator(content,
+					decorator);
 			}
+			source = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+		}
+		else
+		{
+			source = new FileInputStream(toEncrypt);
 		}
 		try (
-			CryptoCipherInputStream cis = new CryptoCipherInputStream(
-				new FileInputStream(toEncrypt), getModel().getCipher());
+			CryptoCipherInputStream cis = new CryptoCipherInputStream(source,
+				getModel().getCipher());
 			OutputStream out = new FileOutputStream(encryptedFile))
 		{
 			int c;

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecoratorRoundTripTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecoratorRoundTripTest.java
@@ -1,0 +1,186 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.crypto.Cipher;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.astrapi69.crypt.api.algorithm.SunJCEAlgorithm;
+import io.github.astrapi69.crypt.data.model.CryptModel;
+import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
+
+/**
+ * Regression tests proving that {@link PBEFileEncryptor} actually applies the
+ * {@link CryptObjectDecorator}s of its {@link CryptModel} and that {@link PBEFileDecryptor} strips
+ * all of them again.
+ * <p>
+ * Both halves used to be broken in a way that cancelled out: the encryptor discarded the decorated
+ * string returned by {@code decorateFile} and encrypted the raw file, and the decryptor re-read the
+ * file on every loop iteration so only the innermost decorator was ever removed. A plain
+ * encrypt-then-decrypt round trip passed regardless - "never added" and "never removed" agree -
+ * which is why these tests also decrypt <em>without</em> the decorators to look at what was really
+ * encrypted.
+ */
+class PBEFileDecoratorRoundTripTest
+{
+
+	private static final String PLAINTEXT = "Hello decorators - ü ö ä €";
+	private static final String PASSWORD = "foo";
+	/**
+	 * The PBE file format does not carry the salt, so encryptor and decryptor must agree on it via
+	 * the model; a fixed salt lets the tests build separate models (with and without decorators)
+	 * that still decrypt each other's output.
+	 */
+	private static final byte[] SALT = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+	@TempDir
+	Path tempDir;
+
+	File toEncrypt;
+
+	@BeforeEach
+	void setUp() throws Exception
+	{
+		toEncrypt = tempDir.resolve("plain.txt").toFile();
+		Files.writeString(toEncrypt.toPath(), PLAINTEXT, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * A decorator set and the content that must come out of the decryptor when the decorators are
+	 * <em>not</em> applied on the way back - i.e. exactly what the encryptor put into the
+	 * ciphertext.
+	 */
+	record DecoratorCase(String name, List<CryptObjectDecorator<String>> decorators,
+		String expectedDecorated) {
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+
+	static Stream<DecoratorCase> decoratorCases()
+	{
+		CryptObjectDecorator<String> dollar = CryptObjectDecorator.<String> builder().prefix("$")
+			.suffix("?").build();
+		CryptObjectDecorator<String> angle = CryptObjectDecorator.<String> builder().prefix("<<")
+			.suffix(">>").build();
+		CryptObjectDecorator<String> prefixOnly = CryptObjectDecorator.<String> builder()
+			.prefix("BEGIN:").suffix("").build();
+		return Stream.of(new DecoratorCase("single", List.of(dollar), "$" + PLAINTEXT + "?"),
+			// applied in list order: the last decorator ends up outermost
+			new DecoratorCase("two, nested", List.of(dollar, angle), "<<$" + PLAINTEXT + "?>>"),
+			new DecoratorCase("three, nested", List.of(angle, dollar, prefixOnly),
+				"BEGIN:$<<" + PLAINTEXT + ">>?"));
+	}
+
+	private CryptModel<Cipher, String, String> model(List<CryptObjectDecorator<String>> decorators)
+	{
+		var builder = CryptModel.<Cipher, String, String> builder().key(PASSWORD)
+			.algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(SALT);
+		for (CryptObjectDecorator<String> decorator : decorators)
+		{
+			builder.decorator(decorator);
+		}
+		return builder.build();
+	}
+
+	private String encryptThenDecrypt(List<CryptObjectDecorator<String>> encryptWith,
+		List<CryptObjectDecorator<String>> decryptWith, String tag) throws Exception
+	{
+		File encrypted = tempDir.resolve(tag + ".enc").toFile();
+		File decrypted = tempDir.resolve(tag + ".decrypted").toFile();
+		new PBEFileEncryptor(model(encryptWith), encrypted).encrypt(toEncrypt);
+		new PBEFileDecryptor(model(decryptWith), decrypted).decrypt(encrypted);
+		return Files.readString(decrypted.toPath(), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Decrypting without the decorators exposes what was really encrypted: it must be the decorated
+	 * content, not the raw file. This is the assertion the original bug failed.
+	 */
+	@ParameterizedTest
+	@MethodSource("decoratorCases")
+	void encryptAppliesDecoratorsInOrder(DecoratorCase testCase) throws Exception
+	{
+		String whatWasEncrypted = encryptThenDecrypt(testCase.decorators(), List.of(), "raw");
+
+		assertEquals(testCase.expectedDecorated(), whatWasEncrypted);
+		assertNotEquals(PLAINTEXT, whatWasEncrypted);
+	}
+
+	/**
+	 * Decrypting with the same decorators must strip every one of them, outermost first, and
+	 * recover the original - including for more than one decorator, which the old decryptor loop
+	 * got wrong.
+	 */
+	@ParameterizedTest
+	@MethodSource("decoratorCases")
+	void decryptStripsAllDecorators(DecoratorCase testCase) throws Exception
+	{
+		assertEquals(PLAINTEXT,
+			encryptThenDecrypt(testCase.decorators(), testCase.decorators(), "roundtrip"));
+	}
+
+	/**
+	 * Decoration must happen in memory: the caller's source file is not rewritten.
+	 */
+	@Test
+	void encryptDoesNotModifyTheSourceFile() throws Exception
+	{
+		List<CryptObjectDecorator<String>> decorators = decoratorCases().toList().get(1)
+			.decorators();
+		File encrypted = tempDir.resolve("untouched.enc").toFile();
+
+		new PBEFileEncryptor(model(decorators), encrypted).encrypt(toEncrypt);
+
+		assertEquals(PLAINTEXT, Files.readString(toEncrypt.toPath(), StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Without decorators the raw file content is encrypted, as before.
+	 */
+	@Test
+	void encryptWithoutDecoratorsEncryptsRawContent() throws Exception
+	{
+		assertEquals(PLAINTEXT, encryptThenDecrypt(List.of(), List.of(), "plain"));
+	}
+
+}


### PR DESCRIPTION
## Summary

- **`PBEFileEncryptor.encrypt`** called `CryptObjectDecoratorExtensions.decorateFile` per decorator and **discarded the returned string**, then encrypted the raw file. `CryptObjectDecorator`s on the `CryptModel` had no effect on file encryption at all.
- **`PBEFileDecryptor.onAfterDecrypt`** re-read the decrypted file on every loop iteration instead of chaining on the string, so with more than one decorator only the innermost was ever stripped.
- Neither showed in any round-trip test - "never added" and "never removed" agree. It surfaced in the mutation stage of the coverage work (#58): a negated-conditional mutant on the decorator loop survived, and tracing *why nothing could notice* led to the discarded return value.

## Fix

- Encryptor decorates in memory, in list order (last decorator outermost), and streams the decorated bytes into the cipher. The caller's source file is never modified.
- Decryptor strips decorators outermost-first, chaining on the string, then writes the result back. UTF-8 on both sides.

## Tests

`PBEFileDecoratorRoundTripTest` (record-driven, `@TempDir` - no fixtures written into `src/test/resources`):
- decrypts **without** the decorators to expose what was really encrypted → must equal the decorated content
- round trips with one, two and three nested decorators recover the original
- the source file is untouched after encryption
- no decorators → raw content, as before

Evidence that the tests catch **both** halves (each half verified red, then green):
- previous `src/main` (old encryptor + old decryptor): the three "what was really encrypted" cases **fail**; the round trips pass only because nothing was ever added
- fixed encryptor + previous decryptor: the **two- and three-decorator round trips fail** (outer markers survive)
- both fixes: 8/8 green; full build green (385 tests)

CHANGELOG entry under 10.5-SNAPSHOT / FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)