### PR TITLE
docs: reorder the test-cases badge and rename its label

### DIFF
--- a/.github/workflows/test-badge.yml
+++ b/.github/workflows/test-badge.yml
@@ -57,6 +57,6 @@ jobs:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 69b2e93dd826ce43cc3f02433a465ae3
           filename: test-cases.json
-          label: test cases
+          label: Tested Use Cases
           message: ${{ steps.test_count.outputs.total }}
           color: ${{ steps.test_count.outputs.color }}

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ correctly without being a cryptographer.**
 [![Java CI with Gradle](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml/badge.svg)](https://github.com/astrapi69/mystic-crypt/actions/workflows/gradle.yml)
 [![Coverage Status](https://codecov.io/gh/astrapi69/mystic-crypt/branch/develop/graph/badge.svg)](https://codecov.io/gh/astrapi69/mystic-crypt)
 [![Mutation Coverage](https://img.shields.io/badge/mutation%20coverage-99%25-brightgreen)](https://pitest.org/)
+![Tested Use Cases](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/astrapi69/69b2e93dd826ce43cc3f02433a465ae3/raw/test-cases.json)
 [![Open Issues](https://img.shields.io/github/issues/astrapi69/mystic-crypt.svg?style=flat)](https://github.com/astrapi69/mystic-crypt/issues)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.astrapi69/mystic-crypt.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.astrapi69/mystic-crypt)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](http://opensource.org/licenses/MIT)
 [![Javadoc](http://www.javadoc.io/badge/io.github.astrapi69/mystic-crypt.svg)](http://www.javadoc.io/doc/io.github.astrapi69/mystic-crypt)
 [![Java](https://img.shields.io/badge/Java-25-orange)](https://openjdk.org/projects/jdk/25/)
-![Tested Use Cases](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/astrapi69/69b2e93dd826ce43cc3f02433a465ae3/raw/test-cases.json)
 </div>
 
 mystic-crypt wraps the JDK's and Bouncy Castle's cryptographic primitives in small, focused classes


### PR DESCRIPTION
Two things:

1. Moves the test-cases badge next to Coverage Status and Mutation Coverage (its natural siblings) instead of trailing after the Java version badge.
2. Renames the badge's own visible label from "test cases" to "Tested Use Cases" - that text is baked into the gist JSON by the dynamic-badges-action step in `test-badge.yml`, not read from the markdown alt text, so both needed to change for the rendered badge to actually show the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)