### PR TITLE
test: kill two survivors via reflection, and correct the record on why

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ correctly without being a cryptographer.**
 
 [![Java CI with Gradle](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml/badge.svg)](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml)
 [![Coverage Status](https://codecov.io/gh/astrapi69/mystic-crypt/branch/develop/graph/badge.svg)](https://codecov.io/gh/astrapi69/mystic-crypt)
-[![Mutation Coverage](https://img.shields.io/badge/mutation%20coverage-98%25-brightgreen)](https://pitest.org/)
+[![Mutation Coverage](https://img.shields.io/badge/mutation%20coverage-99%25-brightgreen)](https://pitest.org/)
 [![Open Issues](https://img.shields.io/github/issues/astrapi69/mystic-crypt.svg?style=flat)](https://github.com/astrapi69/mystic-crypt/issues)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.astrapi69/mystic-crypt.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.astrapi69/mystic-crypt)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](http://opensource.org/licenses/MIT)
@@ -234,7 +234,7 @@ Pull requests are welcome — fork [astrapi69/mystic-crypt](https://github.com/a
 and [open a PR](https://github.com/astrapi69/mystic-crypt/pull/new/develop) against `develop`.
 
 Please add tests for your change. This library sits at 99.91% line and 100% branch coverage with a
-98.8% PIT mutation score; the [conventions for contributors](docs/TESTING.md#conventions-for-contributors)
+99.0% PIT mutation score; the [conventions for contributors](docs/TESTING.md#conventions-for-contributors)
 describe what a good test looks like here — parameterized with records, a property assertion plus
 the matching negative case, and never lowering those numbers.
 

--- a/docs/COVERAGE_EXCEPTIONS.md
+++ b/docs/COVERAGE_EXCEPTIONS.md
@@ -35,7 +35,7 @@ reset digest). Removing the guards killed the mutants and simplified the method 
 (PR #5). See ["Why not literal 100%"](#why-not-literal-100) for how the remaining three were told
 apart from those two.
 
-## `mystic-crypt` - 2 lines / 0 branches uncovered; 12 surviving mutants of 1009
+## `mystic-crypt` - 2 lines / 0 branches uncovered; 10 surviving mutants of 1009
 
 Uncovered lines:
 
@@ -60,10 +60,6 @@ or try-with-resources makes `javac` route the value through a local, and the fil
 - `KeystoreVerifier.isKeystoreFile` (line 115): `return true;` after a successful `KeyStore.load`,
   split by try-with-resources into `iconst_1`/`istore 5` … `iload 5`/`ireturn`. Slot 5 has exactly
   one store, the constant. The `return false` in the catch is killed.
-- `CryptObjectDecoratorExtensions.endsWith` (line 141): the `return false;` inside
-  `if (ArrayUtils.isEmpty(suffix))`. The method is private with one caller, which on `true` would
-  call `removeFromEnd` with a zero-length suffix - `Arrays.copyOf(result, result.length)`, a
-  content-identical copy. The *other* `return false` (suffix does not match) is killed.
 
 **Boundary mutants whose two variants behave identically for every reachable input:**
 
@@ -74,9 +70,6 @@ or try-with-resources makes `javac` route the value through a local, and the fil
   difference at the equality boundaries is array *identity*, and `bytes` is a fresh allocation
   from `BigInteger.toByteArray()` or `Arrays.copyOfRange` that nothing aliases. Worked examples
   are in the `mutants/vss` commit message.
-- `ScryptHasher.isPowerOfTwo` (line 318): `n > 0` → `n >= 0`. Private, one caller
-  (`validateParameters`: `!isPowerOfTwo(n) || n < MIN_N`, `MIN_N == 2`). The answer changes only
-  for `n == 0`, where the second clause throws the identical `IllegalArgumentException`.
 
 **Observationally equivalent for another reason:**
 
@@ -113,17 +106,29 @@ earns its keep:
   "this condition is redundant" needed reading one level up, to the caller of the guarded call. Both
   are listed here rather than under "surviving mutants" above because the fix already shipped
   (PR #5, PR #76) - the record is kept as a reminder to ask the second question, not just the first.
+- `ScryptHasher.isPowerOfTwo:318` and `CryptObjectDecoratorExtensions.endsWith:141`: the equivalence
+  argument through each method's one caller was correct and still is - `validateParameters`
+  independently rejects `n == 0`, and `removeFromEnd` on an empty suffix returns a
+  content-identical copy either way. What was wrong was stopping there. Both are `private` methods
+  invokable via reflection, the same technique already used for the SRP wipe tests above, at zero
+  cost to production code. A reflective call asserting `isPowerOfTwo(0) == false` and
+  `endsWith(x, []) == false` tests the primitive's own contract directly, independent of whether
+  today's one caller happens to make the distinction unobservable - and kills both mutants. Fixed
+  once the question "could a test reach this without touching `src/main`" was actually asked
+  instead of assumed unaskable.
 
 ## Why not literal 100%
 
 `crypt-api` is at 100.0%. `crypt-data` is at 99.6% (3 survivors of 782) and `mystic-crypt` at
-98.8% (12 survivors of 1009). This section is the answer to "why not push those to 100% too" -
-worked through for every one of the 15 remaining survivors, not asserted in general. It was written
-after two rounds of exactly that push: the first round (PR #69) killed everything killable and
+99.0% (10 survivors of 1009). This section is the answer to "why not push those to 100% too" -
+worked through for every one of the 13 remaining survivors, not asserted in general. It was written
+after three rounds of exactly that push: the first round (PR #69) killed everything killable and
 argued the rest was equivalent; the second round (PR #5, PR #76) went back over every argued
 survivor a second time and found seven that were not equivalent at all, but dead code that
-*looked* like an equivalent mutant because nothing exercised the difference. Those seven are killed
-now (see above). What follows is what was left after that second pass, sorted by why it stays.
+*looked* like an equivalent mutant because nothing exercised the difference; a third round, prompted
+by asking whether a low-risk experiment could still find something, found two more that were
+killable through reflection alone, at zero cost to production code (see above). What follows is
+what was left after all three passes, sorted by why it stays.
 
 **Provably impossible - not a matter of effort.**
 
@@ -147,19 +152,14 @@ now (see above). What follows is what was left after that second pass, sorted by
   branches of `call` feed `report` two shared secrets that ML-KEM's correctness property guarantees
   are equal. The only way to make the `match=false` path reachable from `call` is for the KEM
   implementation to sometimes disagree with itself - a real defect, not a test improvement.
-- `KeystoreVerifier.isKeystoreFile:115` (`BooleanTrueReturnValsMutator`): `javap -c -l` shows the
-  survivor is fed by the same `iconst_1` that a successful `KeyStore.load` already produces; the
-  `try`-with-resources block is what routes it through a local slot PIT's constant-return filter
-  doesn't see through. Killable only by abandoning `try`-with-resources for manual resource
-  management, trading automatic cleanup for a mutation score.
-- `ScryptHasher.isPowerOfTwo:318` (`ConditionalsBoundaryMutator`): `private`, one caller, which
-  already rejects the one input (`n == 0`) where the boundary would matter via a second condition.
-  Killable only by widening the method's visibility beyond what any caller needs, so a test can
-  invoke it directly - encapsulation given up for a number.
-- `CryptObjectDecoratorExtensions.endsWith:141` (`BooleanTrueReturnValsMutator`): the empty-suffix
-  branch of a `private` method whose only caller replaces the array with a copy of itself either
-  way (see above) - the public method returns a `new String`, so the difference is array identity,
-  which nothing outside the method can observe without reflection.
+- `KeystoreVerifier.isKeystoreFile:115` (`BooleanTrueReturnValsMutator`): already `public`, so
+  unlike `ScryptHasher.isPowerOfTwo` and `CryptObjectDecoratorExtensions.endsWith` (fixed above),
+  reflection cannot change anything here - there is no private primitive further in for a test to
+  reach. `javap -c -l` shows the survivor is fed by the same `iconst_1` that a successful
+  `KeyStore.load` already produces on every execution of the success path, mutated or not; that
+  identity comes specifically from how `try`-with-resources compiles, not from encapsulation.
+  Killable only by abandoning `try`-with-resources for manual resource management, trading
+  automatic cleanup for a mutation score.
 - `EncryptedPrivateKeyReader.getKeyPair:104` (`PEMParser.close()`, `VoidMethodCallMutator`): this
   is the one case in the list that is **not dead code** - removing the call introduces a real
   resource leak. It survives because a leaked file descriptor is not something a unit test observes
@@ -175,9 +175,12 @@ now (see above). What follows is what was left after that second pass, sorted by
   current algorithm list, not merely unobservable. Restructuring to remove the fall-through would
   change nothing about test coverage and is a separate refactor, not a mutation-testing exercise.
 
-Conclusion: of the 15 individual surviving mutants, 3 are impossible under the current JDK and
-language (`System.exit`, and the two bytecode-identical `verify` mutants), 10 can only be killed by
-weakening a real design property (resource safety, encapsulation, absence of side channels, KEM
-correctness - the 5 `FeldmanVSS` mutants count as one design property, secret-reconstruction
-arithmetic), and the remaining 2 are unreachable dead code whose removal would be cosmetic. None of
-the fifteen is a case of "nobody got around to it yet."
+Conclusion: of the 13 individual surviving mutants, 3 are impossible under the current JDK and
+language (`System.exit`, and the two bytecode-identical `verify` mutants), 8 can only be killed by
+weakening a real design property (resource safety, a bytecode-compilation artifact of
+`try`-with-resources, absence of side channels, KEM correctness - the 5 `FeldmanVSS` mutants count
+as one design property, secret-reconstruction arithmetic), and the remaining 2 are unreachable dead
+code whose removal would be cosmetic. None of the thirteen is a case of "nobody got around to it
+yet" - and two mutants that briefly *were* exactly that (`ScryptHasher.isPowerOfTwo`,
+`CryptObjectDecoratorExtensions.endsWith`, both fixable by reflection alone) are why this list gets
+re-checked rather than taken as final.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,7 +89,7 @@ code the tests do run, how much would they notice being broken?".
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
 | `crypt-data` | `develop` @ `7effa34` (PR #5) | 1018 | 100.00% | 100.00% | 99.6% (779 / 782) | 99.6% |
-| `mystic-crypt` | `develop` @ `d2fa0824` (PR #76) | 752 | 99.91% | 100.00% | 98.8% (997 / 1009) | 98.9% |
+| `mystic-crypt` | `develop` @ `d810ee53` | 754 | 99.91% | 100.00% | 99.0% (999 / 1009) | 99.1% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.
@@ -97,12 +97,15 @@ Regenerate with the commands under [How to run](#how-to-run); the reports are
 `crypt-api` is the only one of the three at a literal 100% mutation score. The other two are not
 at 100% because the remaining survivors cannot be killed without making the code worse - see
 ["Why not literal 100%"](COVERAGE_EXCEPTIONS.md#why-not-literal-100) in
-[COVERAGE_EXCEPTIONS.md](COVERAGE_EXCEPTIONS.md) for the per-mutant reasoning. Two rounds of this
-cycle's work (PR #69/#76 for `mystic-crypt`, PR #5 for `crypt-data`) went specifically after every
-surviving mutant: the first round killed what was killable and documented the rest, a second pass
-re-examined every documented survivor and found seven that were dead code rather than genuinely
-untestable code - removing the redundant guard around them killed the mutant and simplified the
-method at the same time. What is left after both rounds is the floor, not something left undone.
+[COVERAGE_EXCEPTIONS.md](COVERAGE_EXCEPTIONS.md) for the per-mutant reasoning. Three rounds of this
+cycle's work went specifically after every surviving mutant: the first round (PR #69 for
+`mystic-crypt`) killed what was killable and documented the rest; a second pass (PR #5 for
+`crypt-data`, PR #76 for `mystic-crypt`) re-examined every documented survivor and found seven that
+were dead code rather than genuinely untestable code - removing the redundant guard around them
+killed the mutant and simplified the method at the same time; a third pass, prompted by asking
+whether a reflective test could reach a private method without touching production code, found two
+more that way at zero design cost. What is left after all three rounds is the floor, not something
+left undone.
 
 **What these numbers do not tell you.** The two uncovered lines in `mystic-crypt` are
 `MysticCryptCli.main`, which is `System.exit(execute(args))`: no in-process test can execute it

--- a/docs/blogs/why-we-stopped-short-of-100-percent-mutation-coverage.md
+++ b/docs/blogs/why-we-stopped-short-of-100-percent-mutation-coverage.md
@@ -176,6 +176,20 @@ None of the fifteen is unfinished. Each one is either physically impossible to k
 
 ---
 
+## A postscript: two of the fifteen, after all
+
+While preparing this piece, someone asked a fair question about the list above: could a low-risk experiment still turn up a real win among the fifteen, one worth keeping? Checking that question against each of them properly is what this whole post is arguing for, so it seemed dishonest not to actually do it before publishing.
+
+Thirteen held. Two didn't.
+
+`ScryptHasher.isPowerOfTwo` and the empty-suffix branch of `CryptObjectDecoratorExtensions.endsWith` had both been filed under "killable only by making the design worse" — one said it would need wider method visibility, the other noted reflection *could* observe the difference but stopped short of writing that test. Both were wrong in the same way: each is a `private` method whose current caller happens to make the boundary unobservable, but a test can still call the method directly through reflection and check its contract in isolation, at zero cost to the production code. It's the identical trick this post already used for the SRP password-buffer wipe, just not applied consistently the first time.
+
+Two mutants killed, no design compromised, the count moved to thirteen and the score from 98.8% to 99.0% for the larger library. The other thirteen are unchanged - still settled by proof, not effort, for the reasons already given above.
+
+Which is really the point twice over: mutation testing catches the bugs your first pass of reasoning misses, and it's just as good at catching the bugs in *that* reasoning, if you're willing to ask it the second time.
+
+---
+
 ## The actual takeaway
 
 A mutation score isn't a target. It's a question generator.

--- a/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
@@ -25,7 +25,10 @@
 package io.github.astrapi69.mystic.crypt.decorator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
@@ -630,5 +633,27 @@ public class CryptObjectDecoratorExtensionsTest
 		plain.deleteOnExit();
 		java.nio.file.Files.write(plain.toPath(), "payload".getBytes(StandardCharsets.UTF_8));
 		assertEquals("payload", CryptObjectDecoratorExtensions.undecorateFile(plain, decorator));
+	}
+
+	/**
+	 * Test method for the private {@code endsWith(byte[], byte[])} with an empty suffix. Through
+	 * the method's only current caller, {@code undecorateWithBytearrayDecorator}, the answer for an
+	 * empty suffix does not matter: {@code removeFromEnd} on a zero-length suffix returns a
+	 * content-identical copy of the array either way, so the public method's result is the same
+	 * regardless. That is exactly why a boolean-return mutant on this branch survives mutation
+	 * testing without this test - the primitive's own contract, "nothing ends with an empty
+	 * suffix", is untested and unenforced if this method is ever reused by different logic that
+	 * cares about the distinction. Invoked via reflection because the method is private; no
+	 * production code changed to make it testable.
+	 */
+	@Test
+	void endsWith_answersFalseForAnEmptySuffix()
+		throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+	{
+		final Method endsWith = CryptObjectDecoratorExtensions.class.getDeclaredMethod("endsWith",
+			byte[].class, byte[].class);
+		endsWith.setAccessible(true);
+
+		assertFalse((boolean)endsWith.invoke(null, new byte[] { 'x' }, new byte[0]));
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/ScryptHasherTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/ScryptHasherTest.java
@@ -31,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -202,6 +205,26 @@ class ScryptHasherTest
 
 		final byte[] hash16 = ScryptHasher.hashWithSalt(password.clone(), salt, 1024, 8, 1, 16);
 		assertEquals(16, hash16.length);
+	}
+
+	/**
+	 * Test method for the private {@code isPowerOfTwo(int)} at its zero boundary. Through the
+	 * method's only current caller, {@code validateParameters}, the answer at {@code n == 0} does
+	 * not matter: {@code !isPowerOfTwo(n) || n < MIN_N} throws either way, because the second
+	 * clause independently rejects zero. That redundancy is exactly why a boundary mutant on
+	 * {@code isPowerOfTwo} itself survives mutation testing without this test - the primitive's own
+	 * contract, "zero is not a power of two", is untested and unenforced if this method is ever
+	 * called from anywhere else. Invoked via reflection because the method is private; no
+	 * production code changed to make it testable.
+	 */
+	@Test
+	void isPowerOfTwo_answersFalseForZero()
+		throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+	{
+		final Method isPowerOfTwo = ScryptHasher.class.getDeclaredMethod("isPowerOfTwo", int.class);
+		isPowerOfTwo.setAccessible(true);
+
+		assertFalse((boolean)isPowerOfTwo.invoke(null, 0));
 	}
 
 }


### PR DESCRIPTION
Asterios asked whether a throwaway test branch could push toward 100% mutation score, cherry-picking back only real wins. Working through that question found something worth having asked: two of the ten mutants documented as "killable only by making the design worse" in `docs/COVERAGE_EXCEPTIONS.md` were miscategorized.

## The two

- `ScryptHasher.isPowerOfTwo:318` — documented as needing wider visibility to test. It doesn't; it's already reachable via reflection on the `private` method.
- `CryptObjectDecoratorExtensions.endsWith:141` — documented as "observable without reflection", correctly, but the reflective test was never actually written.

Both kill cleanly with a reflective call that touches **zero production code** — the same technique already used for the SRP password-buffer wipe tests earlier in this cycle:

```java
final Method isPowerOfTwo = ScryptHasher.class.getDeclaredMethod("isPowerOfTwo", int.class);
isPowerOfTwo.setAccessible(true);
assertFalse((boolean) isPowerOfTwo.invoke(null, 0));
```

Both are the primitive's own boundary contract ("zero is not a power of two", "nothing ends with an empty suffix"), tested directly rather than relying on today's one caller happening to make the difference unobservable — which stops mattering the moment the primitive gets reused somewhere the caller-level redundancy doesn't hold.

## What this does *not* mean

The other 8 survivors in that bucket — `FeldmanVSS` (5), `KemCommand` (1), `KeystoreVerifier` (1), `EncryptedPrivateKeyReader`'s `PEMParser.close()` (1) — are unaffected. Those are settled by algebra, a cryptographic correctness guarantee, or bytecode identity, not by insufficient effort; no branch experiment, reflective or otherwise, changes a mathematical proof. `docs/COVERAGE_EXCEPTIONS.md` now says explicitly why `KeystoreVerifier` in particular does *not* benefit from this trick: it's already `public`, so there's no private primitive for reflection to reach past.

## Verification

Applied both PIT mutations by hand before writing the real test (`isPowerOfTwo`'s `n > 0` → `n >= 0`; `endsWith`'s empty-suffix `return false` → `true`), confirmed both new tests fail, reverted. Full `pitest` re-run afterward confirms exactly these two gone and the other ten survivors byte-for-byte unchanged.

| | before | after |
|---|---|---|
| Mutation score | 997/1009 (98.8%) | **999/1009 (99.0%)** |
| Tests | 752 | 754 |
| Branch / line coverage | 100.0000% / 99.9115% | unchanged |

`clean build --no-build-cache --rerun-tasks --warning-mode all`: green, 0 deprecations, 0 javac warnings.

## Docs

`docs/COVERAGE_EXCEPTIONS.md` and `docs/TESTING.md` updated: both mutants moved out of the survivor list into "What was not accepted as equivalent" with an honest account of what the first write-up got wrong, all counts corrected (12→10 survivors, 15→13 total remaining across both repos, "two rounds"→"three rounds" of this push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)