### PR TITLE
docs: record crypt-data at a 100% mutation score after round five

### DIFF
--- a/docs/COVERAGE_EXCEPTIONS.md
+++ b/docs/COVERAGE_EXCEPTIONS.md
@@ -17,18 +17,29 @@ check found.
 
 Nothing. Every line, branch and mutant. 78 mutants generated, 78 killed.
 
-## `crypt-data` - 0 lines / 0 branches uncovered; 3 surviving mutants of 782
+## `crypt-data` - 0 lines / 0 branches uncovered; 0 surviving mutants of 779
 
-Every line and branch is covered; no JaCoCo exclusions were added to get there.
+Every line and branch is covered; no JaCoCo exclusions were added to get there. Nothing survives
+either: 779 mutants generated, 779 killed.
 
-Surviving mutants:
+The three mutants that used to survive here were cleared in PR #8, and two of them only because
+the reasoning that had retired them was re-read rather than re-quoted:
 
-- `EncryptedPrivateKeyReader.getKeyPair` (line 104): an explicit `PEMParser.close()` after the PEM
-  object has already been read - removing it leaks a reader but changes no result.
+- `EncryptedPrivateKeyReader.getKeyPair` (line 104, `PEMParser.close()`): documented below as a
+  leak worth accepting because observing it "would be flaky and platform-dependent". Both halves
+  were wrong. The leak is not on the happy path the note assumed but on the exception path, where
+  `close()` is never reached at all, so a malformed PEM file leaks a descriptor per call - a real
+  defect, filed as `crypt-data` issue #7. And the observation is deterministic: counting the
+  entries under `/proc/self/fd` that point at one named file is not the flaky total-descriptor
+  heuristic the note had in mind. The fix is `try`-with-resources, which also makes the method
+  match `PemObjectReader`, the only other place in `src/main` that opens a PEM parser.
 - `EncryptedPrivateKeyReader.getPrivateKey(File, String)` (line 275) and
-  `PrivateKeyReader.getPrivateKey(byte[])` (line 474): the fall-through `return` after every
-  algorithm attempt has failed, reached only when a preceding attempt that succeeds on every JDK
-  shipped does not.
+  `PrivateKeyReader.getPrivateKey(byte[])` (line 474): the fall-through `return optionalPrivateKey`
+  after every algorithm attempt has failed. The note below called restructuring these "cosmetic".
+  It was cheap rather than cosmetic: the local was initialised to `Optional.empty()`, reassigned in
+  every success branch and returned there immediately, so it could never be observed holding
+  anything else. Returning `Optional.of(...)` per branch and `Optional.empty()` at the end says so
+  in the source, and PIT's own equivalent-constant filter then stops generating the mutant.
 
 Two more used to survive here - `CertFactory.newX509CertificateV3(...)` ×2 and
 `HashExtensions.hash(...)` ×2 - until a second look found the guarded conditions were redundant
@@ -155,9 +166,9 @@ earns its keep:
 
 ## Why not literal 100%
 
-`crypt-api` is at 100.0%. `crypt-data` is at 99.6% (3 survivors of 782) and `mystic-crypt` at
-99.5% (5 survivors of 1076). This section is the answer to "why not push those to 100% too" -
-worked through for every one of the 8 remaining survivors, not asserted in general. It was written
+`crypt-api` and `crypt-data` are at 100.0%. `mystic-crypt` is at 99.5% (5 survivors of 1076). This
+section is the answer to "why not push those to 100% too" - worked through for every one of the 5
+remaining survivors, not asserted in general. It was written
 after four rounds of exactly that push: the first round (PR #69) killed everything killable and
 argued the rest was equivalent; the second round (PR #5, PR #76) went back over every argued
 survivor a second time and found seven that were not equivalent at all, but dead code that
@@ -167,8 +178,10 @@ killable through reflection alone, at zero cost to production code; a fourth rou
 `mystic-crypt` found three more killable (two by testing outside the input domain a prior
 "equivalent" argument had implicitly assumed, one by substituting a defective JCA provider) and
 turned two more from unkillable into killable by extracting a `finally`-free helper method so PIT's
-own equivalent-constant filter could apply (see above). What follows is what was left after all
-four rounds, sorted by why it stays.
+own equivalent-constant filter could apply (see above); a fifth round on `crypt-data` (PR #8)
+cleared its last three, two of them by re-reading a retirement argument instead of re-quoting it
+(see the `crypt-data` section above). What follows is what was left after all five rounds, sorted
+by why it stays.
 
 **Provably impossible - not a matter of effort.**
 
@@ -199,30 +212,23 @@ four rounds, sorted by why it stays.
   moving the guarded logic out of the `finally`-carrying method entirely. The same move is not
   available here: the `try`-with-resources *is* the guarded logic, there is nothing to extract it
   from.)
-- `EncryptedPrivateKeyReader.getKeyPair:104` (`PEMParser.close()`, `VoidMethodCallMutator`): this
-  is the one case in the list that is **not dead code** - removing the call introduces a real
-  resource leak. It survives because a leaked file descriptor is not something a unit test observes
-  without OS-level introspection (open file counts, `lsof`-style checks), which would be flaky and
-  platform-dependent. Kept exactly as-is; killing this mutant is not worth what the test would cost
-  in reliability.
+Two entries stood here until round five and no longer do, both from `crypt-data`:
+`EncryptedPrivateKeyReader.getKeyPair:104` was filed under this heading as an acceptable leak whose
+test would be too flaky to be worth it, and the two `getPrivateKey` fall-through returns under a
+heading calling their removal cosmetic. Both retirements were wrong, for different reasons, and the
+`crypt-data` section above records why. What that says about this list: an argument for keeping a
+survivor ages exactly as badly as any other state assertion in these docs.
 
-**Already dead code for an unrelated reason - restructuring would be cosmetic.**
-
-- `EncryptedPrivateKeyReader.getPrivateKey(File, String):275` and
-  `PrivateKeyReader.getPrivateKey(byte[]):474` (`EmptyObjectReturnValsMutator`): fall-through
-  returns after every preceding attempt already returns on success. Provably unreachable given the
-  current algorithm list, not merely unobservable. Restructuring to remove the fall-through would
-  change nothing about test coverage and is a separate refactor, not a mutation-testing exercise.
-
-Conclusion: of the 8 individual surviving mutants, 1 is impossible under the current JDK
-(`System.exit`), 5 can only be killed by weakening a real design property (resource safety, a
+Conclusion: of the 5 individual surviving mutants, 1 is impossible under the current JDK
+(`System.exit`) and 4 can only be killed by weakening a real design property (a
 bytecode-compilation artifact of `try`-with-resources, absence of side channels - the 3
-`FeldmanVSS` mutants count as one design property, secret-reconstruction arithmetic), and the
-remaining 2 are unreachable dead code whose removal would be cosmetic. None of the eight is a case
-of "nobody got around to it yet" - and five mutants that briefly *were* exactly that
-(`ScryptHasher.isPowerOfTwo`, `CryptObjectDecoratorExtensions.endsWith` in round three;
+`FeldmanVSS` mutants count as one design property, secret-reconstruction arithmetic). None of the
+five is a case of "nobody got around to it yet" - and eight mutants that briefly *were* exactly
+that (`ScryptHasher.isPowerOfTwo`, `CryptObjectDecoratorExtensions.endsWith` in round three;
 `FeldmanVSS.reconstructSecretBytes`'s two `NegateConditionalsMutator` variants and
-`KemCommand.call` in round four) are why this list gets re-checked rather than taken as final. Round
+`KemCommand.call` in round four; `EncryptedPrivateKeyReader.getKeyPair` and the two `getPrivateKey`
+fall-through returns in round five) are why this list gets re-checked rather than taken as final.
+Round
 four also demonstrates a second way a survivor disappears: `Argon2Support.verify` and
 `Pbkdf2Support.verify` moved out of this document entirely not because a new test targets them
 directly, but because extracting the guarded logic out of the `finally`-carrying method changed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,6 +36,7 @@ fix ships with a test that is verified to fail without it.
 | `CryptObjectDecoratorExtensions.startsWith` / `endsWith` (private) | `startsWith` indexed `array[i]` without checking the array is at least as long as the prefix (`ArrayIndexOutOfBoundsException`). `endsWith` fell through to an unconditional `return true` whether every suffix byte matched *or* the array simply ran out first, so `removeFromEnd` then computed a negative length (`NegativeArraySizeException`) - and the existing test asserted that exception as correct. The fourth bug-enshrining test of the cycle. | Same mutation pass. |
 | `SRP6aClient.computeSessionKey` / `SRP6aVerifierGenerator.generateVerifier` | Not a defect in the code, but an untested security property: both wipe the UTF-8 `passwordBytes` they derive, and no test could tell whether they did. Declared an equivalent mutant in the first pass; the adversarial verifier disproved that - Bouncy Castle's `SRP6Util.calculateX` hands the array to `Digest.update` *by reference*, so a recording digest observes the production buffer. | Adversarial verification of an equivalence claim. `SrpPasswordBytesWipeTest` now asserts the buffer reads all zeroes. |
 | `Argon2SupportTest.verify_answersFalseForATamperedHash` (test suite) | Flaky by construction: it flipped the *last* base64 character of the 43-character unpadded hash, of which only 4 bits are significant - whenever that character was `A`, the `A→B` flip decoded to identical bytes, `verify` correctly answered `true`, and the test failed. One run in sixteen. The sibling PBKDF2 test already carried a comment warning about exactly this. | First reported as "could not be reproduced in eight runs"; root-caused during the mutation pass when it failed on a clean tree. Now tampers the first character. |
+| `EncryptedPrivateKeyReader.getKeyPair` (`crypt-data`) | **Resource leak.** The PEM parser was closed with a plain call after `readObject()`, so a malformed PEM body - which makes `readObject()` throw - left the underlying `FileReader` open until the garbage collector reclaimed it. A caller validating a batch of key files leaked one descriptor per rejected file. It was the only PEM/Reader construction site in `src/main` not using `try`-with-resources. | Fifth mutation pass: the surviving `PEMParser.close()` mutant had been documented as an acceptable leak whose test would be flaky. Re-reading the code for *which* path leaks showed the exception path never closes at all, and a test that counts the `/proc/self/fd` entries pointing at one named file observes it deterministically. |
 
 ---
 
@@ -88,16 +89,16 @@ code the tests do run, how much would they notice being broken?".
 | Repo | Measured on | Tests | Line | Branch | Mutation score (killed / generated) | Test strength |
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
-| `crypt-data` | `develop` @ `7effa34` (PR #5) | 1018 | 100.00% | 100.00% | 99.6% (779 / 782) | 99.6% |
+| `crypt-data` | `2374c66` (PR #8) | 1019 | 100.00% | 100.00% | 100.0% (779 / 779) | 100.0% |
 | `mystic-crypt` | `develop` @ `b7491c26` | 896 | 99.92% | 100.00% | 99.5% (1071 / 1076) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.
 
-`crypt-api` is the only one of the three at a literal 100% mutation score. The other two are not
-at 100% because the remaining survivors cannot be killed without making the code worse - see
+`crypt-api` and `crypt-data` are at a literal 100% mutation score. `mystic-crypt` is not, because
+its remaining survivors cannot be killed without making the code worse - see
 ["Why not literal 100%"](COVERAGE_EXCEPTIONS.md#why-not-literal-100) in
-[COVERAGE_EXCEPTIONS.md](COVERAGE_EXCEPTIONS.md) for the per-mutant reasoning. Four rounds of this
+[COVERAGE_EXCEPTIONS.md](COVERAGE_EXCEPTIONS.md) for the per-mutant reasoning. Five rounds of this
 cycle's work went specifically after every surviving mutant: the first round (PR #69 for
 `mystic-crypt`) killed what was killable and documented the rest; a second pass (PR #5 for
 `crypt-data`, PR #76 for `mystic-crypt`) re-examined every documented survivor and found seven that
@@ -109,8 +110,12 @@ questioning an unstated assumption in a prior "equivalent for every reachable in
 input space was bigger than the reachable-through-`splitSecret` subset the argument implicitly
 assumed) and one by substituting a defective JCA provider instead of touching production code - plus
 turned two more from unkillable into killable by extracting a `finally`-free helper method, which
-let PIT's own equivalent-constant filter apply. What is left after all four rounds is the floor, not
-something left undone.
+let PIT's own equivalent-constant filter apply. A fifth pass on `crypt-data` alone (PR #8) cleared
+its last three and overturned the reasoning behind two of them: the `PEMParser.close()` mutant was
+documented as an acceptable leak whose test would be flaky, and both halves of that were wrong -
+the leak happens on the exception path where `close()` never runs at all, and counting the
+descriptors in `/proc/self/fd` that point at one named file is deterministic, not a total-count
+heuristic. What is left after all five rounds is the floor, not something left undone.
 
 **What these numbers do not tell you.** The two uncovered lines in `mystic-crypt` are
 `MysticCryptCli.main`, which is `System.exit(execute(args))`: no in-process test can execute it


### PR DESCRIPTION
Follow-up to [crypt-data PR #8](https://github.com/astrapi69/crypt-data/pull/8), which cleared crypt-data's last three surviving mutants. The canonical metrics table and the survivor list live here, so they are updated here.

## The numbers

| Repo | before | after |
|---|---|---|
| `crypt-data` | 1018 tests, 99.6% (779 / 782), 3 survivors, @ `7effa34` | 1019 tests, **100.0% (779 / 779)**, 0 survivors, @ `2374c66` |

Line and branch coverage stay at 100.00% / 100.00%. Measured with `./gradlew clean build` and `./gradlew pitest` in the crypt-data working copy on that commit, read from `jacocoTestReport.xml` and `mutations.xml`.

## The part worth recording

Two of the three survivors had been retired in `COVERAGE_EXCEPTIONS.md` with arguments that were wrong.

`EncryptedPrivateKeyReader.getKeyPair:104` sat under "killable only by making the design worse", described as a leak that changes no result and whose test would be "flaky and platform-dependent". Both halves failed on re-reading:

- The note assumed the happy path, where `close()` runs after `readObject()` returns. The leak is on the *exception* path, where `close()` is never reached at all, so every malformed PEM file leaks a descriptor. That is a real defect, filed as crypt-data issue #7 and fixed with try-with-resources.
- "Flaky and platform-dependent" described a total-open-descriptor-count heuristic. Counting the entries under `/proc/self/fd` that point at one named file is deterministic; the test skips itself where that directory does not exist.

The two `getPrivateKey` fall-through returns sat under "already dead code - restructuring would be cosmetic". Cheap, rather than cosmetic: the local was initialised to `Optional.empty()`, reassigned in every success branch and returned there immediately, so it could never hold anything else at the fall-through. Writing that literal in the source makes PIT's own equivalent-constant filter drop the mutant.

## What changed in the docs

- `TESTING.md`: the `crypt-data` metrics row; the "`crypt-api` is the only one at a literal 100%" sentence, which is no longer true; the round narrative extended to five rounds; a row in the defect table for the resource leak.
- `COVERAGE_EXCEPTIONS.md`: the `crypt-data` section rewritten from three survivors to none, carrying the reasoning for why each is gone; the survivor count and conclusion in "Why not literal 100%" corrected from 8 to 5; the two retired entries replaced by a note on what their retirement got wrong, since the point of that section is the argument, not the tally.

`mystic-crypt`'s own five survivors and its metrics row are untouched.

Merge after crypt-data PR #8, since the numbers describe that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)