### PR TITLE
fix: same decorator defect in FileEncryptor/FileDecryptor; repair the tests that enshrined it (develop CI red after #58+#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ CHANGED:
 
 FIXED:
 
-- PBEFileEncryptor/PBEFileDecryptor decorators: the encryptor computed the decorated file
+- PBEFileEncryptor/PBEFileDecryptor and FileEncryptor/FileDecryptor decorators: the encryptor computed the decorated file
   content via CryptObjectDecoratorExtensions#decorateFile and then discarded it, encrypting the raw
   file - CryptObjectDecorators configured on the CryptModel had no effect on file encryption at all.
   The decryptor re-read the file on every loop iteration instead of chaining on the string, so with
@@ -29,7 +29,10 @@ FIXED:
   encrypt-then-decrypt round trip passes either way ("never added" and "never removed" agree);
   found by a surviving PIT mutant on the decorator loop. The encryptor now decorates in memory
   (the source file is never modified) and encrypts the decorated content, the decryptor strips all
-  decorators outermost-first.
+  decorators outermost-first. FileEncryptor/FileDecryptor had the identical defect and got the
+  identical fix (the tests that had enshrined the old behaviour in PBEFileEncryptorTest and
+  FileEncryptDecryptorTest were corrected, and both families now have a decorator round-trip
+  regression test that decrypts with and without the decorators).
 
 Version 10.2-SNAPSHOT
 -------------

--- a/src/main/java/io/github/astrapi69/mystic/crypt/file/FileDecryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/file/FileDecryptor.java
@@ -30,7 +30,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -45,7 +46,6 @@ import org.apache.commons.io.FilenameUtils;
 
 import io.github.astrapi69.crypt.data.model.CryptModel;
 import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
-import io.github.astrapi69.file.read.ReadFileExtensions;
 import io.github.astrapi69.file.write.StoreFileExtensions;
 import io.github.astrapi69.mystic.crypt.core.AbstractFileDecryptor;
 import io.github.astrapi69.mystic.crypt.decorator.CryptObjectDecoratorExtensions;
@@ -162,14 +162,18 @@ public class FileDecryptor extends AbstractFileDecryptor
 		List<CryptObjectDecorator<String>> decorators = getModel().getDecorators();
 		if (decorators != null && !decorators.isEmpty())
 		{
-			String decryptedFileString = ReadFileExtensions.fromFile(decryptedFile);
+			// Strip the decorators outermost-first, chaining on the string. (Previously each
+			// iteration re-read the file via undecorateFile, so with more than one decorator only
+			// the innermost one was ever removed.)
+			String decryptedFileString = new String(Files.readAllBytes(decryptedFile.toPath()),
+				StandardCharsets.UTF_8);
 			for (int i = decorators.size() - 1; 0 <= i; i--)
 			{
-				decryptedFileString = CryptObjectDecoratorExtensions.undecorateFile(decryptedFile,
-					decorators.get(i));
+				decryptedFileString = CryptObjectDecoratorExtensions
+					.undecorateWithStringDecorator(decryptedFileString, decorators.get(i));
 			}
 			StoreFileExtensions.toFile(decryptedFile, decryptedFileString,
-				Charset.forName("UTF-8").name());
+				StandardCharsets.UTF_8.name());
 		}
 	}
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/file/FileEncryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/file/FileEncryptor.java
@@ -24,11 +24,14 @@
  */
 package io.github.astrapi69.mystic.crypt.file;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -142,16 +145,35 @@ public class FileEncryptor extends AbstractFileEncryptor
 			encryptedFile = newEncryptedFile(toEncrypt.getParent(), filename + ".enc");
 		}
 		List<CryptObjectDecorator<String>> decorators = getModel().getDecorators();
+		InputStream source;
 		if (decorators != null && !decorators.isEmpty())
 		{
-			for (int i = 0; i < decorators.size(); i++)
+			// Decorate in memory and encrypt the decorated content, in list order (last decorator
+			// outermost); FileDecryptor#onAfterDecrypt strips them in reverse order. The source
+			// file
+			// itself is never modified. (Previously the decorated string returned by decorateFile
+			// was discarded and the raw file encrypted, so decorators silently had no effect.)
+			// read through FileInputStream so a missing file or a directory still surfaces as
+			// FileNotFoundException, exactly as on the undecorated path
+			String content;
+			try (InputStream in = new FileInputStream(toEncrypt))
 			{
-				CryptObjectDecoratorExtensions.decorateFile(toEncrypt, decorators.get(i));
+				content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
 			}
+			for (CryptObjectDecorator<String> decorator : decorators)
+			{
+				content = CryptObjectDecoratorExtensions.decorateWithStringDecorator(content,
+					decorator);
+			}
+			source = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+		}
+		else
+		{
+			source = new FileInputStream(toEncrypt);
 		}
 		try (
-			CryptoCipherInputStream cis = new CryptoCipherInputStream(
-				new FileInputStream(toEncrypt), getModel().getCipher());
+			CryptoCipherInputStream cis = new CryptoCipherInputStream(source,
+				getModel().getCipher());
 			OutputStream out = new FileOutputStream(encryptedFile))
 		{
 			int c;

--- a/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptor.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -230,8 +229,13 @@ public class PBEFileEncryptor extends AbstractFileEncryptor
 			// them in reverse order. The source file itself is never modified.
 			// (Previously the decorated string returned by decorateFile was discarded and the raw
 			// file encrypted, so decorators silently had no effect on file encryption at all.)
-			String content = new String(Files.readAllBytes(toEncrypt.toPath()),
-				StandardCharsets.UTF_8);
+			// read through FileInputStream so a missing file or a directory still surfaces as
+			// FileNotFoundException, exactly as on the undecorated path
+			String content;
+			try (InputStream in = new FileInputStream(toEncrypt))
+			{
+				content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+			}
 			for (CryptObjectDecorator<String> decorator : decorators)
 			{
 				content = CryptObjectDecoratorExtensions.decorateWithStringDecorator(content,

--- a/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
@@ -524,4 +524,33 @@ public class CryptObjectDecoratorExtensionsTest
 		String result = CryptObjectDecoratorExtensions.decorateFile(file, decorator);
 		assertEquals("<<payload>>", result);
 	}
+
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateFile(java.io.File, CryptObjectDecorator)}:
+	 * the decorator's prefix and suffix must be stripped from the file content, and content without
+	 * them must be returned unchanged. Since the file encryptors now decorate in memory, this
+	 * helper has no production caller left and is only pinned by this test.
+	 *
+	 * @throws java.io.IOException
+	 *             if an I/O error occurs
+	 */
+	@Test
+	void undecorateFile_stripsThePrefixAndSuffixFromTheFileContent() throws java.io.IOException
+	{
+		CryptObjectDecorator<String> decorator = CryptObjectDecorator.<String> builder()
+			.prefix("<<").suffix(">>").build();
+
+		java.io.File decorated = java.io.File.createTempFile("undecorate-file-test", ".txt");
+		decorated.deleteOnExit();
+		java.nio.file.Files.write(decorated.toPath(),
+			"<<payload>>".getBytes(StandardCharsets.UTF_8));
+		assertEquals("payload",
+			CryptObjectDecoratorExtensions.undecorateFile(decorated, decorator));
+
+		java.io.File plain = java.io.File.createTempFile("undecorate-file-test-plain", ".txt");
+		plain.deleteOnExit();
+		java.nio.file.Files.write(plain.toPath(), "payload".getBytes(StandardCharsets.UTF_8));
+		assertEquals("payload", CryptObjectDecoratorExtensions.undecorateFile(plain, decorator));
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/FileDecoratorRoundTripTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/FileDecoratorRoundTripTest.java
@@ -1,0 +1,186 @@
+/**
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.crypto.Cipher;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.astrapi69.crypt.api.algorithm.SunJCEAlgorithm;
+import io.github.astrapi69.crypt.data.model.CryptModel;
+import io.github.astrapi69.crypt.data.model.CryptObjectDecorator;
+
+/**
+ * Regression tests proving that {@link FileEncryptor} actually applies the
+ * {@link CryptObjectDecorator}s of its {@link CryptModel} and that {@link FileDecryptor} strips all
+ * of them again.
+ * <p>
+ * Both halves used to be broken in a way that cancelled out: the encryptor discarded the decorated
+ * string returned by {@code decorateFile} and encrypted the raw file, and the decryptor re-read the
+ * file on every loop iteration so only the innermost decorator was ever removed. A plain
+ * encrypt-then-decrypt round trip passed regardless - "never added" and "never removed" agree -
+ * which is why these tests also decrypt <em>without</em> the decorators to look at what was really
+ * encrypted.
+ */
+class FileDecoratorRoundTripTest
+{
+
+	private static final String PLAINTEXT = "Hello decorators - ü ö ä €";
+	private static final String PASSWORD = "foo";
+	/**
+	 * The PBE file format does not carry the salt, so encryptor and decryptor must agree on it via
+	 * the model; a fixed salt lets the tests build separate models (with and without decorators)
+	 * that still decrypt each other's output.
+	 */
+	private static final byte[] SALT = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+	@TempDir
+	Path tempDir;
+
+	File toEncrypt;
+
+	@BeforeEach
+	void setUp() throws Exception
+	{
+		toEncrypt = tempDir.resolve("plain.txt").toFile();
+		Files.writeString(toEncrypt.toPath(), PLAINTEXT, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * A decorator set and the content that must come out of the decryptor when the decorators are
+	 * <em>not</em> applied on the way back - i.e. exactly what the encryptor put into the
+	 * ciphertext.
+	 */
+	record DecoratorCase(String name, List<CryptObjectDecorator<String>> decorators,
+		String expectedDecorated) {
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+
+	static Stream<DecoratorCase> decoratorCases()
+	{
+		CryptObjectDecorator<String> dollar = CryptObjectDecorator.<String> builder().prefix("$")
+			.suffix("?").build();
+		CryptObjectDecorator<String> angle = CryptObjectDecorator.<String> builder().prefix("<<")
+			.suffix(">>").build();
+		CryptObjectDecorator<String> prefixOnly = CryptObjectDecorator.<String> builder()
+			.prefix("BEGIN:").suffix("").build();
+		return Stream.of(new DecoratorCase("single", List.of(dollar), "$" + PLAINTEXT + "?"),
+			// applied in list order: the last decorator ends up outermost
+			new DecoratorCase("two, nested", List.of(dollar, angle), "<<$" + PLAINTEXT + "?>>"),
+			new DecoratorCase("three, nested", List.of(angle, dollar, prefixOnly),
+				"BEGIN:$<<" + PLAINTEXT + ">>?"));
+	}
+
+	private CryptModel<Cipher, String, String> model(List<CryptObjectDecorator<String>> decorators)
+	{
+		var builder = CryptModel.<Cipher, String, String> builder().key(PASSWORD)
+			.algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(SALT);
+		for (CryptObjectDecorator<String> decorator : decorators)
+		{
+			builder.decorator(decorator);
+		}
+		return builder.build();
+	}
+
+	private String encryptThenDecrypt(List<CryptObjectDecorator<String>> encryptWith,
+		List<CryptObjectDecorator<String>> decryptWith, String tag) throws Exception
+	{
+		File encrypted = tempDir.resolve(tag + ".enc").toFile();
+		File decrypted = tempDir.resolve(tag + ".decrypted").toFile();
+		new FileEncryptor(model(encryptWith), encrypted).encrypt(toEncrypt);
+		new FileDecryptor(model(decryptWith), decrypted).decrypt(encrypted);
+		return Files.readString(decrypted.toPath(), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Decrypting without the decorators exposes what was really encrypted: it must be the decorated
+	 * content, not the raw file. This is the assertion the original bug failed.
+	 */
+	@ParameterizedTest
+	@MethodSource("decoratorCases")
+	void encryptAppliesDecoratorsInOrder(DecoratorCase testCase) throws Exception
+	{
+		String whatWasEncrypted = encryptThenDecrypt(testCase.decorators(), List.of(), "raw");
+
+		assertEquals(testCase.expectedDecorated(), whatWasEncrypted);
+		assertNotEquals(PLAINTEXT, whatWasEncrypted);
+	}
+
+	/**
+	 * Decrypting with the same decorators must strip every one of them, outermost first, and
+	 * recover the original - including for more than one decorator, which the old decryptor loop
+	 * got wrong.
+	 */
+	@ParameterizedTest
+	@MethodSource("decoratorCases")
+	void decryptStripsAllDecorators(DecoratorCase testCase) throws Exception
+	{
+		assertEquals(PLAINTEXT,
+			encryptThenDecrypt(testCase.decorators(), testCase.decorators(), "roundtrip"));
+	}
+
+	/**
+	 * Decoration must happen in memory: the caller's source file is not rewritten.
+	 */
+	@Test
+	void encryptDoesNotModifyTheSourceFile() throws Exception
+	{
+		List<CryptObjectDecorator<String>> decorators = decoratorCases().toList().get(1)
+			.decorators();
+		File encrypted = tempDir.resolve("untouched.enc").toFile();
+
+		new FileEncryptor(model(decorators), encrypted).encrypt(toEncrypt);
+
+		assertEquals(PLAINTEXT, Files.readString(toEncrypt.toPath(), StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Without decorators the raw file content is encrypted, as before.
+	 */
+	@Test
+	void encryptWithoutDecoratorsEncryptsRawContent() throws Exception
+	{
+		assertEquals(PLAINTEXT, encryptThenDecrypt(List.of(), List.of(), "plain"));
+	}
+
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
@@ -200,10 +200,13 @@ public class FileEncryptDecryptorTest extends AbstractTestCase<String, String>
 
 	/**
 	 * Test method for {@link FileDecryptor#decrypt(File)} that pins the observable effect of the
-	 * {@code onAfterDecrypt} post-processing step: when the {@link CryptModel} carries a string
-	 * decorator, decryption undecorates the recovered content, removing the decorator's prefix and
-	 * suffix from the decrypted file. This exercises the {@code onAfterDecrypt} call and its
-	 * decorator loop; without them the markers would survive into the decrypted file.
+	 * {@code onAfterDecrypt} post-processing step: the encryptor wraps the content in the
+	 * {@link CryptModel}'s decorator ("$" prefix, "?" suffix), and decryption with the same model
+	 * strips it again, so the round trip recovers the plain input - while decrypting the same
+	 * ciphertext with a model that has no decorator exposes the markers the encryptor added. (An
+	 * earlier version of this test wrote the markers into the plain file by hand and expected them
+	 * stripped; that only passed because the encryptor used to discard the decorated content, see
+	 * FileDecoratorRoundTripTest.)
 	 *
 	 * @throws Exception
 	 *             is thrown if any error occurs on the execution
@@ -211,25 +214,39 @@ public class FileEncryptDecryptorTest extends AbstractTestCase<String, String>
 	@Test
 	public void decrypt_appliesTheDecoratorUndecorationInOnAfterDecrypt() throws Exception
 	{
-		File markerPlain = new File(cryptDir, "marker-plain.txt");
-		// the "$" prefix and "?" suffix match the decorator configured in setUp
-		Files.write(markerPlain.toPath(), "$hello?".getBytes(StandardCharsets.UTF_8));
-		File markerEncrypted = new File(cryptDir, "marker.enc");
-		File markerDecrypted = new File(cryptDir, "marker.decrypted");
+		java.nio.file.Path tempDir = Files.createTempDirectory("file-marker");
+		File plain = tempDir.resolve("plain.txt").toFile();
+		Files.write(plain.toPath(), "hello".getBytes(StandardCharsets.UTF_8));
+		File markerEncrypted = tempDir.resolve("marker.enc").toFile();
+		File withDecorator = tempDir.resolve("with-decorator.decrypted").toFile();
+		File withoutDecorator = tempDir.resolve("without-decorator.decrypted").toFile();
+		// the model without the decorator must share key and salt with the decorated one,
+		// otherwise it cannot decrypt at all
+		byte[] salt = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		CryptModel<Cipher, String, String> decorated = CryptModel.<Cipher, String, String> builder()
+			.key(firstKey).algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(salt)
+			.decorator(CryptObjectDecorator.<String> builder().prefix("$").suffix("?").build())
+			.build();
+		CryptModel<Cipher, String, String> undecorated = CryptModel
+			.<Cipher, String, String> builder().key(firstKey)
+			.algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(salt).build();
 
-		encryptor = new FileEncryptor(cryptModel, markerEncrypted);
-		encrypted = encryptor.encrypt(markerPlain);
+		encrypted = new FileEncryptor(decorated, markerEncrypted).encrypt(plain);
 
-		decryptor = new FileDecryptor(cryptModel, markerDecrypted);
-		decrypted = decryptor.decrypt(encrypted);
+		String roundTrip = new String(
+			Files.readAllBytes(
+				new FileDecryptor(decorated, withDecorator).decrypt(encrypted).toPath()),
+			StandardCharsets.UTF_8);
+		String exposed = new String(
+			Files.readAllBytes(
+				new FileDecryptor(undecorated, withoutDecorator).decrypt(encrypted).toPath()),
+			StandardCharsets.UTF_8);
 
-		String content = new String(Files.readAllBytes(decrypted.toPath()), StandardCharsets.UTF_8);
-		assertEquals("hello", content);
+		assertEquals("hello", roundTrip);
+		assertEquals("$hello?", exposed);
 
 		// clean up...
-		DeleteFileExtensions.delete(markerPlain);
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
+		DeleteFileExtensions.delete(tempDir.toFile());
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileEncryptorTest.java
@@ -131,10 +131,13 @@ public class PBEFileEncryptorTest extends AbstractTestCase<String, String>
 
 	/**
 	 * Test method for {@link PBEFileDecryptor#decrypt(File)} that pins the observable effect of the
-	 * {@code onAfterDecrypt} post-processing step: when the {@link CryptModel} carries a string
-	 * decorator, decryption undecorates the recovered content, removing the decorator's prefix and
-	 * suffix from the decrypted file. Without the {@code onAfterDecrypt} decorator loop the markers
-	 * would survive into the decrypted file.
+	 * {@code onAfterDecrypt} post-processing step: the encryptor wraps the content in the
+	 * {@link CryptModel}'s decorator ("$" prefix, "?" suffix), and decryption with the same model
+	 * strips it again, so the round trip recovers the plain input - while decrypting the same
+	 * ciphertext with a model that has no decorator exposes the markers the encryptor added. (An
+	 * earlier version of this test wrote the markers into the plain file by hand and expected them
+	 * stripped; that only passed because the encryptor used to discard the decorated content, see
+	 * PBEFileDecoratorRoundTripTest.)
 	 *
 	 * @throws Exception
 	 *             is thrown if any error occurs on the execution
@@ -142,26 +145,38 @@ public class PBEFileEncryptorTest extends AbstractTestCase<String, String>
 	@Test
 	public void decrypt_appliesTheDecoratorUndecorationInOnAfterDecrypt() throws Exception
 	{
-		File markerPlain = new File(cryptDir, "pbe-marker-plain.txt");
-		// the "$" prefix and "?" suffix match the decorator configured in setUp
-		Files.write(markerPlain.toPath(),
-			"$hello?".getBytes(java.nio.charset.StandardCharsets.UTF_8));
-		File markerEncrypted = new File(cryptDir, "pbe-marker.enc");
-		File markerDecrypted = new File(cryptDir, "pbe-marker.decrypted");
+		java.nio.file.Path tempDir = Files.createTempDirectory("pbe-marker");
+		File plain = tempDir.resolve("plain.txt").toFile();
+		Files.write(plain.toPath(), "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		File markerEncrypted = tempDir.resolve("marker.enc").toFile();
+		File withDecorator = tempDir.resolve("with-decorator.decrypted").toFile();
+		File withoutDecorator = tempDir.resolve("without-decorator.decrypted").toFile();
+		// the model without the decorator must share key and salt with cryptModel, otherwise it
+		// cannot decrypt at all
+		byte[] salt = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		CryptModel<Cipher, String, String> decorated = CryptModel.<Cipher, String, String> builder()
+			.key(password).algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(salt)
+			.decorator(CryptObjectDecorator.<String> builder().prefix("$").suffix("?").build())
+			.build();
+		CryptModel<Cipher, String, String> undecorated = CryptModel
+			.<Cipher, String, String> builder().key(password)
+			.algorithm(SunJCEAlgorithm.PBEWithMD5AndDES).salt(salt).build();
 
-		encryptor = new PBEFileEncryptor(cryptModel, markerEncrypted);
-		encrypted = encryptor.encrypt(markerPlain);
+		encrypted = new PBEFileEncryptor(decorated, markerEncrypted).encrypt(plain);
 
-		decryptor = new PBEFileDecryptor(cryptModel, markerDecrypted);
-		decrypted = decryptor.decrypt(encrypted);
-
-		String content = new String(Files.readAllBytes(decrypted.toPath()),
+		String roundTrip = new String(
+			Files.readAllBytes(
+				new PBEFileDecryptor(decorated, withDecorator).decrypt(encrypted).toPath()),
 			java.nio.charset.StandardCharsets.UTF_8);
-		assertEquals("hello", content);
+		String exposed = new String(
+			Files.readAllBytes(
+				new PBEFileDecryptor(undecorated, withoutDecorator).decrypt(encrypted).toPath()),
+			java.nio.charset.StandardCharsets.UTF_8);
+
+		assertEquals("hello", roundTrip);
+		assertEquals("$hello?", exposed);
 
 		// clean up...
-		DeleteFileExtensions.delete(markerPlain);
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
+		DeleteFileExtensions.delete(tempDir.toFile());
 	}
 }


### PR DESCRIPTION
## Why develop is red

#58 added `decrypt_appliesTheDecoratorUndecorationInOnAfterDecrypt` to `PBEFileEncryptorTest` and `FileEncryptDecryptorTest`: it wrote the `$…?` markers into the plain file by hand and expected them stripped after decryption. That only ever held because the encryptor **never added** any markers (the bug #59 fixed). Each PR was green on its own base; merged together, the PBE variant fails (`expected "hello", got "$hello?"`).

## What this PR does

- **`FileEncryptor` / `FileDecryptor` had the identical defect** as the PBE classes (decorated content discarded on encrypt; only the innermost decorator stripped on decrypt) - their twin test stayed green for the same reason. Same fix as #59.
- Both enshrining tests now encrypt a plain `hello`, assert the round trip returns `hello`, and assert that decrypting the same ciphertext with a model *without* the decorator exposes `$hello?` - i.e. they pin the real observable effect of `onAfterDecrypt`. Temporary directory instead of `src/test/resources`.
- `FileDecoratorRoundTripTest` mirrors `PBEFileDecoratorRoundTripTest` for the `File*` family (one/two/three nested decorators, source file untouched, no-decorator path).
- CHANGELOG entry extended.

## Evidence

- `FileDecoratorRoundTripTest` against the previous `FileEncryptor`/`FileDecryptor`: the three "what was really encrypted" cases **fail**; green after the fix.
- Full `./gradlew build` green on the merged tree (677 tests incl. these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)