### PR TITLE
fix: restore JDK 25 + .gitignore, tighten Argon2 validation, revive dead README links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,77 +1,92 @@
-# Gradle
-.gradle/
-build/
-target/
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
 
-# Environment
-.env
-.env.local
-*.env.*
+##################
+# Compiled files #
+##################
+*.class
 
-# Logs
+##################
+# intellij files #
+##################
+*.iml
+*.iws
+*.ipr
+!.idea/runConfigurations
+.idea/inspectionProfiles
+.idea/copyright
+.idea/libraries
+.idea/codeStyles
+.idea/shelf
+.idea/*.*
+/.idea/$PRODUCT_WORKSPACE_FILE$
+
+#################
+# eclipse files #
+#################
+/.project
+/.classpath
+/.settings
+/.tern-project
+
+#########################
+# maven generated files #
+#########################
+/target
+
+#############
+# Zip files #
+#############
+*.tar
+*.zip
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+
+##############
+# Logs files #
+##############
 *.log
 
-# IDE
-.vscode/
-.idea/
-*.swp
-*.swo
+#################
+# test-ng files #
+#################
+/test-output
 
-# Python
-__pycache__/
-*.pyc
-*.pyo
-*.pyd
-.Python
-venv/
-.venv/
-env/
-ENV/
+############################
+# Binaries generated files #
+############################
+/bin
 
-# Node.js
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+################
+# gradle files #
+################
+/build
+/.gradle
+/gradle
+/out
+# Ignore Gradle GUI config
+gradle-app.setting
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!/gradle/wrapper/gradle-wrapper.jar
+!/gradle/wrapper/gradle-wrapper.properties
+# Cache of project
+.gradletasknamecache
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
 
-# Compiled and binary
-*.class
-*.o
-*.obj
-*.out
-*.exe
-*.dll
-*.so
-*.a
-*.tar.gz
-*.zip
-*.gz
-*.tar
-*.tgz
-*.bz2
-*.xz
-*.7z
-*.rar
-*.zst
-*.lz4
-*.lzh
-*.cab
-*.arj
-*.rpm
-*.deb
-*.Z
-*.lz
-*.lzo
-
-# Coverage
-coverage/
-htmlcov/
-.coverage
-
-# OS
-.DS_Store
-Thumbs.db
-
-# Testing
-.mypy_cache/
-.pytest_cache/
+##############################################################
+# virtual machine crash logs                                 #
+# see http://www.java.com/en/download/help/error_hotspot.xml #
+##############################################################
+hs_err_pid*
+/.attach_pid*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ CHANGED:
 
 FIXED:
 
+- Argon2id verify(): a zero m/t/p parameter in an encoded hash is now rejected as malformed
+  (returns false) instead of reaching Bouncy Castle, which threw IllegalArgumentException; the
+  decode guard is now <= 0 rather than < 0.
+- restored projectSourceCompatibility to 25 and the curated .gitignore, both of which an
+  automated commit had reverted (to JDK 21 and a generic template) after the JDK 25 upgrade.
+- README: replaced the dead oss.sonatype.org (OSSRH, sunset 2025) links and badge with the
+  Maven Central Portal.
 - PBEFileEncryptor/PBEFileDecryptor and FileEncryptor/FileDecryptor decorators: the encryptor computed the decorated file
   content via CryptObjectDecoratorExtensions#decorateFile and then discarded it, encrypting the raw
   file - CryptObjectDecorators configured on the CryptModel had no effect on file encryption at all.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ then add the dependency to the dependencies area
 
 ## Maven dependency
 
-Maven dependency is now available on sonatype.
-Check out [sonatype repository](https://oss.sonatype.org/index.html#nexus-search;quick~mystic-crypt) for latest snapshots and releases.
+Maven dependency is available on Maven Central.
+Check out the [Maven Central page](https://central.sonatype.com/artifact/io.github.astrapi69/mystic-crypt) for the latest releases.
 
 You can first define the version properties and add than the following maven dependency to your project `pom.xml` if you want to import the core functionality of mystic-crypt:
 
@@ -254,10 +254,10 @@ Here is a list of awesome projects for cryptography:
 |Special thanks to [Travis CI](https://travis-ci.com) for providing a free continuous integration service for open source projects|
 |     <img width=1000/>     |
 
-|**Nexus Sonatype repositories**|
+|**Maven Central**|
 |     :---:      |
-|[![sonatype repository](https://img.shields.io/nexus/r/https/oss.sonatype.org/io.github.astrapi69/mystic-crypt.svg?style=for-the-badge)](https://oss.sonatype.org/index.html#nexus-search;gav~io.github.astrapi69~mystic-crypt~~~) mystic-crypt|
-|Special thanks to [sonatype repository](https://www.sonatype.com) for providing a free maven repository service for open source projects|
+|[![Maven Central](https://img.shields.io/maven-central/v/io.github.astrapi69/mystic-crypt.svg?style=for-the-badge&label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.astrapi69/mystic-crypt) mystic-crypt|
+|Special thanks to [Sonatype](https://www.sonatype.com) for providing the Maven Central Portal free for open source projects|
 |     <img width=1000/>     |
 
 |**codecov.io**|

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ######################
 projectVersion=10.5-SNAPSHOT
 groupPackage=io.github.astrapi69
-projectSourceCompatibility=21
+projectSourceCompatibility=25
 projectInceptionYear=2015
 projectHolderUsername=astrapi69
 projectLeaderName=Asterios Raptis

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/Argon2Support.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/Argon2Support.java
@@ -183,7 +183,10 @@ final class Argon2Support
 					throw new IllegalArgumentException("not a valid argon2id PHC-encoded hash");
 			}
 		}
-		if (memoryKB < 0 || iterations < 0 || parallelism < 0)
+		// Argon2 requires m >= 8 KB, t >= 1 and p >= 1; a zero (or negative) value is not a valid
+		// encoding, and letting it through would make Bouncy Castle throw from rawHash instead of
+		// verify() returning false for a malformed hash
+		if (memoryKB <= 0 || iterations <= 0 || parallelism <= 0)
 		{
 			throw new IllegalArgumentException("not a valid argon2id PHC-encoded hash");
 		}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/Argon2SupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/Argon2SupportTest.java
@@ -75,6 +75,14 @@ public class Argon2SupportTest
 				"$argon2id$v=19$m=8,t=-1,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
 			new MalformedHashCase("negative parallelism parameter",
 				"$argon2id$v=19$m=8,t=1,p=-1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			// zero is not a valid Argon2 parameter either; without the <= 0 guard it would slip
+			// through decode() and make Bouncy Castle throw from the hash itself
+			new MalformedHashCase("zero memory parameter",
+				"$argon2id$v=19$m=0,t=1,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("zero iterations parameter",
+				"$argon2id$v=19$m=8,t=0,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
+			new MalformedHashCase("zero parallelism parameter",
+				"$argon2id$v=19$m=8,t=1,p=0$c2FsdHNhbHRzYWx0c2E$aGFzaA"),
 			new MalformedHashCase("too few parts", "$argon2id$v=19$m=8,t=1,p=1$c2FsdA"));
 	}
 


### PR DESCRIPTION
Depends on #60 (branched from it). Three unrelated pre-release fixes.

## 1. JDK 25 restored — this blocks the release

`24c85269` (automated `qwen.ai[bot]` commit, "Update project configuration and build settings") set `projectSourceCompatibility` back to **21** after the JDK 25 upgrade, and replaced the curated `.gitignore` with a generic template.

Consequences: `develop` silently produced **Java 21 bytecode** despite the README and CI both saying JDK 25, and `./gradlew build` on the release commit fails outright:

```
Could not resolve io.github.astrapi69:crypt-api:10.0.0.
  > Dependency resolution is looking for a library compatible with JVM runtime version 21,
    but 'io.github.astrapi69:crypt-api:10.0.0' is only compatible with JVM runtime version 25 or newer.
```

Both reverted. Verified: compiled `Sha3Hasher.class` is now bytecode major 69 (Java 25).

## 2. Argon2 parameter validation

`Argon2Support.decode` guarded `m/t/p < 0`, so a **zero** parameter passed and reached Bouncy Castle, which threw `IllegalArgumentException` out of `verify()` instead of `verify()` returning `false` for a malformed hash. Guard is now `<= 0`; three zero-parameter cases added to `Argon2SupportTest`.

Found as a surviving PIT boundary mutant that the exceptions list had written off as equivalent — the round-2 fact-check of `docs/TESTING.md` checked that claim against Bouncy Castle and found it wrong. The mutant is now killed and the reason is gone from the list.

## 3. README

`oss.sonatype.org` links and the Nexus badge have been dead since OSSRH was sunset; replaced with the Maven Central Portal.

## Checks

`./gradlew build` green on JDK 25: 689 tests, 0 failures; line 98.89%, branch 97.82%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)