### PR TITLE
chore: adopt the adaptive-learner rule set for the crypt family

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -1,0 +1,75 @@
+# Coding Standards
+
+Developer: Asterios Raptis (solo, AI-assisted). Goal: pragmatic, maintainable
+library code. No over-engineering. When unclear: ask rather than guess.
+
+## Java
+
+- JDK 25 toolchain, Gradle, JPMS module (`module-info.java` - a new public
+  package needs an `exports` entry there, and the consumer side must actually
+  resolve it: crypt-data packages are usable only if its module exports them).
+- Formatting and license headers via Spotless (`./gradlew spotlessApply`);
+  never hand-format against it.
+- Javadoc on every public type and member, in the established style of the
+  file's neighbors (including the explicit no-arg-constructor javadoc pattern
+  in the CLI package).
+- No emojis in code or comments. No em-dash; use hyphens or commas.
+
+## Naming
+
+- No generic names: `data`, `info`, `result`, `temp`, `item`, `obj`, `val`,
+  `tmp`, `x` are forbidden (exception: loop indices and lambdas). Name the
+  thing: `signatureBytes`, `keyAlgorithm`, `storeFile`.
+- No I-prefix for interfaces.
+- Test names describe behavior, not implementation:
+  `deletesExactlyTheGivenAliasAndKeepsTheStoreType`, not `testDelete`.
+
+## Function design and cohesion
+
+- One responsibility per method; over ~40 lines is a refactoring signal.
+- "Step 1 / Step 2" comments inside one method mean: split it.
+- Do not mix abstraction levels in one method; a high-level method calls
+  small, individually testable helpers.
+- Crash early: guard clauses at the top, not deeply nested if/else.
+- Shared data travels in a record, not in loose maps.
+- Hard to test is a design verdict, not a testing problem: a method that
+  needs a pile of scaffolding to exercise is cut wrong.
+
+## DRY and the Boy Scout Rule
+
+- Same logic or constant in two places: extract. Three duplicates: refactor
+  now, not later.
+- Leave touched code cleaner than found - if a touched function violates
+  these rules, fix the violation along with the change.
+
+## Git
+
+- Conventional Commits with scope where clear: `feat(cli): ...`,
+  `fix(keystore): ...`, `build:`, `docs:`, `test:`, `chore:`.
+- One commit per logical change - but atomic means "green individually", not
+  "one conceptual thing": when splitting would break an intermediate state
+  (source and test edits that only compile together), it is one commit.
+
+## Errors
+
+- Exceptions carry the reason and the offending value, precise enough that an
+  issue built from the message is actionable without follow-up questions:
+  `"unknown key algorithm 'X'. Use ..."` - never a bare `"failed"`.
+- Never swallow an exception; rethrow with context or let it propagate.
+- CLI exit codes are the contract; document them and keep error exits
+  distinguishable from domain results (see `verify-signature`: 0 valid,
+  1 invalid, 2 error).
+
+## Dependencies
+
+New dependencies only after asking, with a manual check on maintenance
+status and security. Prefer the existing stack: JDK, Bouncy Castle,
+crypt-api/crypt-data, picocli, JUnit 5. See library-first.md.
+
+## Security
+
+- Never commit keys, passwords or tokens - including test fixtures: test key
+  material is generated at test runtime, never checked in.
+- Secrets stay out of process argument lists where a stdin variant exists
+  (`--password-stdin` pattern) and are never echoed into logs or build
+  output.

--- a/.claude/rules/docs-and-numbers.md
+++ b/.claude/rules/docs-and-numbers.md
@@ -1,0 +1,60 @@
+# Documentation and numeric claims
+
+## Single source of truth for volatile numbers
+
+Test counts, coverage and mutation numbers live in ONE canonical place:
+the metrics table in `docs/TESTING.md` (with the commit hash each number was
+measured on) plus the survivor list in `docs/COVERAGE_EXCEPTIONS.md`. Other
+documents (README badge and contributing section, CHANGELOG) either reference
+them or are updated in the same commit that updates the table. Norms do not
+age, state assertions do: prose mentions the principle or the pointer, not a
+raw number that will go stale.
+
+## Numeric claims are measured, not remembered
+
+Any number reported anywhere (docs, commit messages, PR bodies, chat
+summaries) is verified by running the authoritative command in the same
+session:
+
+- Test count: sum of `tests` attributes in `build/test-results/test/*.xml`
+  after a full `./gradlew clean build`.
+- Line/branch coverage: `build/reports/jacoco/test/jacocoTestReport.xml`
+  counters.
+- Mutation score and survivors: `build/reports/pitest/mutations.xml` after
+  `./gradlew pitest` (note: a PIT run deletes
+  `src/test/resources/crypt/test.txt` - restore it and check `git status`
+  before staging anything).
+
+Grep output, memory of a previous count, or a number the user quoted are
+starting points, never authoritative. If the command cannot be run, mark the
+number "as of <date>".
+
+## CHANGELOG discipline
+
+The CHANGELOG entry for a release is part of the release commit, not an
+afterthought: rename the pending SNAPSHOT header to the version, fold in
+never-released SNAPSHOT sections, list the actual changes. (Both crypt-data
+and mystic-crypt had accumulated releases with untouched CHANGELOGs - this
+rule exists so that stops.)
+
+## Doc values are read from code, not from memory
+
+Every nameable reference in documentation - a Gradle task, a file path, a
+class or option name - is checked against the repo before it is written.
+
+## Definition of done
+
+A task is done when: the code is merged (or the PR is open per PR-PFLICHT),
+`./gradlew clean build` is green, tests for the change exist, the docs whose
+numbers or statements it touches are updated, and nothing needed for the
+change is left dangling.
+
+## Self-clarification
+
+When a question arises mid-task, in order: (1) answer it from repo evidence
+(git history, adjacent files, these rules) and note the basis; (2) park it -
+take the conservative assumption, mark the spot
+(`<!-- TODO(clarify): ... -->` or a code comment), continue; (3) stop and ask
+ONLY when it blocks meaningful progress or risks a destructive change. The
+final report lists parked questions and the assumptions taken - no silent
+guess ever ships.

--- a/.claude/rules/library-first.md
+++ b/.claude/rules/library-first.md
@@ -1,0 +1,42 @@
+# Library first - the implementation hierarchy
+
+Before writing any new utility, walk this hierarchy top-down and stop at the
+first level that fits. The PR/commit documents WHY a lower level was chosen.
+
+## 0. Never implement cryptographic primitives yourself
+
+Ciphers, hashes, signatures, KDFs, random generation, padding, encodings of
+key material: always the JDK or Bouncy Castle. Own code only orchestrates
+proven primitives. This level has no exceptions.
+
+## 1. JDK first
+
+`java.security`, `javax.crypto`, `java.util.HexFormat`, `java.nio.file`,
+`MessageDigest.isEqual` (constant-time comparison), records, switch
+expressions. The JDK has grown: Ed25519 since 15, ML-KEM/ML-DSA since 24 -
+check before assuming Bouncy Castle is needed.
+
+## 2. Bouncy Castle
+
+For what the JDK lacks (SLH-DSA, PEM/PKCS parsing via bcpkix, X.509
+building). Registered once via `SecurityProviderSupport.ensureBouncyCastle()`.
+
+## 3. The crypt family and existing io.github.astrapi69 libraries
+
+crypt-api (interfaces/enums), crypt-data (factories, readers, writers,
+extensions), then the wider silly-*/file-worker family. Check what exists
+before duplicating it here - but verify the API is actually usable from a
+JPMS module (exported package) and behaves correctly; a family API with a
+defect (e.g. a helper hardcoding a store type) is fixed at its source or
+consciously worked around with a comment saying why.
+
+## 4. A new dependency
+
+Only after asking, and only if 1-3 do not fit: maintained (recent releases),
+no known CVEs, sane transitive footprint, JPMS-capable (module or at least
+automatic module name).
+
+## 5. Write it yourself
+
+Smallest scope that works, library-grade (own tests, javadoc, no incidental
+coupling), and the reason documented in the PR.

--- a/.claude/rules/quality-gates.md
+++ b/.claude/rules/quality-gates.md
@@ -1,0 +1,63 @@
+# Quality gates
+
+## The bar
+
+100% branch coverage and the documented PIT mutation score are the release
+gate. Every uncovered line and every surviving mutant has a stated reason in
+`docs/COVERAGE_EXCEPTIONS.md` - reasons are argued per case, never asserted
+in general. Meaningful coverage is the goal: assertions on real behavior
+properties, regression pins for known bug classes - not line execution.
+Numbers are re-measured and the docs updated before every release
+(docs-and-numbers.md).
+
+## Cadence
+
+- `./gradlew clean build` (tests + Jacoco + Spotless) after every change -
+  the everyday gate.
+- `./gradlew pitest` after a feature phase and before a release - not on
+  every commit. Kill what is killable; document the rest with its reason.
+- A weakened assertion that a mutant survives (e.g. `contains("1 entries")`
+  also matching "-1 entries") is fixed by sharpening the assertion, never by
+  excluding the mutant.
+
+## Gates fail closed
+
+A check that cannot check must never report green. Absent tool, missing
+baseline, empty input set: that is a failure or an explicit skip with a
+reason, never a pass. "I could not check" is not "there is nothing to find".
+A gate that scans a set reports the size of the set - "0 findings" and
+"0 files looked at" must not print the same green.
+
+## Checks are disabled by declaration, not by silence
+
+Turning any check, hook or workflow off (or letting it degrade into a
+warn-and-return no-op) happens only visibly: in the diff, with a reason.
+A rule weakened inside a diff framed as cleanup/reflow is never accepted -
+either the change is content-neutral or it is declared and reviewed as a
+content change.
+
+## Wired is not working
+
+A new CI workflow, scheduled job or hook is triggered at least once in the
+same session it is wired, and the result of that first run is confirmed and
+noted. A workflow that ships without a known-good first run is a hypothesis,
+not a feature. (Concretely: `publish.yml` triggers on `RELEASE-*` tag pushes -
+after a manual Central publish, pushing that tag re-runs it as a duplicate.)
+
+## Stale is not flaky
+
+A test that fails deterministically on unchanged code is stale, not flaky:
+isolate it, time it, check whether the asserted element/behavior still exists
+(`git log <last-tag>..HEAD -- <spec>` proves whether the current diff touched
+it). Retries and timeouts are band-aids that mask stale assertions. When a
+feature is removed or changed by design, its tests are updated in the SAME
+change.
+
+## Real interfaces, real data
+
+Test tools through the interface they actually use (the CLI through
+`execute(...)`, key stores through real files in `@TempDir`), not through
+mocks of it - mocks hide the resolution and encoding behavior where the real
+bugs live. When a change rests on a prediction about data shape (a format, a
+heuristic, a mapping), run it against real data before landing and report
+what was found - a spec is a hypothesis, not a contract.

--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -1,0 +1,45 @@
+# Test-Driven Development
+
+Code changes with behavior (a new code path, a condition, a calculation, a
+validation, a mapping) follow Red-Green-Refactor:
+
+1. **RED** - write a test that describes the change; it MUST fail first.
+2. **GREEN** - the minimal code that makes it pass. YAGNI: nothing "for later".
+3. **REFACTOR** - clean up; tests stay green.
+
+## Four-test target per feature or fix
+
+1. **Reproduction test** - the failing test before the fix/feature.
+2. **Happy path** - the expected normal case.
+3. **Edge cases** - empty/missing/unexpected inputs.
+4. **Boundary values** - the edges of the valid range.
+
+Edge + boundary cases are normally ONE parameterized test (JUnit
+`@ParameterizedTest` with records/`@MethodSource`/`@CsvSource` and speaking
+case names - `test[3]` tells nobody what broke). No artificial tests just for
+counting; every test asserts a real behavior property, ideally paired with
+its matching negative case.
+
+## Bug fixes
+
+ALWAYS write the reproducing test first (RED, proves the bug), then fix until
+GREEN. The reproduction test stays in the repo as a regression guard.
+
+## Repo-specific conventions
+
+- CLI tests drive `MysticCryptCli.execute(...)` and assert the exit code and
+  captured stdout/stderr (`AbstractCliTest`), never `main`.
+- File-based tests use `@TempDir` with real files - no mocked file systems,
+  no mocked KeyStores. Test through the interface the user actually hits.
+- Every test class registers Bouncy Castle itself
+  (`SecurityProviderSupport.ensureBouncyCastle()` in `@BeforeAll`) - never
+  rely on another test class having done it.
+- Never delete, comment out or weaken an existing test to make the build
+  green.
+
+## Exceptions
+
+No TDD for: pure documentation, pure configuration without logic, mechanical
+refactors covered by the existing suite (which must stay green). None of the
+exceptions lift the hard rule that `./gradlew build` stays green after every
+change.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,74 @@
+# Workflow (adopted from adaptive-learner, adapted for the crypt-* family)
+
+These rules apply to mystic-crypt and, when working there, to crypt-api and
+crypt-data as well.
+
+## GITHUB-ISSUE-PFLICHT
+
+Every bug fix needs a GitHub issue BEFORE the fix begins.
+
+1. Search first (`gh issue list --search "<keywords>" --state all`); reopen a
+   closed issue if the bug recurred, do not file a duplicate.
+2. No fix without an issue - also retroactively: a NEW bug discovered while
+   working on another one gets its own issue before it is fixed.
+3. Commit subject and PR cite the issue: `(#NN)` or `Closes #NN`. `Refs` does
+   not auto-close; `Closes`/`Fixes` does.
+4. Verify the premise before filing: if the reported defect does not actually
+   exist, surface that finding instead - a false issue is worse than none.
+
+## PR-PFLICHT
+
+Every pushed code change gets a pull request against `develop` - whether or
+not the task asked for one. "No PR, wasn't requested" is not a valid
+completion report. Opening the PR is the last step of the change, in the same
+turn as the push.
+
+Exceptions: no code change; a release freeze; the user explicitly said
+"push only" for this task.
+
+## Priority order (fixed)
+
+1. Merge open PRs
+2. Bugs
+3. Infrastructure (CI, security, gates)
+4. Cleanup/refactoring
+5. Features
+6. Release
+
+## Release freeze
+
+While a release PR or release branch is open and the version is not yet
+tagged and published: no other merges to `develop`, no new feature PRs. Tag
+first, then continue. Exception: a fix that blocks the release itself.
+
+Releases follow the family order crypt-api -> crypt-data -> mystic-crypt;
+a downstream release commit is pushed only when the upstream version is
+actually resolvable on Maven Central.
+
+## Git discipline
+
+- Never `--amend` + force-push on an open PR - add a new commit instead
+  (squash-merge still yields one clean commit).
+- Never `git add -A` - add paths explicitly (PIT leaves files behind).
+- Do not add `Co-Authored-By` trailers attributing non-human collaborators
+  (AI tools, bots). Human co-authors only, unless an explicit note in the
+  commit body states who authorized the attribution.
+- Before preparing any release from a local copy: `git fetch` and compare
+  with origin first - a stale local line has already diverged once.
+
+## Claimed work is not executed work
+
+Before building on any claimed change - your own previous step included -
+verify the artifact, not the narrative: `git status`, `git log -1` (did HEAD
+move?), the gate's own exit code. A pre-commit hook can roll a commit back
+while printing "Passed".
+
+After every merge, check BOTH: is the referenced issue closed, and did the
+change actually land on the target branch (`git log origin/develop -- <path>`,
+read the diff)? A squash freezes the branch at merge time; a push made after
+the merge is silently lost.
+
+## Mass edits
+
+A proposed `sed`/regex sweep is inspected, not executed: read the matches,
+map each to its real target, apply individually, diff the result.


### PR DESCRIPTION
Adopts the transferable parts of adaptive-learner's `.claude/rules` into this repo, adapted for a JPMS Java crypto library: workflow duties (issue-first, PR-first, release freeze, git discipline), TDD with the four-test target, coding standards, the library-first hierarchy (never hand-roll crypto primitives), documentation/numeric-claims discipline, and quality-gate principles (fail-closed, wired-vs-working, stale-vs-flaky).

Docs-only changeset. Full report with the per-file verdicts: https://claude.ai/code/artifact/bf2c0bfa-ed06-4a11-b882-067f0e1f1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)