### PR TITLE
test: close the assertion gaps the rules-adoption audit surfaced

### DIFF
--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/SharedSecretEncryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/SharedSecretEncryptorTest.java
@@ -26,6 +26,7 @@ package io.github.astrapi69.mystic.crypt.key;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -113,5 +114,38 @@ public class SharedSecretEncryptorTest
 		actual = new String(decrypt, "UTF-8");
 
 		assertEquals(expected, actual);
+	}
+
+	/**
+	 * The matching negative case: a decryptor built from a third, unrelated key pair derives a
+	 * different shared secret, so the AES-GCM tag check must reject the ciphertext - the plaintext
+	 * must never come back for the wrong party.
+	 *
+	 * @throws Exception
+	 *             is thrown if any error occurs
+	 */
+	@Test
+	public void decrypt_withAnUnrelatedKeyPair_fails() throws Exception
+	{
+		Security.addProvider(new BouncyCastleProvider());
+
+		byte[] iv = new SecureRandom().generateSeed(16);
+		KeyPair keyPairBob = KeyPairGeneratorFactory
+			.newKeyPairGenerator("brainpoolp256r1", "ECDH", "BC").generateKeyPair();
+		KeyPair keyPairAlice = KeyPairGeneratorFactory
+			.newKeyPairGenerator("brainpoolp256r1", "ECDH", "BC").generateKeyPair();
+		KeyPair keyPairEve = KeyPairGeneratorFactory
+			.newKeyPairGenerator("brainpoolp256r1", "ECDH", "BC").generateKeyPair();
+
+		SharedSecretEncryptor encryptor = new SharedSecretEncryptor(keyPairBob.getPrivate(),
+			keyPairAlice.getPublic(), "ECDH", "AES", "BC", "AES/GCM/NoPadding", iv);
+		byte[] encrypted = encryptor
+			.encrypt("Hi there, whats up!".getBytes(StandardCharsets.UTF_8));
+
+		SharedSecretDecryptor eavesdropper = new SharedSecretDecryptor(keyPairEve.getPrivate(),
+			keyPairBob.getPublic(), "ECDH", "AES", "BC", "AES/GCM/NoPadding", iv);
+
+		assertThrows(Exception.class, () -> eavesdropper.decrypt(encrypted),
+			"a decryptor without the right key pair must fail the GCM tag check");
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/agreement/KeyToolFactoryTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/agreement/KeyToolFactoryTest.java
@@ -24,6 +24,9 @@
  */
 package io.github.astrapi69.mystic.crypt.key.agreement;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -41,6 +44,7 @@ import java.util.Date;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.astrapi69.collection.array.ArrayFactory;
 import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
@@ -55,10 +59,7 @@ import io.github.astrapi69.crypt.data.model.KeyStoreInfo;
 import io.github.astrapi69.crypt.data.model.Validity;
 import io.github.astrapi69.crypt.data.model.X509CertificateV1Info;
 import io.github.astrapi69.crypt.data.model.X509CertificateV3Info;
-import io.github.astrapi69.file.create.FileFactory;
 import io.github.astrapi69.file.create.model.FileInfo;
-import io.github.astrapi69.file.delete.DeleteFileExtensions;
-import io.github.astrapi69.file.search.PathFinder;
 import io.github.astrapi69.random.number.RandomBigIntegerFactory;
 
 /**
@@ -72,11 +73,14 @@ public class KeyToolFactoryTest
 	 * Test method for creating a keystore and a truststore using {@link KeyStoreInfo},
 	 * {@link KeyPairInfo}, and other related objects.
 	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
 	 * @throws Exception
 	 *             if any error occurs during the creation or saving of keystores
 	 */
 	@Test
-	public void testCreateKeyStoreAndTrustStoreWithInfoObjects() throws Exception
+	public void testCreateKeyStoreAndTrustStoreWithInfoObjects(@TempDir File temporaryDirectory)
+		throws Exception
 	{
 		Security.addProvider(new BouncyCastleProvider());
 		DistinguishedNameInfo distinguishedNameInfo;
@@ -122,7 +126,7 @@ public class KeyToolFactoryTest
 		privateKey = keyPair.getPrivate();
 
 		// Initialize a KeyStore and store the key pair and certificate
-		keystoreFile = FileFactory.newFile(PathFinder.getSrcTestResourcesDir(), "ssl-keystore.jks");
+		keystoreFile = new File(temporaryDirectory, "ssl-keystore.jks");
 		keystoreFileInfo = FileInfo.toFileInfo(keystoreFile);
 		keyStoreInfo = KeyStoreInfo.builder().fileInfo(keystoreFileInfo).type("JKS")
 			.keystorePassword(password).build();
@@ -130,27 +134,59 @@ public class KeyToolFactoryTest
 			certificateAlias, password);
 
 		// Initialize a KeyStore for the truststore and store the key pair and certificate
-		trustStoreFile = FileFactory.newFile(PathFinder.getSrcTestResourcesDir(),
-			"ssl-truststore.jks");
+		trustStoreFile = new File(temporaryDirectory, "ssl-truststore.jks");
 		trustStoreFileInfo = FileInfo.toFileInfo(trustStoreFile);
 		KeyStoreInfo trustStoreInfo = KeyStoreInfo.builder().fileInfo(trustStoreFileInfo)
 			.type("JKS").keystorePassword(password).build();
 		KeyStoreFactory.newKeystoreAndSaveForSsl(trustStoreInfo, privateKey, certificate,
 			certificateAlias, password);
-		// comment if you want to check with SecureServer and SecureClient
-		DeleteFileExtensions.delete(keystoreFile);
-		DeleteFileExtensions.delete(trustStoreFile);
+
+		// the written stores must be loadable and actually hold the entry
+		assertStoreHoldsTheEntry(keystoreFile, certificateAlias, privateKey, "Test Server");
+		assertStoreHoldsTheEntry(trustStoreFile, certificateAlias, privateKey, "Test Server");
+	}
+
+	/**
+	 * Reloads the given store file and asserts it holds the expected private-key entry with a
+	 * certificate for the expected subject - the behavior properties the two creation tests exist
+	 * to secure.
+	 *
+	 * @param storeFile
+	 *            the key store file to reload
+	 * @param alias
+	 *            the expected alias
+	 * @param expectedPrivateKey
+	 *            the private key that must be stored under the alias
+	 * @param expectedCommonName
+	 *            the common name the stored certificate's subject must contain
+	 * @throws Exception
+	 *             if loading fails
+	 */
+	private static void assertStoreHoldsTheEntry(File storeFile, String alias,
+		PrivateKey expectedPrivateKey, String expectedCommonName) throws Exception
+	{
+		KeyStore reloaded = KeyStoreFactory.loadKeyStore(storeFile, "JKS", "password");
+		assertTrue(reloaded.containsAlias(alias), "the alias must exist in " + storeFile);
+		assertEquals(expectedPrivateKey, reloaded.getKey(alias, "password".toCharArray()),
+			"the stored private key must be readable and equal to the generated one");
+		X509Certificate storedCertificate = (X509Certificate)reloaded.getCertificate(alias);
+		assertTrue(
+			storedCertificate.getSubjectX500Principal().getName()
+				.contains("CN=" + expectedCommonName),
+			"the stored certificate must carry the expected subject");
 	}
 
 	/**
 	 * Test method for creating a keystore and a truststore without using {@link KeyStoreInfo},
 	 * {@link KeyPairInfo}, and other related objects.
 	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
 	 * @throws Exception
 	 *             if any error occurs during the creation or saving of keystores
 	 */
 	@Test
-	public void testCreateKeyStoreAndTrustStore() throws Exception
+	public void testCreateKeyStoreAndTrustStore(@TempDir File temporaryDirectory) throws Exception
 	{
 		Security.addProvider(new BouncyCastleProvider());
 		KeyPair keyPair;
@@ -194,7 +230,7 @@ public class KeyToolFactoryTest
 		cert = CertFactory.newX509CertificateV3(keyPair, issuer, serial, notBefore, notAfter,
 			subject, signatureAlgorithm);
 
-		keystoreFile = FileFactory.newFile(PathFinder.getSrcTestResourcesDir(), "ssl-keystore.jks");
+		keystoreFile = new File(temporaryDirectory, "ssl-keystore.jks");
 
 		// Initialize a KeyStore and store the key pair and certificate
 		keyStore = KeyStoreFactory.newKeyStore(keystoreFile, "JKS", "password");
@@ -203,8 +239,7 @@ public class KeyToolFactoryTest
 		// Save the KeyStore to a file
 		KeyStoreExtensions.store(keyStore, keystoreFile, "password");
 
-		trustStoreFile = FileFactory.newFile(PathFinder.getSrcTestResourcesDir(),
-			"ssl-truststore.jks");
+		trustStoreFile = new File(temporaryDirectory, "ssl-truststore.jks");
 
 		// Initialize a KeyStore for the truststore and store the key pair and certificate
 		trustStore = KeyStoreFactory.newKeyStore(trustStoreFile, "JKS", "password");
@@ -212,9 +247,12 @@ public class KeyToolFactoryTest
 			new Certificate[] { cert });
 		// Save the KeyStore to a file
 		KeyStoreExtensions.store(trustStore, trustStoreFile, "password");
-		// comment if you want to check with SecureServer and SecureClient
-		DeleteFileExtensions.delete(keystoreFile);
-		DeleteFileExtensions.delete(trustStoreFile);
+
+		// the written stores must be loadable and actually hold the entry
+		assertStoreHoldsTheEntry(keystoreFile, certificateAlias, keyPair.getPrivate(),
+			"Tyler Durden");
+		assertStoreHoldsTheEntry(trustStoreFile, certificateAlias, keyPair.getPrivate(),
+			"Tyler Durden");
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordByteDecryptorTest.java
@@ -73,6 +73,32 @@ public class PasswordByteDecryptorTest
 	}
 
 	/**
+	 * Test method for {@link PasswordByteDecryptor#decrypt(byte[])} with the wrong password: the
+	 * core security property is that the plaintext never comes back. The cipher is unauthenticated
+	 * CBC, so a wrong key usually fails the padding check but can (about 1 in 256) produce garbage
+	 * instead of an exception - the assertion therefore accepts either, but never the plaintext.
+	 */
+	@Test
+	public void decrypt_withTheWrongPassword_neverYieldsThePlaintext() throws Exception
+	{
+		byte[] textBytes = "bar".getBytes(StandardCharsets.UTF_8);
+		byte[] encrypted = new PasswordByteEncryptor("foo").encrypt(textBytes);
+		PasswordByteDecryptor decryptor = new PasswordByteDecryptor("wrong-password");
+
+		try
+		{
+			byte[] decrypted = decryptor.decrypt(encrypted);
+			assertFalse(Arrays.equals(textBytes, decrypted),
+				"decrypting with the wrong password must never yield the plaintext");
+		}
+		catch (Exception exception)
+		{
+			assertFalse(exception instanceof IllegalArgumentException,
+				"the failure must come from the cipher, not from the length guard");
+		}
+	}
+
+	/**
 	 * Test method for {@link PasswordByteDecryptor#decrypt(byte[])}, encrypted data that is shorter
 	 * than the salt prefix has to be rejected
 	 */

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordFileDecryptorTest.java
@@ -25,6 +25,7 @@
 package io.github.astrapi69.mystic.crypt.pw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -196,5 +197,40 @@ public class PasswordFileDecryptorTest extends AbstractTestCase<String, String>
 	{
 		assertEquals(Cipher.DECRYPT_MODE,
 			new PasswordFileDecryptor(password, null).newOperationMode());
+	}
+
+	/**
+	 * Test method for {@link PasswordFileDecryptor#decrypt(File)} with the wrong password: the
+	 * plaintext must never come back. The cipher is unauthenticated CBC, so a wrong key usually
+	 * fails the padding check but can (about 1 in 256) produce garbage instead of an exception -
+	 * the assertion therefore accepts either, but never the original content.
+	 *
+	 * @param temporaryDirectory
+	 *            the temporary directory of this test
+	 * @throws Exception
+	 *             is thrown if an error occurs
+	 */
+	@Test
+	public void decrypt_withTheWrongPassword_neverYieldsThePlaintext(
+		@TempDir File temporaryDirectory) throws Exception
+	{
+		File source = new File(temporaryDirectory, "secret-message.txt");
+		StoreFileExtensions.toFile(source, "the quick brown fox jumps over the lazy dog");
+		File encryptedFile = new PasswordFileEncryptor(password,
+			new File(temporaryDirectory, "secret-message.enc")).encrypt(source);
+		PasswordFileDecryptor fileDecryptor = new PasswordFileDecryptor("wrong-password",
+			new File(temporaryDirectory, "decrypted.txt"));
+
+		try
+		{
+			File decryptedFile = fileDecryptor.decrypt(encryptedFile);
+			assertNotEquals(FileChecksumExtensions.getChecksum(source, MdAlgorithm.MD5.name()),
+				FileChecksumExtensions.getChecksum(decryptedFile, MdAlgorithm.MD5.name()),
+				"decrypting with the wrong password must never yield the original content");
+		}
+		catch (Exception exception)
+		{
+			// expected: the wrong key fails inside the cipher
+		}
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordStringDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PasswordStringDecryptorTest.java
@@ -64,4 +64,28 @@ public class PasswordStringDecryptorTest
 		assertEquals(text, decryptor.decrypt(firstEncrypted));
 		assertEquals(text, decryptor.decrypt(secondEncrypted));
 	}
+
+	/**
+	 * Test method for {@link PasswordStringDecryptor#decrypt(String)} with the wrong password: the
+	 * plaintext must never come back. The cipher is unauthenticated CBC, so a wrong key usually
+	 * fails the padding check but can (about 1 in 256) produce garbage instead of an exception -
+	 * the assertion therefore accepts either, but never the plaintext.
+	 */
+	@Test
+	public void decrypt_withTheWrongPassword_neverYieldsThePlaintext() throws Exception
+	{
+		String text = "bar";
+		String encrypted = new PasswordStringEncryptor("foo").encrypt(text);
+		PasswordStringDecryptor decryptor = new PasswordStringDecryptor("wrong-password");
+
+		try
+		{
+			assertNotEquals(text, decryptor.decrypt(encrypted),
+				"decrypting with the wrong password must never yield the plaintext");
+		}
+		catch (Exception exception)
+		{
+			// expected: the wrong key fails inside the cipher
+		}
+	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/secret/FeldmanVSSTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/secret/FeldmanVSSTest.java
@@ -185,16 +185,16 @@ class FeldmanVSSTest
 	void testReconstructSecretBytes()
 	{
 		byte[] originalSecret = "ByteTest".getBytes();
-		int expectedLength = 32;
 
 		ShareGenerationResult result = FeldmanVSS.splitSecret(originalSecret, 3, 5);
 
 		List<Share> subset = result.getShares().subList(0, 3);
 
-		BigInteger reconstructed = FeldmanVSS.reconstructSecret(subset, result.getCommitments(),
-			result.getCommitments().getQ());
+		byte[] reconstructed = FeldmanVSS.reconstructSecretBytes(subset, result.getCommitments(),
+			result.getCommitments().getQ(), originalSecret.length);
 
-		assertEquals(result.getSecret(), reconstructed, "Reconstructed BigInteger should match");
+		assertArrayEquals(originalSecret, reconstructed,
+			"the reconstructed bytes must equal the original secret");
 	}
 
 	@Test

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/Blake2bHasherTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/Blake2bHasherTest.java
@@ -31,14 +31,52 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class for {@link Blake2bHasher}.
  */
 class Blake2bHasherTest
 {
+
+	/**
+	 * A known-answer vector (RFC 7693). The expected digests were generated with
+	 * {@code printf '<input>' | openssl dgst -blake2b512 -r} and {@code b2sum -l 256}, so a
+	 * mismatch here means Bouncy Castle's BLAKE2b disagrees with OpenSSL/coreutils - not a typo in
+	 * this file. Without these, a mutant that swaps in any other keyed PRF would satisfy every
+	 * length/determinism/sensitivity assertion in this class.
+	 */
+	record Vector(String description, String input, int digestLength, String expectedHex) {
+	}
+
+	static Stream<Vector> knownAnswerVectors()
+	{
+		return Stream.of(
+			new Vector("empty input, 512 bit", "", 64,
+				"786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419"
+					+ "d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce"),
+			new Vector("abc, 512 bit", "abc", 64,
+				"ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1"
+					+ "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923"),
+			new Vector("empty input, 256 bit", "", 32,
+				"0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"),
+			new Vector("abc, 256 bit", "abc", 32,
+				"bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("knownAnswerVectors")
+	void testKnownAnswerVectors(Vector vector)
+	{
+		byte[] hash = Blake2bHasher.hash(vector.input().getBytes(StandardCharsets.UTF_8),
+			vector.digestLength());
+		assertEquals(vector.expectedHex(), HexFormat.of().formatHex(hash), vector.description());
+	}
 
 	@Test
 	void testHashDefaultLength()

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/Blake2sHasherTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/Blake2sHasherTest.java
@@ -31,14 +31,46 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class for {@link Blake2sHasher}.
  */
 class Blake2sHasherTest
 {
+
+	/**
+	 * A known-answer vector (RFC 7693). The expected digests were generated with
+	 * {@code printf '<input>' | openssl dgst -blake2s256 -r}, so a mismatch here means Bouncy
+	 * Castle's BLAKE2s disagrees with OpenSSL - not a typo in this file. Without these, a mutant
+	 * that swaps in any other hash would satisfy every length/determinism/sensitivity assertion in
+	 * this class.
+	 */
+	record Vector(String description, String input, String expectedHex) {
+	}
+
+	static Stream<Vector> knownAnswerVectors()
+	{
+		return Stream.of(
+			new Vector("empty input, 256 bit", "",
+				"69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"),
+			new Vector("abc, 256 bit", "abc",
+				"508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("knownAnswerVectors")
+	void testKnownAnswerVectors(Vector vector)
+	{
+		byte[] hash = Blake2sHasher.hash(vector.input().getBytes(StandardCharsets.UTF_8),
+			Blake2sHasher.DEFAULT_DIGEST_LENGTH);
+		assertEquals(vector.expectedHex(), HexFormat.of().formatHex(hash), vector.description());
+	}
 
 	@Test
 	void testHashDefaultLength()

--- a/src/test/java/io/github/astrapi69/mystic/crypt/sha/ScryptHasherTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/sha/ScryptHasherTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +43,24 @@ import org.junit.jupiter.api.Test;
  */
 class ScryptHasherTest
 {
+
+	/**
+	 * The RFC 7914 section 12 known-answer vector: scrypt(P="password", S="NaCl", N=1024, r=8, p=1,
+	 * dkLen=64). The expected hex was generated with {@code openssl kdf ... SCRYPT}, so a mismatch
+	 * here means Bouncy Castle's scrypt disagrees with OpenSSL - not a typo in this file. Without
+	 * it, a mutant that swaps in any other KDF would satisfy every existing assertion.
+	 */
+	@Test
+	void testKnownAnswerVectorFromRfc7914()
+	{
+		byte[] hash = ScryptHasher.hashWithSalt("password".toCharArray(),
+			"NaCl".getBytes(StandardCharsets.UTF_8), 1024, 8, 1, 64);
+
+		assertEquals(
+			"27b418c674c769d12501fbb1f53bac32df6514c0f28d043872b148b348961a79"
+				+ "057a6861cc3553246aa0ddb63bc074450b924022547a799538d603396835dd62",
+			HexFormat.of().formatHex(hash));
+	}
 
 	@Test
 	void testHashWithDefaultParameters()

--- a/src/test/java/io/github/astrapi69/mystic/crypt/simple/CharacterSetCryptTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/simple/CharacterSetCryptTest.java
@@ -91,24 +91,4 @@ public class CharacterSetCryptTest
 	/**
 	 * Test method for test utf-8 characters in a loop
 	 */
-	@Test
-	public void testUtf8Characters()
-	{
-		int count = 1;
-		for (int i = 0; i < 65536; i++)
-		{
-			char[] chars = Character.toChars(i);
-			char currentChar = chars[0];
-			Character c = Character.valueOf(currentChar);
-			if (Character.isDefined(i) && Character.isAlphabetic(i) && !Character.isIdeographic(i)
-				&& !Character.isISOControl(i) && Character.getType(currentChar) != 5)
-			{
-
-				System.out.println(
-					count + ":" + i + "=    " + c + "    ::" + Character.getType(currentChar));
-				count++;
-			}
-		}
-	}
-
 }


### PR DESCRIPTION
First follow-up to the adopted rule set (#82): an adversarially-verified audit compared the suite against tdd.md's four-test target and found real assertion gaps - tests that could not fail, missing wrong-key negatives on the PBE decryptors and the shared-secret cryptor, and hash/KDF classes without a single known-answer vector (an algorithm swap passed the whole suite). All vectors were generated locally with openssl/b2sum, per docs-and-numbers.md.

Full suite green; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)