### PR TITLE
build: require manual approval before a release goes public

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -74,7 +74,12 @@ nmcp {
         // dedicated token pair.
         username = System.getenv("CENTRAL_PORTAL_TOKEN_USERNAME") ?: ""
         password = System.getenv("CENTRAL_PORTAL_TOKEN_PASSWORD") ?: ""
-        publishingType = "AUTOMATIC"
+        // USER_MANAGED, matching crypt-api and crypt-data: CI uploads the bundle and the Portal
+        // validates it, but the version stays unpublished until it is released by hand at
+        // https://central.sonatype.com. AUTOMATIC would release it the moment validation passes,
+        // and a released Maven Central version can never be changed or withdrawn - only
+        // superseded by a new one.
+        publishingType = "USER_MANAGED"
     }
 }
 


### PR DESCRIPTION
mystic-crypt was the only one of the three repositories still on `publishingType = "AUTOMATIC"`. `crypt-api` and `crypt-data` already use `USER_MANAGED`.

```diff
-        publishingType = "AUTOMATIC"
+        publishingType = "USER_MANAGED"
```

## Why this matters before 11.0.0

CI publishes on every push:

```yaml
if grep -q -- '-SNAPSHOT' gradle.properties; then
  ./gradlew publishAllPublicationsToCentralSnapshots
else
  ./gradlew publishAllPublicationsToCentralPortal
fi
```

So the moment `projectVersion` loses its `-SNAPSHOT` suffix and lands on `develop`:

| | `AUTOMATIC` | `USER_MANAGED` |
|---|---|---|
| Upload + validation | in CI | in CI |
| Release to Maven Central | **immediately, by the Portal** | waits for a human at [central.sonatype.com](https://central.sonatype.com) |
| If something is wrong | already public | discard the validated version, no trace |

A released Maven Central version can never be changed or withdrawn — only superseded by a new one. A mistake also consumes one of the monthly publishing slots.

Only real releases are affected. SNAPSHOT pushes go to the snapshot repository and never read this setting.

Verified: `./gradlew build` green, and `publishAllPublicationsToCentralPortal` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)