### PR TITLE
refactor: remove a redundant guard in KeyCommittingAeadEncryptor

### DIFF
--- a/src/main/java/io/github/astrapi69/mystic/crypt/aead/KeyCommittingAeadEncryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/aead/KeyCommittingAeadEncryptor.java
@@ -164,7 +164,9 @@ public class KeyCommittingAeadEncryptor extends AbstractByteArrayEncryptor
 	{
 		byte[] keyBytes = commitmentKey.getEncoded();
 		byte[] input = ArrayUtils.addAll(keyBytes, iv);
-		if (associatedData != null && associatedData.length > 0)
+		// ArrayUtils.addAll with an empty array returns a content-identical copy of input, so
+		// checking associatedData.length > 0 first is redundant - only the null case matters
+		if (associatedData != null)
 		{
 			input = ArrayUtils.addAll(input, associatedData);
 		}
@@ -199,9 +201,10 @@ public class KeyCommittingAeadEncryptor extends AbstractByteArrayEncryptor
 		// Compute commitment tag over key, IV, and associated data
 		final byte[] commitmentTag = computeCommitmentTag(iv, associatedData);
 
-		// Include commitment tag in associated data for GCM
+		// Include commitment tag in associated data for GCM. ArrayUtils.addAll with an empty
+		// array is a content-identical copy, so only the null case needs distinguishing.
 		byte[] finalAssociatedData = commitmentTag;
-		if (associatedData != null && associatedData.length > 0)
+		if (associatedData != null)
 		{
 			finalAssociatedData = ArrayUtils.addAll(commitmentTag, associatedData);
 		}
@@ -271,9 +274,10 @@ public class KeyCommittingAeadEncryptor extends AbstractByteArrayEncryptor
 			throw new SecurityException("Commitment verification failed: key mismatch detected");
 		}
 
-		// Reconstruct associated data with commitment tag
+		// Reconstruct associated data with commitment tag. ArrayUtils.addAll with an empty array
+		// is a content-identical copy, so only the null case needs distinguishing.
 		byte[] finalAssociatedData = commitmentTag;
-		if (associatedData != null && associatedData.length > 0)
+		if (associatedData != null)
 		{
 			finalAssociatedData = ArrayUtils.addAll(commitmentTag, associatedData);
 		}


### PR DESCRIPTION
Bringing the mutation score toward 100% meant looking hard at every remaining survivor. This one turned out to be dead code, not untestable code — the mutant was a symptom, the guard was the actual problem.

## The guard was already redundant

Three sites (`computeCommitmentTag`, `encrypt`, `decrypt`) all guarded a call to `ArrayUtils.addAll(x, associatedData)`:

```diff
- if (associatedData != null && associatedData.length > 0)
+ if (associatedData != null)
  {
      finalAssociatedData = ArrayUtils.addAll(commitmentTag, associatedData);
  }
```

`ArrayUtils.addAll` with an empty second array returns a **content-identical copy** of the first — checked with a throwaway probe before touching production code:

```
sameRef=false equalContent=true
```

The `.length > 0` half of the condition never changed the outcome; only the null case matters.

## Numbers

| | before | after |
|---|---|---|
| Mutation score | 1000 / 1015 (98.5%) | **997 / 1009 (98.8%)** |
| Tests | 752 | 752 |
| Branch / line coverage | 100.0000% / 99.9115% | unchanged |

Kills the three `ConditionalsBoundaryMutator` survivors on the removed check (`:167`, `:204`, `:276`). Fewer total mutations generated — not because anything was excluded, but because the removed condition no longer exists for PIT to mutate.

## Verification

`clean build --no-build-cache --rerun-tasks`: green, 752 tests, 0 failures, BRANCH 100.0000%, LINE 99.9115% (unchanged from before this branch). `pitest` re-run from scratch, confirmed exactly these three gone and nothing new surviving.

## What's left, unchanged

The other 12 survivors — `System.exit` in the CLI `main` (unreachable by any in-process test), two bytecode-proven constant-rewritten-as-itself mutants (`Argon2Support`/`Pbkdf2Support`), five `FeldmanVSS` arithmetic equivalents, `ScryptHasher.isPowerOfTwo`, `KeystoreVerifier`, `CryptObjectDecoratorExtensions.endsWith`, `KemCommand.report` — all stay, each with its argument in `docs/COVERAGE_EXCEPTIONS.md`. None of them is dead code; killing any of them would require either weakening production code or writing a test that doesn't exercise real behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)