### PR TITLE
fix: run the test-badge workflow against Gradle, not Maven

### DIFF
--- a/.github/workflows/test-badge.yml
+++ b/.github/workflows/test-badge.yml
@@ -12,23 +12,27 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run tests
-        run: mvn test --batch-mode
+        run: ./gradlew test
 
       - name: Extract test count
         id: test_count
         run: |
-          # Surefire Reports parsen: alle "Tests run:" Werte summieren
-          TOTAL=$(grep -rh "Tests run:" target/surefire-reports/*.txt \
-            | awk -F'[,:]' '{sum += $2} END {print sum}')
+          # Gradle's JUnit XML reports: one <testsuite tests="N" .../> root per test class,
+          # sum the tests attribute across all of them.
+          TOTAL=$(grep -ohE 'tests="[0-9]+"' build/test-results/test/*.xml \
+            | grep -oE '[0-9]+' | awk '{sum += $1} END {print sum}')
 
           # Fallback falls kein Report existiert
           if [ -z "$TOTAL" ] || [ "$TOTAL" -eq 0 ]; then


### PR DESCRIPTION
Closes #88.

`test-badge.yml` was Maven-shaped in a Gradle-only project - `mvn test` has no `pom.xml` to run against and failed on every trigger, including three times directly on `develop`.

- `./gradlew test` instead of `mvn test --batch-mode`
- sum `build/test-results/test/*.xml`'s `tests="N"` attribute instead of grepping Surefire's text reports
- JDK 21 → 25 (`gradle.properties`: `projectSourceCompatibility=25`)
- aligned checkout/setup-java/setup-gradle action versions with the existing `gradle.yml`

The badge-update step itself (schneegans/dynamic-badges-action against the gist) is unchanged. Verified the extraction locally: matches a Python cross-check of the same real report files exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)