### PR TITLE
build: stop ignoring the gradle/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,6 @@
 ################
 /build
 /.gradle
-/gradle
 /out
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
`.gitignore` line 75 was `/gradle` — the whole directory that holds every build script this repo applies. The 14 files already tracked there were unaffected (git keeps tracking a file regardless of ignore rules), but any **new** file under `gradle/` would silently be left out of `git add -A`, and `git add gradle/x.gradle` refuses unless forced.

Noticed in #74: staging `gradle/dependencies.gradle` printed *"paths are ignored by one of your .gitignore files: gradle"*.

`/.gradle` (the local cache) stays ignored. After the change `git status gradle/` shows nothing new — there was nothing untracked waiting.

crypt-api and crypt-data carry the same line; separate PRs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)