### PR TITLE
build: export the five transitive modules with compile scope

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,17 +3,17 @@ dependencies {
     implementation libs.commons.codec
     implementation libs.commons.io
     implementation libs.commons.lang3
-    implementation libs.guava
-    implementation libs.crypt.api
-    implementation libs.crypt.data
+    api libs.guava
+    api libs.crypt.api
+    api libs.crypt.data
     implementation libs.throwable
     implementation libs.randomizer
     implementation libs.file.worker
     implementation libs.silly.collection
     implementation libs.jobj.core
-    implementation libs.silly.bean
+    api libs.silly.bean
     implementation libs.jobj.cloner
-    implementation libs.bcprov.jdk18on
+    api libs.bcprov.jdk18on
     implementation libs.bcprov.ext.jdk18on
     implementation libs.bcpkix.jdk18on
     implementation libs.xml.base


### PR DESCRIPTION
Found while checking the freshly released 11.0.0 from a consumer's point of view: a project that declares **only** `io.github.astrapi69:mystic-crypt:11.0.0` cannot compile three of the six README examples.

```
error: package io.github.astrapi69.crypt.api.algorithm does not exist
error: package io.github.astrapi69.crypt.data.factory does not exist
```

`AesAlgorithm`, `MessageDigestAlgorithm` and `KeyPairGeneratorAlgorithm` live in crypt-api, `SecretKeyFactoryExtensions` in crypt-data — and both are published with `<scope>runtime</scope>`: on the runtime classpath, absent at compile time.

**Not a regression**: 10.1 has the same scopes. Long-standing, just never noticed because `ReadmeExamplesTest` compiles inside this repo, where the siblings are on the compile classpath anyway.

## The contradiction

`module-info.java` already names the modules whose types appear in this module's public API:

```java
requires transitive com.google.common;
requires transitive io.github.astrapi69.crypt.api;
requires transitive io.github.astrapisixtynine.crypt.data;
requires transitive org.bouncycastle.provider;
requires transitive io.github.astrapisixtynine.silly.bean;
```

but `gradle/dependencies.gradle` declared every dependency as `implementation`, so the POM said the opposite. Those five are now `api`; `java-library` publishes that as compile scope. The other thirteen stay `implementation`.

## Verification

- `generatePomFileForMavenJavaPublication`: exactly guava, crypt-api, crypt-data, silly-bean, bcprov-jdk18on as `compile`, the rest `runtime`
- full build green, 752 tests
- **a throwaway consumer that declares only `mystic-crypt:11.1-SNAPSHOT`** (published to mavenLocal with a throwaway signing key, no `mavenLocal` leak into this repo) compiles and runs all six README examples:

```
1 symmetric : attack at dawn
2 password  : true/false
3 signature : true
4 x25519    : true
5 ml-kem    : true
6 sha3      : 32 bytes
```

## For 11.0.0 users

Until this ships, add the two siblings explicitly:

```groovy
implementation 'io.github.astrapi69:mystic-crypt:11.0.0'
implementation 'io.github.astrapi69:crypt-api:10.0.0'
implementation 'io.github.astrapi69:crypt-data:11.0.0'
```

Whether this warrants an 11.0.1 or waits for 11.1 is a release-cadence decision, not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)