### PR TITLE
chore: fail-closed quality gates, no duplicate release publish

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,14 @@
-# How to Contribute
+# How to contribute
 
-Your are welcome to create pull requests or join in our mailing list for bugfixes, documentations, examples, suggestions or anything else.
+Contributions are welcome - as GitHub issues and as pull requests.
+
+- **Found a bug?** Open an issue first, with enough context that the fix is
+  actionable (input, expected and actual behavior, stack trace). The fix then
+  starts with a failing test that reproduces the bug.
+- **Pull requests** go against the `develop` branch, one concern per PR, with
+  tests for every behavior change. `./gradlew clean build` must be green -
+  it runs the tests, the coverage gate and the Spotless format check.
+- **Conventions** for tests and code live in
+  [docs/TESTING.md](../docs/TESTING.md#conventions-for-contributors) and the
+  contributing section of the [README](../README.md#contributing); the
+  current coverage and mutation numbers are documented there as well.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,19 +30,22 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Execute Gradle build
         run: ./gradlew build
-        env:
-          ossrhUsername: ${{secrets.OSSRHUSERNAME}}
-          ossrhPassword: ${{secrets.OSSRHPASSWORD}}
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-      - name: Publish to Maven Central
+          # a broken upload must not read as green coverage tracking
+          fail_ci_if_error: true
+      # Snapshots only. A non-SNAPSHOT version on develop is deliberately NOT
+      # published here: the release commit reaches develop before the RELEASE-*
+      # tag, and publishing it from this push would duplicate the tag-triggered
+      # upload in publish.yml (#84).
+      - name: Publish snapshot to Maven Central
         if: github.event_name == 'push'
         run: |
           if grep -q -- '-SNAPSHOT' gradle.properties; then
             ./gradlew publishAllPublicationsToCentralSnapshots
           else
-            ./gradlew publishAllPublicationsToCentralPortal
+            echo "non-SNAPSHOT version: release publishing happens only via publish.yml (RELEASE-* tag)"
           fi
         env:
           CENTRAL_PORTAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_PORTAL_TOKEN_USERNAME }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/first-interaction@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Welcome to mystic-crypt and thanks for your first issue and helping us out to make our library better'' first issue'
-        pr-message: 'Welcome to mystic-crypt and thanks for your first pull request and helping us out to make our library better'' first pr'
+        issue-message: 'Welcome to mystic-crypt and thanks for your first issue - it helps us make the library better!'
+        pr-message: 'Welcome to mystic-crypt and thanks for your first pull request - it helps us make the library better!'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# mystic-crypt
+
+Java cryptography library (JDK 25, Gradle, JPMS module
+`io.github.astrapisixtynine.mystic.crypt`), published to Maven Central as
+`io.github.astrapi69:mystic-crypt`. Current version: see `gradle.properties`
+(`projectVersion`).
+
+Top of a three-repo family, released in this order:
+
+1. `crypt-api` - interfaces, enums (KeyPairGeneratorAlgorithm, KeystoreType, ...)
+2. `crypt-data` - factories, key readers/writers, extensions
+3. `mystic-crypt` - this repo: encryptors/decryptors, obfuscation, PQC
+   (ML-KEM, ML-DSA, SLH-DSA), SRP/JPAKE, and the picocli CLI
+
+All three live side by side under `~/dev/git/hub/astrapi69/`. A downstream
+release commit is pushed only when the upstream version is resolvable on
+Maven Central.
+
+## Layout
+
+- `src/main/java/.../mystic/crypt/` - one package per concern: `key` (signers,
+  verifiers, KEM, key exchange), `cli` (picocli commands, root
+  `MysticCryptCli`), `pw` (password hashing), `obfuscation`, `file`, `sha`,
+  `ssl`, `provider` (Bouncy Castle registration), ...
+- `docs/TESTING.md` - canonical test/coverage/mutation numbers (with the
+  commit they were measured on); `docs/COVERAGE_EXCEPTIONS.md` - every
+  uncovered line and surviving PIT mutant with its reason.
+- `gradle/*.gradle` - split build config (dependencies, testing,
+  mutation-testing, formatting, publishing, tagging).
+
+## Commands
+
+```
+./gradlew clean build      # tests + Jacoco + Spotless check - the everyday gate
+./gradlew spotlessApply    # format + license headers (run before committing)
+./gradlew pitest           # PIT mutation testing (minutes; restores needed:
+                           #   git checkout -- src/test/resources/crypt/test.txt)
+./gradlew publishAllPublicationsToCentralPortal   # Central upload (USER_MANAGED;
+                           # needs CENTRAL_PORTAL_TOKEN_USERNAME/PASSWORD env)
+./gradlew tagRelease       # RELEASE-X tag (tag push triggers publish.yml!)
+```
+
+## Conventions (details in .claude/rules/)
+
+- Gitflow on `develop`; every pushed change gets a PR (workflow.md).
+- Bug fixes: GitHub issue first, failing test first (tdd.md).
+- Quality bar: 100% branch coverage, ~99% PIT score, exceptions documented
+  per case (quality-gates.md).
+- Numbers in docs are measured, never remembered (docs-and-numbers.md).
+- Never hand-roll crypto primitives; JDK -> Bouncy Castle -> crypt family ->
+  new dependency, in that order (library-first.md).
+- Spotless owns formatting; no `git add -A` (PIT leftovers); no
+  `Co-Authored-By` trailers for non-human collaborators.
+
+## Session start
+
+1. `git fetch` and compare with origin before building on the local state -
+   this repo family has had a diverged never-pushed local line once.
+2. `git log --oneline -5` for recent context.
+3. `./gradlew build` for a green baseline before changing anything.

--- a/gradle/mutation-testing.gradle
+++ b/gradle/mutation-testing.gradle
@@ -9,4 +9,9 @@ pitest {
     threads = 4
     outputFormats = ["HTML", "XML"]
     timestampedReports = false
+    // fail-closed floor for the documented mutation score (docs/TESTING.md:
+    // 99.1% with every survivor argued in docs/COVERAGE_EXCEPTIONS.md) - a
+    // run that falls under 99% fails instead of relying on someone reading
+    // the HTML report
+    mutationThreshold = 99
 }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -13,4 +13,22 @@ jacocoTestReport {
     }
 }
 
+// The documented quality bar (docs/TESTING.md) enforced, not just measured:
+// the build fails when branch coverage drops below 100%. Line coverage is not
+// gated because the two System.exit lines in MysticCryptCli#main are a
+// documented, argued exception (docs/COVERAGE_EXCEPTIONS.md).
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 1.0
+            }
+        }
+    }
+}
+jacocoTestCoverageVerification.dependsOn test
+
 check.dependsOn jacocoTestReport
+check.dependsOn jacocoTestCoverageVerification


### PR DESCRIPTION
Second follow-up to the adopted rule set (#82), repo-hygiene findings from the adversarially-verified audit. Closes #84.

- CI publishes snapshots only from develop pushes; releases go exclusively through the RELEASE-* tag workflow - the same release is no longer uploaded twice (#84).
- The documented quality bar is now enforced, not just measured: Jacoco branch-coverage verification (RED-proven before committing) and a PIT mutationThreshold floor.
- Codecov upload fails closed; dead OSSRH env wiring removed; CONTRIBUTING stub replaced; greetings quoting fixed.
- Also carries the CLAUDE.md that was stranded on the merged #82 branch (pushed 30s after the merge - exactly the lesson the new rules document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)