### PR TITLE
test: parameterize sibling tests into record-based case lists

### DIFF
--- a/src/test/java/io/github/astrapi69/mystic/crypt/base/BaseByteArrayEnDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/base/BaseByteArrayEnDecryptorTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -38,6 +39,8 @@ import javax.crypto.spec.PBEKeySpec;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
 import io.github.astrapi69.crypt.api.algorithm.compound.CompoundAlgorithm;
@@ -92,32 +95,37 @@ public class BaseByteArrayEnDecryptorTest
 	}
 
 	/**
-	 * Regression test proving GCM support: a caller who explicitly opts into
-	 * {@link MysticSymmetricAlgorithm#AES_GCM_NO_PADDING} must be able to round-trip through
+	 * Regression test proving AEAD support: a caller who explicitly opts into an AEAD algorithm
+	 * must be able to round-trip through
 	 * {@link BaseByteArrayEncryptor}/{@link BaseByteArrayDecryptor}, and two encryptions of the
-	 * same plaintext must produce different ciphertext (a fresh nonce per call). Before this fix,
-	 * {@link BaseByteArrayDecryptor}'s construction-time cached cipher had no way to receive a
-	 * per-message GCM nonce and threw immediately.
+	 * same plaintext must produce different ciphertext (a fresh nonce per call). Before the GCM
+	 * fix, {@link BaseByteArrayDecryptor}'s construction-time cached cipher had no way to receive a
+	 * per-message nonce and threw immediately.
 	 *
+	 * @param testCase
+	 *            the AEAD case
 	 * @throws Exception
 	 *             is thrown if a security error occurs
 	 */
-	@Test
-	public void testEncryptDecryptWithGcm() throws Exception
+	@ParameterizedTest
+	@MethodSource("aeadCases")
+	public void testEncryptDecryptWithAeadAlgorithm(AeadCase testCase) throws Exception
 	{
-		SecretKey gcmKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.name(), 128);
-		CryptModel<Cipher, SecretKey, String> gcmModel = CryptModel
-			.<Cipher, SecretKey, String> builder().key(gcmKey)
-			.algorithm(MysticSymmetricAlgorithm.AES_GCM_NO_PADDING).build();
+		SecretKey secretKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.name(),
+			testCase.keyBits());
+		CryptModel<Cipher, SecretKey, String> cryptModel = CryptModel
+			.<Cipher, SecretKey, String> builder().key(secretKey).algorithm(testCase.algorithm())
+			.build();
 
-		BaseByteArrayEncryptor encryptor = new BaseByteArrayEncryptor(gcmModel);
-		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(gcmModel);
+		BaseByteArrayEncryptor encryptor = new BaseByteArrayEncryptor(cryptModel);
+		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(cryptModel);
 		byte[] plainMessageBytes = "the quick brown fox jumps over the lazy dog"
 			.getBytes(StandardCharsets.UTF_8);
 
 		byte[] firstEncrypted = encryptor.encrypt(plainMessageBytes);
 		byte[] secondEncrypted = encryptor.encrypt(plainMessageBytes);
-		assertFalse(Arrays.equals(firstEncrypted, secondEncrypted));
+		assertFalse(Arrays.equals(firstEncrypted, secondEncrypted),
+			testCase.description() + ": a fresh nonce per call must vary the ciphertext");
 
 		assertEquals(new String(plainMessageBytes, StandardCharsets.UTF_8),
 			new String(decryptor.decrypt(firstEncrypted), StandardCharsets.UTF_8));
@@ -126,36 +134,19 @@ public class BaseByteArrayEnDecryptorTest
 	}
 
 	/**
-	 * Test method proving ChaCha20-Poly1305 support: a caller who explicitly opts into
-	 * {@link MysticSymmetricAlgorithm#CHACHA20_POLY1305} must be able to round-trip through
-	 * {@link BaseByteArrayEncryptor}/{@link BaseByteArrayDecryptor}, and two encryptions of the
-	 * same plaintext must produce different ciphertext (a fresh nonce per call). ChaCha20 keys must
-	 * be exactly 32 bytes (256 bits), unlike AES which also accepts 128/192 bits.
-	 *
-	 * @throws Exception
-	 *             is thrown if a security error occurs
+	 * One AEAD round-trip case. ChaCha20 keys must be exactly 32 bytes (256 bits), unlike AES-GCM
+	 * which also accepts 128 bits - that is why the key size is part of the case.
 	 */
-	@Test
-	public void testEncryptDecryptWithChaCha20Poly1305() throws Exception
+	record AeadCase(String description, MysticSymmetricAlgorithm algorithm, int keyBits) {
+	}
+
+	static Stream<AeadCase> aeadCases()
 	{
-		SecretKey chaChaKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.name(), 256);
-		CryptModel<Cipher, SecretKey, String> chaChaModel = CryptModel
-			.<Cipher, SecretKey, String> builder().key(chaChaKey)
-			.algorithm(MysticSymmetricAlgorithm.CHACHA20_POLY1305).build();
-
-		BaseByteArrayEncryptor encryptor = new BaseByteArrayEncryptor(chaChaModel);
-		BaseByteArrayDecryptor decryptor = new BaseByteArrayDecryptor(chaChaModel);
-		byte[] plainMessageBytes = "the quick brown fox jumps over the lazy dog"
-			.getBytes(StandardCharsets.UTF_8);
-
-		byte[] firstEncrypted = encryptor.encrypt(plainMessageBytes);
-		byte[] secondEncrypted = encryptor.encrypt(plainMessageBytes);
-		assertFalse(Arrays.equals(firstEncrypted, secondEncrypted));
-
-		assertEquals(new String(plainMessageBytes, StandardCharsets.UTF_8),
-			new String(decryptor.decrypt(firstEncrypted), StandardCharsets.UTF_8));
-		assertEquals(new String(plainMessageBytes, StandardCharsets.UTF_8),
-			new String(decryptor.decrypt(secondEncrypted), StandardCharsets.UTF_8));
+		return Stream.of(
+			new AeadCase("AES/GCM/NoPadding, 128-bit key",
+				MysticSymmetricAlgorithm.AES_GCM_NO_PADDING, 128),
+			new AeadCase("ChaCha20-Poly1305, 256-bit key",
+				MysticSymmetricAlgorithm.CHACHA20_POLY1305, 256));
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KemCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KemCommandTest.java
@@ -136,25 +136,4 @@ class KemCommandTest extends AbstractCliTest
 		assertNotEquals(0, run("kem", "--algorithm", "ML-KEM-999"));
 	}
 
-	@org.junit.jupiter.api.Test
-	void reportReturnsOneAndReportsNoMatchForDifferingSecrets()
-	{
-		java.io.PrintStream originalOut = System.out;
-		java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
-		System
-			.setOut(new java.io.PrintStream(buffer, true, java.nio.charset.StandardCharsets.UTF_8));
-		int exitCode;
-		try
-		{
-			exitCode = KemCommand.report("test", new byte[] { 9 }, new byte[] { 1 },
-				new byte[] { 2 });
-		}
-		finally
-		{
-			System.setOut(originalOut);
-		}
-		assertEquals(1, exitCode, "differing secrets must return exit code 1");
-		assertTrue(buffer.toString(java.nio.charset.StandardCharsets.UTF_8)
-			.contains("shared secrets do not match"));
-	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/decorator/CryptObjectDecoratorExtensionsTest.java
@@ -156,52 +156,54 @@ public class CryptObjectDecoratorExtensionsTest
 	}
 
 	/**
-	 * Test method for the decoration of an crypt object with {@link CryptObjectDecorator} with byte
-	 * array as prefix and suffix
+	 * One decorate/undecorate edge case around empty prefixes and suffixes - the cases the CSV
+	 * files cannot carry, because an empty CSV field arrives as {@code null}, not as {@code ""}.
+	 * The empty-suffix case is the corner the {@code endsWith} mutant of the third mutation round
+	 * lived in.
 	 */
-	@Test
-	public void testDecorateWithByteArrayDecorator()
+	record PrefixSuffixCase(String description, String prefix, String suffix, String expected) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	static Stream<PrefixSuffixCase> decorateEdgeCases()
 	{
-		String actual;
-		String expected;
-		String toEncrypt;
-		CryptObjectDecorator<byte[]> decorator;
-		Charset utf8 = Charset.forName("UTF-8");
+		return Stream.of(new PrefixSuffixCase("prefix and suffix", "s", "s", "smiles"),
+			new PrefixSuffixCase("empty prefix", "", "s", "miles"),
+			new PrefixSuffixCase("empty suffix", "s", "", "smile"),
+			new PrefixSuffixCase("empty prefix and suffix", "", "", "mile"));
+	}
 
-		toEncrypt = "mile";
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("s".getBytes(utf8))
-			.suffix("s".getBytes(utf8)).build();
+	static Stream<PrefixSuffixCase> undecorateEdgeCases()
+	{
+		return Stream.of(new PrefixSuffixCase("prefix and suffix", "s", "s", "mile"),
+			new PrefixSuffixCase("empty prefix", "", "s", "smile"),
+			new PrefixSuffixCase("empty suffix", "s", "", "miles"),
+			new PrefixSuffixCase("empty prefix and suffix", "", "", "smiles"));
+	}
 
-		actual = CryptObjectDecoratorExtensions.decorateWithBytearrayDecorator(toEncrypt, decorator,
-			utf8);
-		expected = "smiles";
-		assertEquals(actual, expected);
+	/**
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#decorateWithBytearrayDecorator(String, CryptObjectDecorator, Charset)}
+	 * with empty prefixes and suffixes
+	 *
+	 * @param testCase
+	 *            the edge case
+	 */
+	@ParameterizedTest
+	@MethodSource("decorateEdgeCases")
+	public void decorateWithBytearrayDecorator_handlesEmptyPrefixAndSuffix(
+		PrefixSuffixCase testCase)
+	{
+		CryptObjectDecorator<byte[]> decorator = CryptObjectDecorator.<byte[]> builder()
+			.prefix(testCase.prefix().getBytes(StandardCharsets.UTF_8))
+			.suffix(testCase.suffix().getBytes(StandardCharsets.UTF_8)).build();
 
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("".getBytes(utf8))
-			.suffix("s".getBytes(utf8)).build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithBytearrayDecorator(toEncrypt, decorator,
-			utf8);
-		expected = "miles";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("s".getBytes(utf8))
-			.suffix("".getBytes(utf8)).build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithBytearrayDecorator(toEncrypt, decorator,
-			utf8);
-		expected = "smile";
-		assertEquals(actual, expected);
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("".getBytes(utf8))
-			.suffix("".getBytes(utf8)).build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithBytearrayDecorator(toEncrypt, decorator,
-			utf8);
-		expected = "mile";
-		assertEquals(actual, expected);
+		assertEquals(testCase.expected(), CryptObjectDecoratorExtensions
+			.decorateWithBytearrayDecorator("mile", decorator, StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -225,90 +227,43 @@ public class CryptObjectDecoratorExtensionsTest
 	}
 
 	/**
-	 * Test method for the decoration of an crypt object with {@link CryptObjectDecorator}
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#decorateWithStringDecorator(String, CryptObjectDecorator)}
+	 * with empty prefixes and suffixes
+	 *
+	 * @param testCase
+	 *            the edge case
 	 */
-	@Test
-	public void testDecorateWithStringDecorator()
+	@ParameterizedTest
+	@MethodSource("decorateEdgeCases")
+	public void decorateWithStringDecorator_handlesEmptyPrefixAndSuffix(PrefixSuffixCase testCase)
 	{
-		String actual;
-		String expected;
-		String toEncrypt;
-		CryptObjectDecorator<String> decorator;
+		CryptObjectDecorator<String> decorator = CryptObjectDecorator.<String> builder()
+			.prefix(testCase.prefix()).suffix(testCase.suffix()).build();
 
-		toEncrypt = "mile";
-		decorator = CryptObjectDecorator.<String> builder().prefix("s").suffix("s").build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithStringDecorator(toEncrypt, decorator);
-		expected = "smiles";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("").suffix("s").build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithStringDecorator(toEncrypt, decorator);
-		expected = "miles";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("s").suffix("").build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithStringDecorator(toEncrypt, decorator);
-		expected = "smile";
-		assertEquals(actual, expected);
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("").suffix("").build();
-
-		actual = CryptObjectDecoratorExtensions.decorateWithStringDecorator(toEncrypt, decorator);
-		expected = "mile";
-		assertEquals(actual, expected);
+		assertEquals(testCase.expected(),
+			CryptObjectDecoratorExtensions.decorateWithStringDecorator("mile", decorator));
 	}
 
 	/**
-	 * Test method for undecorate an crypt object with {@link CryptObjectDecorator} with byte array
-	 * as prefix and suffix
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateWithBytearrayDecorator(String, CryptObjectDecorator)}
+	 * with empty prefixes and suffixes
+	 *
+	 * @param testCase
+	 *            the edge case
 	 */
-	@Test
-	public void testUndecorateWithByteArrayDecorator()
+	@ParameterizedTest
+	@MethodSource("undecorateEdgeCases")
+	public void undecorateWithBytearrayDecorator_handlesEmptyPrefixAndSuffix(
+		PrefixSuffixCase testCase)
 	{
-		String actual;
-		String expected;
-		String toEncrypt;
-		CryptObjectDecorator<byte[]> decorator;
+		CryptObjectDecorator<byte[]> decorator = CryptObjectDecorator.<byte[]> builder()
+			.prefix(testCase.prefix().getBytes(StandardCharsets.UTF_8))
+			.suffix(testCase.suffix().getBytes(StandardCharsets.UTF_8)).build();
 
-		toEncrypt = "smiles";
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("s".getBytes())
-			.suffix("s".getBytes()).build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithBytearrayDecorator(toEncrypt,
-			decorator);
-		expected = "mile";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("".getBytes())
-			.suffix("s".getBytes()).build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithBytearrayDecorator(toEncrypt,
-			decorator);
-		expected = "smile";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("s".getBytes())
-			.suffix("".getBytes()).build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithBytearrayDecorator(toEncrypt,
-			decorator);
-		expected = "miles";
-		assertEquals(actual, expected);
-		// new scenario ...
-		decorator = CryptObjectDecorator.<byte[]> builder().prefix("".getBytes())
-			.suffix("".getBytes()).build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithBytearrayDecorator(toEncrypt,
-			decorator);
-		expected = "smiles";
-		assertEquals(actual, expected);
+		assertEquals(testCase.expected(),
+			CryptObjectDecoratorExtensions.undecorateWithBytearrayDecorator("smiles", decorator));
 	}
 
 	/**
@@ -332,42 +287,22 @@ public class CryptObjectDecoratorExtensionsTest
 	}
 
 	/**
-	 * Test method for undecorate an crypt object with {@link CryptObjectDecorator}
+	 * Test method for
+	 * {@link CryptObjectDecoratorExtensions#undecorateWithStringDecorator(String, CryptObjectDecorator)}
+	 * with empty prefixes and suffixes
+	 *
+	 * @param testCase
+	 *            the edge case
 	 */
-	@Test
-	public void testUndecorateWithStringDecorator()
+	@ParameterizedTest
+	@MethodSource("undecorateEdgeCases")
+	public void undecorateWithStringDecorator_handlesEmptyPrefixAndSuffix(PrefixSuffixCase testCase)
 	{
-		String actual;
-		String expected;
-		String toEncrypt;
-		CryptObjectDecorator<String> decorator;
+		CryptObjectDecorator<String> decorator = CryptObjectDecorator.<String> builder()
+			.prefix(testCase.prefix()).suffix(testCase.suffix()).build();
 
-		toEncrypt = "smiles";
-		decorator = CryptObjectDecorator.<String> builder().prefix("s").suffix("s").build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithStringDecorator(toEncrypt, decorator);
-		expected = "mile";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("").suffix("s").build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithStringDecorator(toEncrypt, decorator);
-		expected = "smile";
-		assertEquals(actual, expected);
-
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("s").suffix("").build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithStringDecorator(toEncrypt, decorator);
-		expected = "miles";
-		assertEquals(actual, expected);
-		// new scenario ...
-		decorator = CryptObjectDecorator.<String> builder().prefix("").suffix("").build();
-
-		actual = CryptObjectDecoratorExtensions.undecorateWithStringDecorator(toEncrypt, decorator);
-		expected = "smiles";
-		assertEquals(actual, expected);
+		assertEquals(testCase.expected(),
+			CryptObjectDecoratorExtensions.undecorateWithStringDecorator("smiles", decorator));
 	}
 
 

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/FileEncryptDecryptorTest.java
@@ -30,12 +30,15 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.checksum.FileChecksumExtensions;
 import io.github.astrapi69.crypt.api.algorithm.MdAlgorithm;
@@ -86,22 +89,96 @@ public class FileEncryptDecryptorTest extends AbstractTestCase<String, String>
 	 * @throws Exception
 	 *             is thrown if any error occurs on the execution
 	 */
-	@Test
-	public void testEncryptDecryptConstructorFiles() throws Exception
+	/**
+	 * One constructor-variant case: the encrypt-decrypt-checksum round trip is identical, only how
+	 * encryptor and decryptor are constructed differs.
+	 */
+	record ConstructorCase(String description, FileEncryptorFactory encryptorFactory,
+		FileDecryptorFactory decryptorFactory) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	/** Builds the encryptor of one constructor variant. */
+	@FunctionalInterface
+	interface FileEncryptorFactory
 	{
-		// new scenario...
-		File encryptedCnstr = new File(cryptDir, "encryptedCnstr.enc");
-		File decryptedCnstr = new File(cryptDir, "decryptedCnstr.decrypted");
-		encryptor = new FileEncryptor(cryptModel, encryptedCnstr);
+		FileEncryptor create(CryptModel<Cipher, String, String> model, File directory)
+			throws Exception;
+	}
+
+	/** Builds the decryptor of one constructor variant. */
+	@FunctionalInterface
+	interface FileDecryptorFactory
+	{
+		FileDecryptor create(CryptModel<Cipher, String, String> model, File directory)
+			throws Exception;
+	}
+
+	static Stream<ConstructorCase> constructorCases()
+	{
+		return Stream.of(
+			new ConstructorCase("constructor files",
+				(model, directory) -> new FileEncryptor(model,
+					new File(directory, "encryptedCnstr.enc")),
+				(model, directory) -> new FileDecryptor(model,
+					new File(directory, "decryptedCnstr.decrypted"))),
+			new ConstructorCase("default file name convention",
+				(model, directory) -> new FileEncryptor(model),
+				(model, directory) -> new FileDecryptor(model)),
+			new ConstructorCase("factory methods overridden", (model, directory) -> {
+				return new FileEncryptor(model)
+				{
+					/** The Constant serialVersionUID. */
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					protected File newEncryptedFile(final String parent, final String child)
+					{
+						return new File(directory, "encryptedFctrNjctd.enc");
+					}
+				};
+			}, (model, directory) -> {
+				return new FileDecryptor(model)
+				{
+					/** The Constant serialVersionUID. */
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					protected File newDecryptedFile(final String parent, final String child)
+					{
+						return new File(directory, "decryptedFctrNjctd.decrypted");
+					}
+				};
+			}));
+	}
+
+	/**
+	 * Test method for the encryption with the class {@link FileEncryptor} and decryption with the
+	 * class {@link FileDecryptor} over every constructor variant
+	 *
+	 * @param testCase
+	 *            the constructor-variant case
+	 * @throws Exception
+	 *             is thrown if any error occurs on the execution
+	 */
+	@ParameterizedTest
+	@MethodSource("constructorCases")
+	public void testEncryptDecryptRoundTrip(ConstructorCase testCase) throws Exception
+	{
+		encryptor = testCase.encryptorFactory().create(cryptModel, cryptDir);
 		encrypted = encryptor.encrypt(toEncrypt);
 
-		decryptor = new FileDecryptor(cryptModel, decryptedCnstr);
+		decryptor = testCase.decryptorFactory().create(cryptModel, cryptDir);
 
 		decrypted = decryptor.decrypt(encrypted);
 
 		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
 		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
+		assertEquals(actual, expected, testCase.description());
 		// clean up...
 		DeleteFileExtensions.delete(encrypted);
 		DeleteFileExtensions.delete(decrypted);
@@ -125,78 +202,6 @@ public class FileEncryptDecryptorTest extends AbstractTestCase<String, String>
 		});
 	}
 
-	/**
-	 * Test method for the encrpytion with the class {@link FileEncryptor} and decryption with the
-	 * class {@link FileDecryptor} with the default file name convention
-	 *
-	 * @throws Exception
-	 *             is thrown if any error occurs on the execution
-	 */
-	@Test
-	public void testEncryptDecryptDefaultFiles() throws Exception
-	{
-		encryptor = new FileEncryptor(cryptModel);
-		encrypted = encryptor.encrypt(toEncrypt);
-
-		decryptor = new FileDecryptor(cryptModel);
-
-		decrypted = decryptor.decrypt(encrypted);
-
-		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
-		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
-		// clean up...
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
-	}
-
-	/**
-	 * Test method for the encrpytion with the class {@link FileEncryptor} and decryption with the
-	 * class {@link FileDecryptor} with factory injection
-	 *
-	 * @throws Exception
-	 *             is thrown if any error occurs on the execution
-	 */
-	@Test
-	public void testEncryptDecryptFactoryInjected() throws Exception
-	{
-		encryptor = new FileEncryptor(cryptModel)
-		{
-
-			/** The Constant serialVersionUID. */
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected File newEncryptedFile(final String parent, final String child)
-			{
-				return new File(cryptDir, "encryptedFctrNjctd.enc");
-			}
-		};
-		encrypted = encryptor.encrypt(toEncrypt);
-
-		decryptor = new FileDecryptor(cryptModel)
-		{
-
-			/** The Constant serialVersionUID. */
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected File newDecryptedFile(final String parent, final String child)
-			{
-				return new File(cryptDir, "decryptedFctrNjctd.decrypted");
-			}
-		};
-
-		decrypted = decryptor.decrypt(encrypted);
-
-		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
-		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
-
-		// clean up...
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
-	}
 
 	/**
 	 * Test method for {@link FileDecryptor#decrypt(File)} that pins the observable effect of the

--- a/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/file/PBEFileDecryptorTest.java
@@ -29,11 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.checksum.FileChecksumExtensions;
 import io.github.astrapi69.crypt.api.algorithm.MdAlgorithm;
@@ -76,88 +79,74 @@ public class PBEFileDecryptorTest extends AbstractTestCase<String, String>
 	}
 
 	/**
-	 * Test method for the encrpytion with the class {@link PBEFileEncryptor} and decryption with
-	 * the class {@link PBEFileDecryptor} with the constructor with model
-	 *
-	 * @throws Exception
-	 *             is thrown if any error occurs on the execution
+	 * One constructor-variant case: the encrypt-decrypt-checksum round trip is identical, only how
+	 * encryptor and decryptor are constructed differs.
 	 */
-	@Test
-	public void testDecryptWithModel() throws Exception
+	record ConstructorCase(String description, PbeEncryptorFactory encryptorFactory,
+		PbeDecryptorFactory decryptorFactory) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
+
+	/** Builds the encryptor of one constructor variant. */
+	@FunctionalInterface
+	interface PbeEncryptorFactory
 	{
-		// new scenario...
-		encryptor = new PBEFileEncryptor(cryptModel);
-		encrypted = encryptor.encrypt(toEncrypt);
+		PBEFileEncryptor create(CryptModel<Cipher, String, String> model, File directory)
+			throws Exception;
+	}
 
-		decryptor = new PBEFileDecryptor(cryptModel);
+	/** Builds the decryptor of one constructor variant. */
+	@FunctionalInterface
+	interface PbeDecryptorFactory
+	{
+		PBEFileDecryptor create(CryptModel<Cipher, String, String> model, File directory)
+			throws Exception;
+	}
 
-		decrypted = decryptor.decrypt(encrypted);
-
-		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
-		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
-		// clean up...
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
+	static Stream<ConstructorCase> constructorCases()
+	{
+		return Stream.of(
+			new ConstructorCase("model only", (model, directory) -> new PBEFileEncryptor(model),
+				(model, directory) -> new PBEFileDecryptor(model)),
+			new ConstructorCase("model and file",
+				(model, directory) -> new PBEFileEncryptor(model,
+					new File(directory, "encryptedCnstr.enc")),
+				(model, directory) -> new PBEFileDecryptor(model,
+					new File(directory, "decryptedCnstr.decrypted"))),
+			new ConstructorCase("model, file and custom file extension",
+				(model, directory) -> new PBEFileEncryptor(model,
+					new File(directory, "encryptedCnstr.encfoo"), ".encfoo"),
+				(model, directory) -> new PBEFileDecryptor(model,
+					new File(directory, "decryptedCnstr.decryptfoo"), ".decryptfoo")));
 	}
 
 	/**
-	 * Test method for the encrpytion with the class {@link PBEFileEncryptor} and decryption with
-	 * the class {@link PBEFileDecryptor} with the constructor with model and file
+	 * Test method for the encryption with the class {@link PBEFileEncryptor} and decryption with
+	 * the class {@link PBEFileDecryptor} over every constructor variant
 	 *
+	 * @param testCase
+	 *            the constructor-variant case
 	 * @throws Exception
 	 *             is thrown if any error occurs on the execution
 	 */
-	@Test
-	public void testDecryptWithModelAndFile() throws Exception
+	@ParameterizedTest
+	@MethodSource("constructorCases")
+	public void testEncryptDecryptRoundTrip(ConstructorCase testCase) throws Exception
 	{
-		// new scenario...
-		File encryptedCnstr = new File(cryptDir, "encryptedCnstr.enc");
-		File decryptedCnstr = new File(cryptDir, "decryptedCnstr.decrypted");
-		encryptor = new PBEFileEncryptor(cryptModel, encryptedCnstr);
+		encryptor = testCase.encryptorFactory().create(cryptModel, cryptDir);
 		encrypted = encryptor.encrypt(toEncrypt);
 
-		decryptor = new PBEFileDecryptor(cryptModel, decryptedCnstr);
+		decryptor = testCase.decryptorFactory().create(cryptModel, cryptDir);
 
 		decrypted = decryptor.decrypt(encrypted);
 
 		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
 		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
-		// clean up...
-		DeleteFileExtensions.delete(encrypted);
-		DeleteFileExtensions.delete(decrypted);
-	}
-
-	/**
-	 * Test method for the encrpytion with the class {@link PBEFileEncryptor} and decryption with
-	 * the class {@link PBEFileDecryptor} with the constructor with model, file and custom file
-	 * extension
-	 *
-	 * @throws Exception
-	 *             is thrown if any error occurs on the execution
-	 */
-	@Test
-	public void testDecryptWithModelAndFileAndWithCustomFileExtension() throws Exception
-	{
-		// new scenario...
-		String customEncryptedFileExtension;
-		String customDecryptedFileExtension;
-
-		customEncryptedFileExtension = ".encfoo";
-		customDecryptedFileExtension = ".decryptfoo";
-		File encryptedCnstr = new File(cryptDir, "encryptedCnstr" + customEncryptedFileExtension);
-		File decryptedCnstr = new File(cryptDir, "decryptedCnstr" + customDecryptedFileExtension);
-		encryptor = new PBEFileEncryptor(cryptModel, encryptedCnstr, customEncryptedFileExtension);
-		encrypted = encryptor.encrypt(toEncrypt);
-
-		decryptor = new PBEFileDecryptor(cryptModel, decryptedCnstr, customDecryptedFileExtension);
-
-		decrypted = decryptor.decrypt(encrypted);
-
-		expected = FileChecksumExtensions.getChecksum(toEncrypt, MdAlgorithm.MD5.name());
-		actual = FileChecksumExtensions.getChecksum(decrypted, MdAlgorithm.MD5.name());
-		assertEquals(actual, expected);
+		assertEquals(actual, expected, testCase.description());
 		// clean up...
 		DeleteFileExtensions.delete(encrypted);
 		DeleteFileExtensions.delete(decrypted);

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyHexEncryptDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyHexEncryptDecryptorTest.java
@@ -30,10 +30,12 @@ import java.io.File;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
+import java.util.stream.Stream;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.crypt.data.key.reader.PrivateKeyReader;
 import io.github.astrapi69.crypt.data.key.reader.PublicKeyReader;
@@ -57,84 +59,54 @@ public class KeyHexEncryptDecryptorTest
 	}
 
 	/**
-	 * Test encrypt and decrypt with {@link PublicKeyHexEncryptor#encrypt(String)} and
-	 * {@link PrivateKeyHexDecryptor#decrypt(String)} loaded from pem files
-	 *
-	 * @throws Exception
-	 *             is thrown if the encryption or the decryption fails
+	 * One key-source case: the same round trip runs once over DER files and once over PEM files -
+	 * only how the key pair is read differs.
 	 */
-	@Test
-	public void testEncryptDecrypt() throws Exception
+	record KeySourceCase(String description, ThrowingSupplier<PrivateKey> privateKey,
+		ThrowingSupplier<PublicKey> publicKey) {
+	}
+
+	static Stream<KeySourceCase> keySourceCases()
 	{
-
-		String actual;
-		String expected;
-		File derDir;
-		File publickeyDerFile;
-		File privatekeyDerFile;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		PublicKeyHexEncryptor encryptor;
-		PrivateKeyHexDecryptor decryptor;
-		String encrypted;
-
-		expected = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,;-)";
-
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "/der");
-		publickeyDerFile = new File(derDir, "public.der");
-		privatekeyDerFile = new File(derDir, "private.der");
-
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-
-		publicKey = PublicKeyReader.readPublicKey(publickeyDerFile);
-
-		encryptor = new PublicKeyHexEncryptor(publicKey);
-
-		encrypted = encryptor.encrypt(expected);
-
-		decryptor = new PrivateKeyHexDecryptor(privateKey);
-
-		actual = decryptor.decrypt(encrypted);
-		assertEquals(actual, expected);
+		File derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
+		File pemDir = new File(PathFinder.getSrcTestResourcesDir(), "pem");
+		return Stream.of(
+			new KeySourceCase("keys read from DER files",
+				() -> PrivateKeyReader.readPrivateKey(new File(derDir, "private.der")),
+				() -> PublicKeyReader.readPublicKey(new File(derDir, "public.der"))),
+			new KeySourceCase("keys read from PEM files",
+				() -> PrivateKeyReader.readPemPrivateKey(new File(pemDir, "private.pem")),
+				() -> PublicKeyReader.readPemPublicKey(new File(pemDir, "public.pem"))));
 	}
 
 	/**
 	 * Test encrypt and decrypt with {@link PublicKeyHexEncryptor#encrypt(String)} and
-	 * {@link PrivateKeyHexDecryptor#decrypt(String)} loaded from pem files.
+	 * {@link PrivateKeyHexDecryptor#decrypt(String)} over every key source
 	 *
+	 * @param testCase
+	 *            the key-source case
 	 * @throws Exception
 	 *             is thrown if the encryption or the decryption fails
 	 */
-	@Test
-	public void testEncryptDecryptPemFiles() throws Exception
+	@ParameterizedTest
+	@MethodSource("keySourceCases")
+	public void testEncryptDecrypt(KeySourceCase testCase) throws Exception
 	{
-		String actual;
-		String expected;
-		File publickeyPemDir;
-		File publickeyPemFile;
-		File privatekeyPemFile;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		PublicKeyHexEncryptor encryptor;
-		PrivateKeyHexDecryptor decryptor;
-		String encrypted;
+		String expected = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,;-)";
 
-		expected = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,;-)";
+		PublicKeyHexEncryptor encryptor = new PublicKeyHexEncryptor(testCase.publicKey().get());
+		String encrypted = encryptor.encrypt(expected);
 
-		publickeyPemDir = new File(PathFinder.getSrcTestResourcesDir(), "pem");
-		publickeyPemFile = new File(publickeyPemDir, "public.pem");
-		privatekeyPemFile = new File(publickeyPemDir, "private.pem");
+		PrivateKeyHexDecryptor decryptor = new PrivateKeyHexDecryptor(testCase.privateKey().get());
 
-		privateKey = PrivateKeyReader.readPemPrivateKey(privatekeyPemFile);
+		assertEquals(expected, decryptor.decrypt(encrypted), testCase.description());
+	}
 
-		publicKey = PublicKeyReader.readPemPublicKey(publickeyPemFile);
-
-		encryptor = new PublicKeyHexEncryptor(publicKey);
-
-		encrypted = encryptor.encrypt(expected);
-		decryptor = new PrivateKeyHexDecryptor(privateKey);
-		actual = decryptor.decrypt(encrypted);
-		assertEquals(actual, expected);
+	/** A supplier whose read may throw - key readers declare checked exceptions. */
+	@FunctionalInterface
+	interface ThrowingSupplier<T>
+	{
+		T get() throws Exception;
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyDecryptorTest.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
+import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -40,6 +41,8 @@ import javax.crypto.SecretKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
 import io.github.astrapi69.crypt.data.factory.SecretKeyFactoryExtensions;
@@ -65,101 +68,69 @@ public class PrivateKeyDecryptorTest
 	}
 
 	/**
-	 * Test method for {@link PrivateKeyDecryptor} constructor with {@link PrivateKey} object
-	 *
-	 * @throws Exception
-	 *             is thrown if instantiation of the cipher object fails.
+	 * One constructor-variant case: the round trip is identical, only how encryptor and decryptor
+	 * are constructed (bare keys vs {@link CryptModel} objects) differs.
 	 */
-	@Test
-	public void testConstructorWithPrivateKey() throws Exception
+	record ConstructorCase(String description,
+		ThrowingFunction<PublicKey, PublicKeyEncryptor> encryptorFactory,
+		ThrowingFunction<PrivateKey, PrivateKeyDecryptor> decryptorFactory) {
+	}
+
+	static Stream<ConstructorCase> constructorCases()
 	{
-
-		String actual;
-		String expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		byte[] testBytes;
-		File derDir;
-		File privatekeyDerFile;
-		PublicKeyEncryptor encryptor;
-		PrivateKeyDecryptor decryptor;
-		byte[] decrypted;
-
-		actual = RandomStringFactory.newRandomLongString(10000000);
-
-		testBytes = actual.getBytes("UTF-8");
-
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
-
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
-
-		encryptor = new PublicKeyEncryptor(publicKey);
-		assertNotNull(encryptor);
-
-		byte[] encrypt = encryptor.encrypt(testBytes);
-
-		decryptor = new PrivateKeyDecryptor(privateKey);
-		assertNotNull(decryptor);
-		decrypted = decryptor.decrypt(encrypt);
-		assertNotNull(decrypted);
-		expected = new String(decrypted, "UTF-8");
-		assertEquals(expected, actual);
+		return Stream.of(
+			new ConstructorCase("bare key constructors", PublicKeyEncryptor::new,
+				PrivateKeyDecryptor::new),
+			new ConstructorCase("CryptModel constructors", publicKey -> {
+				CryptModel<Cipher, PublicKey, byte[]> encryptModel = CryptModel
+					.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
+				SecretKey symmetricKey = SecretKeyFactoryExtensions
+					.newSecretKey(AesAlgorithm.AES.getAlgorithm(), 128);
+				CryptModel<Cipher, SecretKey, String> symmetricKeyModel = CryptModel
+					.<Cipher, SecretKey, String> builder().key(symmetricKey)
+					.algorithm(AesAlgorithm.AES).operationMode(Cipher.ENCRYPT_MODE).build();
+				return new PublicKeyEncryptor(encryptModel, symmetricKeyModel);
+			}, privateKey -> new PrivateKeyDecryptor(
+				CryptModel.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build(),
+				AesAlgorithm.AES)));
 	}
 
 	/**
-	 * Test method for {@link PrivateKeyDecryptor} constructor with {@link CryptModel} object
+	 * Test method for the {@link PublicKeyEncryptor}/{@link PrivateKeyDecryptor} round trip over
+	 * every constructor variant
 	 *
+	 * @param testCase
+	 *            the constructor-variant case
 	 * @throws Exception
 	 *             is thrown if instantiation of the cipher object fails.
 	 */
-	@Test
-	public void testConstructorWithCryptModel() throws Exception
+	@ParameterizedTest
+	@MethodSource("constructorCases")
+	public void testEncryptDecryptRoundTrip(ConstructorCase testCase) throws Exception
 	{
-		String actual;
-		String expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		SecretKey symmetricKey;
-		CryptModel<Cipher, PublicKey, byte[]> encryptModel;
-		CryptModel<Cipher, SecretKey, String> symmetricKeyModel;
-		CryptModel<Cipher, PrivateKey, byte[]> decryptModel;
-		byte[] testBytes;
-		File derDir;
-		File privatekeyDerFile;
-		PublicKeyEncryptor encryptor;
-		PrivateKeyDecryptor decryptor;
-		byte[] decrypted;
+		String plainText = RandomStringFactory.newRandomLongString(10000000);
+		byte[] testBytes = plainText.getBytes("UTF-8");
 
-		actual = RandomStringFactory.newRandomLongString(10000000);
+		File derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
+		PrivateKey privateKey = PrivateKeyReader.readPrivateKey(new File(derDir, "private.der"));
+		PublicKey publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
 
-		testBytes = actual.getBytes("UTF-8");
-
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
-
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
-
-		decryptModel = CryptModel.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build();
-		encryptModel = CryptModel.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
-		symmetricKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.getAlgorithm(),
-			128);
-		symmetricKeyModel = CryptModel.<Cipher, SecretKey, String> builder().key(symmetricKey)
-			.algorithm(AesAlgorithm.AES).operationMode(Cipher.ENCRYPT_MODE).build();
-
-		encryptor = new PublicKeyEncryptor(encryptModel, symmetricKeyModel);
+		PublicKeyEncryptor encryptor = testCase.encryptorFactory().apply(publicKey);
 		assertNotNull(encryptor);
+		byte[] encrypted = encryptor.encrypt(testBytes);
 
-		byte[] encrypt = encryptor.encrypt(testBytes);
-
-		decryptor = new PrivateKeyDecryptor(decryptModel, AesAlgorithm.AES);
+		PrivateKeyDecryptor decryptor = testCase.decryptorFactory().apply(privateKey);
 		assertNotNull(decryptor);
-		decrypted = decryptor.decrypt(encrypt);
+		byte[] decrypted = decryptor.decrypt(encrypted);
 		assertNotNull(decrypted);
-		expected = new String(decrypted, "UTF-8");
-		assertEquals(expected, actual);
+		assertEquals(plainText, new String(decrypted, "UTF-8"), testCase.description());
+	}
+
+	/** A factory whose construction may throw - the cipher constructors declare exceptions. */
+	@FunctionalInterface
+	interface ThrowingFunction<T, R>
+	{
+		R apply(T input) throws Exception;
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyGenericEnDecryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/PrivateKeyGenericEnDecryptorTest.java
@@ -31,11 +31,13 @@ import java.io.File;
 import java.io.Serializable;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.astrapi69.crypt.api.algorithm.AesAlgorithm;
 import io.github.astrapi69.crypt.data.factory.SecretKeyFactoryExtensions;
@@ -63,52 +65,109 @@ public class PrivateKeyGenericEnDecryptorTest
 	 * @throws Exception
 	 *             is thrown if any error occurs
 	 */
-	@Test
-	public void testDecrypt() throws Exception
+	/**
+	 * Builds the generic encryptor/decryptor pair for one constructor variant; the generic method
+	 * keeps the payload type flexible so the Person and the JSON round trip share the variants.
+	 */
+	interface GenericCryptorFactory
 	{
-		Person actual;
-		Person expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		SecretKey symmetricKey;
-		CryptModel<Cipher, PublicKey, byte[]> encryptModel;
-		CryptModel<Cipher, SecretKey, String> symmetricKeyModel;
-		CryptModel<Cipher, PrivateKey, byte[]> decryptModel;
-		File derDir;
-		File privatekeyDerFile;
-		PublicKeyEncryptor encryptor;
-		PrivateKeyDecryptor decryptor;
+		<T extends Serializable> PublicKeyGenericEncryptor<T> newEncryptor(PublicKey publicKey)
+			throws Exception;
 
-		PublicKeyGenericEncryptor<Person> genericEncryptor;
-		PrivateKeyGenericDecryptor<Person> genericDecryptor;
-		Person toEncrypt;
+		<T extends Serializable> PrivateKeyGenericDecryptor<T> newDecryptor(PrivateKey privateKey)
+			throws Exception;
+	}
 
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
+	/** One constructor-variant case of the 2x2 matrix (payload x construction). */
+	record ConstructorVariant(String description, GenericCryptorFactory factory) {
+		@Override
+		public String toString()
+		{
+			return description;
+		}
+	}
 
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
+	static Stream<ConstructorVariant> constructorVariants()
+	{
+		return Stream.of(new ConstructorVariant("bare key constructors", new GenericCryptorFactory()
+		{
+			@Override
+			public <T extends Serializable> PublicKeyGenericEncryptor<T> newEncryptor(
+				PublicKey publicKey)
+			{
+				return new PublicKeyGenericEncryptor<>(publicKey);
+			}
 
-		decryptModel = CryptModel.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build();
-		encryptModel = CryptModel.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
-		symmetricKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.getAlgorithm(),
-			128);
-		symmetricKeyModel = CryptModel.<Cipher, SecretKey, String> builder().key(symmetricKey)
-			.algorithm(AesAlgorithm.AES).operationMode(Cipher.ENCRYPT_MODE).build();
+			@Override
+			public <T extends Serializable> PrivateKeyGenericDecryptor<T> newDecryptor(
+				PrivateKey privateKey)
+			{
+				return new PrivateKeyGenericDecryptor<>(privateKey);
+			}
+		}), new ConstructorVariant("CryptModel constructors", new GenericCryptorFactory()
+		{
+			@Override
+			public <T extends Serializable> PublicKeyGenericEncryptor<T> newEncryptor(
+				PublicKey publicKey) throws Exception
+			{
+				CryptModel<Cipher, PublicKey, byte[]> encryptModel = CryptModel
+					.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
+				SecretKey symmetricKey = SecretKeyFactoryExtensions
+					.newSecretKey(AesAlgorithm.AES.getAlgorithm(), 128);
+				CryptModel<Cipher, SecretKey, String> symmetricKeyModel = CryptModel
+					.<Cipher, SecretKey, String> builder().key(symmetricKey)
+					.algorithm(AesAlgorithm.AES).operationMode(Cipher.ENCRYPT_MODE).build();
+				return new PublicKeyGenericEncryptor<>(
+					new PublicKeyEncryptor(encryptModel, symmetricKeyModel));
+			}
 
-		encryptor = new PublicKeyEncryptor(encryptModel, symmetricKeyModel);
-		assertNotNull(encryptor);
-		decryptor = new PrivateKeyDecryptor(decryptModel, AesAlgorithm.AES);
-		assertNotNull(decryptor);
+			@Override
+			public <T extends Serializable> PrivateKeyGenericDecryptor<T> newDecryptor(
+				PrivateKey privateKey) throws Exception
+			{
+				CryptModel<Cipher, PrivateKey, byte[]> decryptModel = CryptModel
+					.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build();
+				return new PrivateKeyGenericDecryptor<>(
+					new PrivateKeyDecryptor(decryptModel, AesAlgorithm.AES));
+			}
+		}));
+	}
 
-		genericEncryptor = new PublicKeyGenericEncryptor<>(encryptor);
-		genericDecryptor = new PrivateKeyGenericDecryptor<Person>(decryptor);
+	/** Reads the test key pair from the DER resources. */
+	private static PrivateKey readTestPrivateKey() throws Exception
+	{
+		File derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
+		return PrivateKeyReader.readPrivateKey(new File(derDir, "private.der"));
+	}
 
-		actual = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
-		byte[] encrypt = genericEncryptor.encrypt(actual);
-		Person decryptedPerson = genericDecryptor.decrypt(encrypt);
-		expected = decryptedPerson;
-		assertEquals(actual, expected);
+	/**
+	 * Test method for {@link PublicKeyGenericEncryptor#encrypt(Serializable)} and the corresponding
+	 * method {@link PrivateKeyGenericDecryptor#decrypt(byte[])} with serializable test object
+	 * {@link Person}, over every constructor variant
+	 *
+	 * @param variant
+	 *            the constructor variant
+	 * @throws Exception
+	 *             is thrown if any error occurs
+	 */
+	@ParameterizedTest
+	@MethodSource("constructorVariants")
+	public void testEncryptDecryptPerson(ConstructorVariant variant) throws Exception
+	{
+		PrivateKey privateKey = readTestPrivateKey();
+		PublicKey publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
+
+		PublicKeyGenericEncryptor<Person> genericEncryptor = variant.factory()
+			.newEncryptor(publicKey);
+		PrivateKeyGenericDecryptor<Person> genericDecryptor = variant.factory()
+			.newDecryptor(privateKey);
+		assertNotNull(genericEncryptor);
+		assertNotNull(genericDecryptor);
+
+		Person person = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
+		byte[] encrypted = genericEncryptor.encrypt(person);
+
+		assertEquals(person, genericDecryptor.decrypt(encrypted), variant.description());
 	}
 
 	/**
@@ -118,137 +177,36 @@ public class PrivateKeyGenericEnDecryptorTest
 	 * @throws Exception
 	 *             is thrown if any error occurs
 	 */
-	@Test
-	public void testDecryptJson() throws Exception
-	{
-		String actual;
-		String expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		SecretKey symmetricKey;
-		CryptModel<Cipher, PublicKey, byte[]> encryptModel;
-		CryptModel<Cipher, SecretKey, String> symmetricKeyModel;
-		CryptModel<Cipher, PrivateKey, byte[]> decryptModel;
-		File derDir;
-		File privatekeyDerFile;
-		PublicKeyEncryptor encryptor;
-		PrivateKeyDecryptor decryptor;
-
-		PublicKeyGenericEncryptor<String> genericEncryptor;
-		PrivateKeyGenericDecryptor<String> genericDecryptor;
-		Person personToEncrypt;
-		byte[] encryptedBytes;
-		String decryptedJson;
-
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
-
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
-
-		encryptModel = CryptModel.<Cipher, PublicKey, byte[]> builder().key(publicKey).build();
-		decryptModel = CryptModel.<Cipher, PrivateKey, byte[]> builder().key(privateKey).build();
-		symmetricKey = SecretKeyFactoryExtensions.newSecretKey(AesAlgorithm.AES.getAlgorithm(),
-			128);
-		symmetricKeyModel = CryptModel.<Cipher, SecretKey, String> builder().key(symmetricKey)
-			.algorithm(AesAlgorithm.AES).operationMode(Cipher.ENCRYPT_MODE).build();
-
-		encryptor = new PublicKeyEncryptor(encryptModel, symmetricKeyModel);
-		assertNotNull(encryptor);
-		decryptor = new PrivateKeyDecryptor(decryptModel, AesAlgorithm.AES);
-		assertNotNull(decryptor);
-
-		genericEncryptor = new PublicKeyGenericEncryptor<>(encryptor);
-		genericDecryptor = new PrivateKeyGenericDecryptor<>(decryptor);
-
-		personToEncrypt = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
-		actual = ObjectToJsonExtensions.toJson(personToEncrypt);
-		encryptedBytes = genericEncryptor.encrypt(actual);
-		decryptedJson = genericDecryptor.decrypt(encryptedBytes);
-		expected = decryptedJson;
-		assertEquals(actual, expected);
-		Person decryptedPerson = JsonStringToObjectExtensions.toObject(decryptedJson, Person.class);
-		assertEquals(personToEncrypt, decryptedPerson);
-	}
-
 	/**
 	 * Test method for {@link PublicKeyGenericEncryptor#encrypt(Serializable)} and the corresponding
-	 * method {@link PrivateKeyGenericDecryptor#decrypt(byte[])} with json object with only
-	 * {@link PrivateKey} and {@link PublicKey} object
+	 * method {@link PrivateKeyGenericDecryptor#decrypt(byte[])} with a json payload, over every
+	 * constructor variant
 	 *
+	 * @param variant
+	 *            the constructor variant
 	 * @throws Exception
 	 *             is thrown if any error occurs
 	 */
-	@Test
-	public void testDecryptJsonWithPrivateKeyAndPublicKey() throws Exception
+	@ParameterizedTest
+	@MethodSource("constructorVariants")
+	public void testEncryptDecryptJson(ConstructorVariant variant) throws Exception
 	{
-		String actual;
-		String expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		File derDir;
-		File privatekeyDerFile;
+		PrivateKey privateKey = readTestPrivateKey();
+		PublicKey publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
 
-		PublicKeyGenericEncryptor<String> genericEncryptor;
-		PrivateKeyGenericDecryptor<String> genericDecryptor;
-		Person personToEncrypt;
-		byte[] encryptedBytes;
-		String decryptedJson;
+		PublicKeyGenericEncryptor<String> genericEncryptor = variant.factory()
+			.newEncryptor(publicKey);
+		PrivateKeyGenericDecryptor<String> genericDecryptor = variant.factory()
+			.newDecryptor(privateKey);
 
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
+		Person person = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
+		String json = ObjectToJsonExtensions.toJson(person);
+		byte[] encrypted = genericEncryptor.encrypt(json);
+		String decryptedJson = genericDecryptor.decrypt(encrypted);
 
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
-
-		genericEncryptor = new PublicKeyGenericEncryptor<>(publicKey);
-		genericDecryptor = new PrivateKeyGenericDecryptor<>(privateKey);
-
-		personToEncrypt = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
-		actual = ObjectToJsonExtensions.toJson(personToEncrypt);
-		encryptedBytes = genericEncryptor.encrypt(actual);
-		decryptedJson = genericDecryptor.decrypt(encryptedBytes);
-		expected = decryptedJson;
-		assertEquals(actual, expected);
-		Person decryptedPerson = JsonStringToObjectExtensions.toObject(decryptedJson, Person.class);
-		assertEquals(personToEncrypt, decryptedPerson);
-	}
-
-	/**
-	 * Test method for {@link PublicKeyGenericEncryptor#encrypt(Serializable)} and the corresponding
-	 * method {@link PrivateKeyGenericDecryptor#decrypt(byte[])} with serializable test object
-	 * {@link Person} with only {@link PrivateKey} and {@link PublicKey} object
-	 *
-	 * @throws Exception
-	 *             is thrown if any error occurs
-	 */
-	@Test
-	public void testDecryptWithPrivateKeyAndPublicKey() throws Exception
-	{
-		Person actual;
-		Person expected;
-		PrivateKey privateKey;
-		PublicKey publicKey;
-		File derDir;
-		File privatekeyDerFile;
-
-		PublicKeyGenericEncryptor<Person> genericEncryptor;
-		PrivateKeyGenericDecryptor<Person> genericDecryptor;
-
-		derDir = new File(PathFinder.getSrcTestResourcesDir(), "der");
-		privatekeyDerFile = new File(derDir, "private.der");
-
-		privateKey = PrivateKeyReader.readPrivateKey(privatekeyDerFile);
-		publicKey = PrivateKeyExtensions.generatePublicKey(privateKey);
-
-		genericEncryptor = new PublicKeyGenericEncryptor<>(publicKey);
-		genericDecryptor = new PrivateKeyGenericDecryptor<Person>(privateKey);
-
-		actual = Person.builder().about("about").name("Foo").gender(Gender.MALE).build();
-		byte[] encrypt = genericEncryptor.encrypt(actual);
-		Person decryptedPerson = genericDecryptor.decrypt(encrypt);
-		expected = decryptedPerson;
-		assertEquals(actual, expected);
+		assertEquals(json, decryptedJson, variant.description());
+		assertEquals(person, JsonStringToObjectExtensions.toObject(decryptedJson, Person.class),
+			variant.description());
 	}
 
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterExtensionsTest.java
@@ -26,7 +26,11 @@ package io.github.astrapi69.mystic.crypt.obfuscation.character;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.meanbean.test.BeanTester;
 
 import io.github.astrapi69.test.base.AbstractTestCase;
@@ -38,34 +42,36 @@ public class CharacterExtensionsTest extends AbstractTestCase<Boolean, Boolean>
 {
 
 	/**
-	 * Test method for {@link CharacterExtensions#equalsIgnoreCase(Character, Character)}
+	 * One case of the {@link CharacterExtensions#equalsIgnoreCase(Character, Character)} truth
+	 * table; a record instead of a CSV source because half the cases carry {@code null}.
 	 */
-	@Test
-	public void testEqualsIgnoreCase()
+	record EqualsIgnoreCaseCase(String description, Character left, Character right,
+		boolean expected) {
+	}
+
+	static Stream<EqualsIgnoreCaseCase> equalsIgnoreCaseCases()
 	{
+		return Stream.of(
+			new EqualsIgnoreCaseCase("different case of the same letter", 'C', 'c', true),
+			new EqualsIgnoreCaseCase("null against a character", null, 'c', false),
+			new EqualsIgnoreCaseCase("a character against null", 'c', null, false),
+			new EqualsIgnoreCaseCase("two different letters", 'c', 'd', false),
+			new EqualsIgnoreCaseCase("null against null", null, null, true));
+	}
 
-		expected = true;
-		actual = CharacterExtensions.equalsIgnoreCase(Character.valueOf('C'),
-			Character.valueOf('c'));
-		assertEquals(expected, actual);
-
-		expected = false;
-		actual = CharacterExtensions.equalsIgnoreCase(null, Character.valueOf('c'));
-		assertEquals(expected, actual);
-
-		expected = false;
-		actual = CharacterExtensions.equalsIgnoreCase(Character.valueOf('c'), null);
-		assertEquals(expected, actual);
-
-		expected = false;
-		actual = CharacterExtensions.equalsIgnoreCase(Character.valueOf('c'),
-			Character.valueOf('d'));
-		assertEquals(expected, actual);
-
-		expected = true;
-		actual = CharacterExtensions.equalsIgnoreCase(null, null);
-
-		assertEquals(expected, actual);
+	/**
+	 * Test method for {@link CharacterExtensions#equalsIgnoreCase(Character, Character)}
+	 *
+	 * @param testCase
+	 *            the truth-table case
+	 */
+	@ParameterizedTest
+	@MethodSource("equalsIgnoreCaseCases")
+	public void testEqualsIgnoreCase(EqualsIgnoreCaseCase testCase)
+	{
+		assertEquals(testCase.expected(),
+			CharacterExtensions.equalsIgnoreCase(testCase.left(), testCase.right()),
+			testCase.description());
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterObfuscatorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/CharacterObfuscatorTest.java
@@ -28,9 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -110,90 +114,45 @@ public class CharacterObfuscatorTest extends AbstractTestCase<String, String>
 	}
 
 	/**
-	 * Test method for {@link CharacterObfuscator#disentangle()}
+	 * One obfuscate/disentangle round trip. {@code expectedDisentangled} is a separate field
+	 * because the round trip is not lossless for every input: an uppercase first letter outside the
+	 * rule set comes back lowercase (see the "long text with an uppercase N" case).
 	 */
-	@Test
-	public void testDisentangle()
-	{
-		stringToObfuscate = "abac";
-		// obfuscate the key
-		obfuscator = new CharacterObfuscator(rules, stringToObfuscate);
-		actual = obfuscator.obfuscate();
-		expected = "AcAC";
-		assertEquals(expected, actual);
+	record RoundTripCase(String description, String input, String expectedObfuscated,
+		String expectedDisentangled) {
+	}
 
-		actual = obfuscator.disentangle();
-		expected = stringToObfuscate;
-		assertEquals(expected, actual);
+	static Stream<RoundTripCase> roundTripCases()
+	{
+		String loremText = "leonardo Lorem ipsum dolor sit amet, sea consul verterem perfecto id. Alii prompta electram te nec, at minimum copiosae quo. Eos iudico nominati oportere ei, usu at dicta legendos. In nostrum insolens disputando pro, iusto equidem ius id.";
+		String numbersText = "Numbers are only part of the data a typical Java program needs to read and write. Most programs also need to handle text, which is composed of characters. Since computers only really understand numbers, characters are encoded by matching each character in a given script to a particular number. For example, in the common ASCII encoding, the character A is mapped to the number 65; the character B is mapped to the number 66; the character C is mapped to the number 67; and so on. Different encodings may encode different scripts or may encode the same or similar scripts in different ways.";
+		return Stream.of(
+			new RoundTripCase("four characters covered by the rules", "abac", "AcAC", "abac"),
+			new RoundTripCase("eight characters", "leonardo", "Lfpobsep", "leonardo"),
+			new RoundTripCase("long text", loremText,
+				"Lfpobsep Lpsfn jqtvn epmps tju bnfu, tfb dpotvm wfsufsfn qfsgfdup je. Amjj qspnqub fmfdusbn uf ofd, bu njojnvn dpqjptbf rvp. Ept jvejdp opnjobuj pqpsufsf fj, vtv bu ejdub mfhfoept. Io optusvn jotpmfot ejtqvuboep qsp, jvtup frvjefn jvt je.",
+				loremText),
+			new RoundTripCase("long text with an uppercase N outside the rule set", numbersText,
+				"Nvncfst bsf pomz qbsu pg uif ebub b uzqjdbm Jbwb qsphsbn offet up sfbe boe xsjuf. Mptu qsphsbnt bmtp offe up iboemf ufyu, xijdi jt dpnqptfe pg dibsbdufst. Sjodf dpnqvufst pomz sfbmmz voefstuboe ovncfst, dibsbdufst bsf fodpefe cz nbudijoh fbdi dibsbdufs jo b hjwfo tdsjqu up b qbsujdvmbs ovncfs. Fps fybnqmf, jo uif dpnnpo ASCII fodpejoh, uif dibsbdufs A jt nbqqfe up uif ovncfs 65; uif dibsbdufs B jt nbqqfe up uif ovncfs 66; uif dibsbdufs C jt nbqqfe up uif ovncfs 67; boe tp po. Djggfsfou fodpejoht nbz fodpef ejggfsfou tdsjqut ps nbz fodpef uif tbnf ps tjnjmbs tdsjqut jo ejggfsfou xbzt.",
+				"numbers" + numbersText.substring("Numbers".length())));
 	}
 
 	/**
-	 * Test method for {@link CharacterObfuscator#obfuscate()}
+	 * Test method for {@link CharacterObfuscator#obfuscate()} and
+	 * {@link CharacterObfuscator#disentangle()}
+	 *
+	 * @param testCase
+	 *            the round-trip case
 	 */
-	@Test
-	public void testObfuscate()
+	@ParameterizedTest
+	@MethodSource("roundTripCases")
+	public void testObfuscateDisentangleRoundTrip(RoundTripCase testCase)
 	{
-		// a key for obfuscation
-		stringToObfuscate = "abac";
+		obfuscator = new CharacterObfuscator(rules, testCase.input());
 
-		// obfuscate the key
-		obfuscator = new CharacterObfuscator(rules, stringToObfuscate);
-		actual = obfuscator.obfuscate();
-		expected = "AcAC";
-		assertEquals(expected, actual);
-
-		actual = obfuscator.disentangle();
-		expected = stringToObfuscate;
-		assertEquals(expected, actual);
-	}
-
-	/**
-	 * Test method for {@link CharacterObfuscator#obfuscate()}
-	 */
-	@Test
-	public void testObfuscateEightChars()
-	{
-		// new scenario...
-		// a key for obfuscation
-		stringToObfuscate = "leonardo";
-
-		// obfuscate the key
-		obfuscator = new CharacterObfuscator(rules, stringToObfuscate);
-		actual = obfuscator.obfuscate();
-		expected = "Lfpobsep";
-		assertEquals(expected, actual);
-
-		actual = obfuscator.disentangle();
-		expected = stringToObfuscate;
-		assertEquals(expected, actual);
-
-		// new scenario...
-		// a key for obfuscation
-		stringToObfuscate = "leonardo Lorem ipsum dolor sit amet, sea consul verterem perfecto id. Alii prompta electram te nec, at minimum copiosae quo. Eos iudico nominati oportere ei, usu at dicta legendos. In nostrum insolens disputando pro, iusto equidem ius id.";
-
-		// obfuscate the key
-		obfuscator = new CharacterObfuscator(rules, stringToObfuscate);
-		actual = obfuscator.obfuscate();
-		expected = "Lfpobsep Lpsfn jqtvn epmps tju bnfu, tfb dpotvm wfsufsfn qfsgfdup je. Amjj qspnqub fmfdusbn uf ofd, bu njojnvn dpqjptbf rvp. Ept jvejdp opnjobuj pqpsufsf fj, vtv bu ejdub mfhfoept. Io optusvn jotpmfot ejtqvuboep qsp, jvtup frvjefn jvt je.";
-		assertEquals(expected, actual);
-
-		actual = obfuscator.disentangle();
-		expected = stringToObfuscate;
-		assertEquals(expected, actual);
-
-		// new scenario...
-		// a key for obfuscation
-		stringToObfuscate = "Numbers are only part of the data a typical Java program needs to read and write. Most programs also need to handle text, which is composed of characters. Since computers only really understand numbers, characters are encoded by matching each character in a given script to a particular number. For example, in the common ASCII encoding, the character A is mapped to the number 65; the character B is mapped to the number 66; the character C is mapped to the number 67; and so on. Different encodings may encode different scripts or may encode the same or similar scripts in different ways.";
-
-		// obfuscate the key
-		obfuscator = new CharacterObfuscator(rules, stringToObfuscate);
-		actual = obfuscator.obfuscate();
-		expected = "Nvncfst bsf pomz qbsu pg uif ebub b uzqjdbm Jbwb qsphsbn offet up sfbe boe xsjuf. Mptu qsphsbnt bmtp offe up iboemf ufyu, xijdi jt dpnqptfe pg dibsbdufst. Sjodf dpnqvufst pomz sfbmmz voefstuboe ovncfst, dibsbdufst bsf fodpefe cz nbudijoh fbdi dibsbdufs jo b hjwfo tdsjqu up b qbsujdvmbs ovncfs. Fps fybnqmf, jo uif dpnnpo ASCII fodpejoh, uif dibsbdufs A jt nbqqfe up uif ovncfs 65; uif dibsbdufs B jt nbqqfe up uif ovncfs 66; uif dibsbdufs C jt nbqqfe up uif ovncfs 67; boe tp po. Djggfsfou fodpejoht nbz fodpef ejggfsfou tdsjqut ps nbz fodpef uif tbnf ps tjnjmbs tdsjqut jo ejggfsfou xbzt.";
-		assertEquals(expected, actual);
-
-		actual = obfuscator.disentangle();
-		expected = "numbers are only part of the data a typical Java program needs to read and write. Most programs also need to handle text, which is composed of characters. Since computers only really understand numbers, characters are encoded by matching each character in a given script to a particular number. For example, in the common ASCII encoding, the character A is mapped to the number 65; the character B is mapped to the number 66; the character C is mapped to the number 67; and so on. Different encodings may encode different scripts or may encode the same or similar scripts in different ways.";
-		assertEquals(expected, actual);
+		assertEquals(testCase.expectedObfuscated(), obfuscator.obfuscate(), testCase.description());
+		assertEquals(testCase.expectedDisentangled(), obfuscator.disentangle(),
+			testCase.description());
 	}
 
 }


### PR DESCRIPTION
Third follow-up to the adopted rule set (#82): folds copied sibling test methods into record-based @ParameterizedTest case lists with speaking names, per tdd.md. One notable audit correction: the four decorator 'new scenario' methods were NOT redundant with the CSV-driven tests - empty CSV fields arrive as null, so the empty-prefix/suffix cases (the endsWith-mutant corner) only live here; they are parameterized instead of deleted.

PIT-verified mutation-neutral: 1074 mutants, 1064 killed (99.1%), same ten documented survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)