### PR TITLE
feat(cli): close the gaps between the library CLI and the UI plugins

### DIFF
--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/CertificateCommand.java
@@ -27,14 +27,17 @@ package io.github.astrapi69.mystic.crypt.cli;
 import java.io.File;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 import org.bouncycastle.asn1.x500.X500Name;
 
 import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
-import io.github.astrapi69.crypt.data.factory.CertFactory;
 import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
 import io.github.astrapi69.crypt.data.key.writer.CertificateWriter;
+import io.github.astrapi69.mystic.crypt.ssl.SelfSignedCertificateFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -43,7 +46,9 @@ import picocli.CommandLine.Option;
  * and subject are the same distinguished name (self-signed).
  */
 @Command(name = "cert", mixinStandardHelpOptions = true, //
-	description = "Create a self-signed X.509 certificate and write it as PEM.")
+	description = "Create a self-signed X.509 certificate and write it as PEM, with basic "
+		+ "constraints, key usage and subject alternative names. Exit code 0 = written, "
+		+ "2 = error.")
 public class CertificateCommand implements Callable<Integer>
 {
 
@@ -81,20 +86,142 @@ public class CertificateCommand implements Callable<Integer>
 	@Option(names = "--out", required = true, description = "Write the certificate PEM to this file.")
 	File out;
 
+	@Option(names = "--basic-constraints", description = "Basic constraints: 'ca' or 'end-entity', "
+		+ "optionally with a path length as in 'ca,pathlen=1'.")
+	String basicConstraints;
+
+	@Option(names = "--key-usage", split = ",", description = "Key usages, comma separated: "
+		+ "digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, "
+		+ "keyCertSign, cRLSign, encipherOnly, decipherOnly.")
+	List<String> keyUsages = new ArrayList<>();
+
+	@Option(names = "--san", description = "A subject alternative name as type:value, repeatable, "
+		+ "e.g. dns:example.org, ip:10.0.0.1, email:someone@example.org, uri:https://example.org.")
+	List<String> subjectAlternativeNames = new ArrayList<>();
+
+	@Option(names = "--critical", split = ",", description = "Which of the extensions to mark "
+		+ "critical, comma separated: basic-constraints, key-usage, san.")
+	List<String> criticalExtensions = new ArrayList<>();
+
 	@Override
-	public Integer call() throws Exception
+	public Integer call()
 	{
-		KeyPairGeneratorAlgorithm keyPairAlgorithm = CliSupport.parseKeyPairAlgorithm(algorithm);
-		KeyPair keyPair = CliSupport.isSizeBased(keyPairAlgorithm)
-			? KeyPairFactory.newKeyPair(keyPairAlgorithm, size)
-			: KeyPairFactory.newKeyPair(keyPairAlgorithm);
+		try
+		{
+			KeyPairGeneratorAlgorithm keyPairAlgorithm = CliSupport
+				.parseKeyPairAlgorithm(algorithm);
+			KeyPair keyPair = CliSupport.isSizeBased(keyPairAlgorithm)
+				? KeyPairFactory.newKeyPair(keyPairAlgorithm, size)
+				: KeyPairFactory.newKeyPair(keyPairAlgorithm);
 
-		X500Name distinguishedName = new X500Name(subject);
-		X509Certificate certificate = CertFactory.newX509CertificateV3(keyPair, distinguishedName,
-			days, distinguishedName, signatureAlgorithm);
-		CertificateWriter.writeInPemFormat(certificate, out);
+			X500Name distinguishedName = new X500Name(subject);
+			X509Certificate certificate = SelfSignedCertificateFactory.create(keyPair,
+				distinguishedName, days, signatureAlgorithm, extensions());
+			CertificateWriter.writeInPemFormat(certificate, out);
 
-		System.out.println("wrote self-signed certificate for '" + subject + "' to " + out);
-		return 0;
+			System.out.println("wrote self-signed certificate for '" + subject + "' to " + out
+				+ describeExtensions());
+			return 0;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
+	}
+
+	/**
+	 * Builds the extension set from the options.
+	 *
+	 * @return the extensions to write
+	 */
+	private SelfSignedCertificateFactory.Extensions extensions()
+	{
+		List<SelfSignedCertificateFactory.SubjectAlternativeName> names = new ArrayList<>();
+		for (String name : subjectAlternativeNames)
+		{
+			names.add(SelfSignedCertificateFactory.SubjectAlternativeName.parse(name));
+		}
+		return new SelfSignedCertificateFactory.Extensions(parseBasicConstraints(), keyUsages,
+			names, criticalExtensions);
+	}
+
+	/**
+	 * Parses {@code ca} or {@code end-entity}, optionally with {@code ,pathlen=n}.
+	 *
+	 * @return the parsed basic constraints, or null when the option was not given
+	 */
+	private SelfSignedCertificateFactory.BasicConstraintsSpec parseBasicConstraints()
+	{
+		if (basicConstraints == null)
+		{
+			return null;
+		}
+		String[] parts = basicConstraints.split(",");
+		boolean certificateAuthority = switch (parts[0].trim().toLowerCase(Locale.ROOT))
+		{
+			case "ca" -> true;
+			case "end-entity" -> false;
+			default -> throw new IllegalArgumentException("basic constraints are either 'ca' or "
+				+ "'end-entity', optionally with a path length as in 'ca,pathlen=1', but were '"
+				+ basicConstraints + "'");
+		};
+		Integer pathLength = null;
+		for (int i = 1; i < parts.length; i++)
+		{
+			String part = parts[i].trim();
+			if (!part.toLowerCase(Locale.ROOT).startsWith("pathlen="))
+			{
+				throw new IllegalArgumentException("'" + part + "' is not part of basic "
+					+ "constraints; only pathlen=<number> follows 'ca'");
+			}
+			pathLength = parsePathLength(part.substring("pathlen=".length()));
+		}
+		if (pathLength != null && !certificateAuthority)
+		{
+			throw new IllegalArgumentException("a path length only means something for a CA: an "
+				+ "end entity signs no certificates, so there is no chain below it to limit");
+		}
+		return new SelfSignedCertificateFactory.BasicConstraintsSpec(certificateAuthority,
+			pathLength);
+	}
+
+	private static Integer parsePathLength(String value)
+	{
+		try
+		{
+			int pathLength = Integer.parseInt(value);
+			if (pathLength < 0)
+			{
+				throw new IllegalArgumentException(
+					"a path length cannot be negative, but was " + pathLength);
+			}
+			return pathLength;
+		}
+		catch (NumberFormatException notANumber)
+		{
+			throw new IllegalArgumentException(
+				"a path length must be a number, but was '" + value + "'", notANumber);
+		}
+	}
+
+	/** Names the extensions that were written, so the run says what the certificate carries. */
+	private String describeExtensions()
+	{
+		List<String> written = new ArrayList<>();
+		if (basicConstraints != null)
+		{
+			written.add("basic constraints (" + basicConstraints + ")");
+		}
+		if (!keyUsages.isEmpty())
+		{
+			written.add("key usage (" + String.join(", ", keyUsages) + ")");
+		}
+		if (!subjectAlternativeNames.isEmpty())
+		{
+			written.add(
+				"subject alternative names (" + String.join(", ", subjectAlternativeNames) + ")");
+		}
+		return written.isEmpty() ? "" : " with " + String.join(", ", written);
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommand.java
@@ -25,10 +25,15 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Callable;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -44,7 +49,9 @@ import picocli.CommandLine.Parameters;
  * offer the non-cryptographic digests (CRC32, Adler32).
  */
 @Command(name = "checksum", mixinStandardHelpOptions = true, //
-	description = "Compute the checksum (message digest) of a file.")
+	description = "Compute the checksum of a file: a plain digest, which answers whether the "
+		+ "file changed, or with --hmac a keyed MAC, which answers whether it changed at the "
+		+ "hands of someone without the key.")
 public class ChecksumCommand implements Callable<Integer>
 {
 
@@ -59,10 +66,27 @@ public class ChecksumCommand implements Callable<Integer>
 	{
 	}
 
-	@Option(names = { "-a", "--algorithm" }, defaultValue = "SHA-256", //
+	/** The digest used when none is named. */
+	private static final String DEFAULT_DIGEST_ALGORITHM = "SHA-256";
+
+	/** The MAC used when --hmac is given without naming one. */
+	private static final String DEFAULT_MAC_ALGORITHM = "HmacSHA256";
+
+	@Option(names = { "-a", "--algorithm" }, //
 		description = "Digest algorithm (a JDK name), e.g. MD5, SHA-1, SHA-256, SHA-512 "
-			+ "(default: SHA-256).")
+			+ "(default: SHA-256). With --hmac a MAC name such as HmacSHA256 (default: HmacSHA256).")
 	String algorithm;
+
+	@Option(names = "--hmac", description = "Compute a keyed MAC instead of a plain digest, which "
+		+ "answers whether the file was changed by someone who does not hold the key.")
+	boolean hmac;
+
+	@Option(names = "--key", description = "The MAC key. Prefer --key-stdin to keep it out of the "
+		+ "process arguments.")
+	String key;
+
+	@Option(names = "--key-stdin", description = "Read the MAC key from the first line of standard input.")
+	boolean keyStdin;
 
 	@Parameters(index = "0", paramLabel = "FILE", description = "The file to checksum.")
 	File file;
@@ -70,18 +94,74 @@ public class ChecksumCommand implements Callable<Integer>
 	@Override
 	public Integer call() throws Exception
 	{
-		MessageDigest messageDigest;
 		try
 		{
-			messageDigest = MessageDigest.getInstance(algorithm);
+			byte[] content = Files.readAllBytes(file.toPath());
+			if (hmac)
+			{
+				String macAlgorithm = algorithm == null ? DEFAULT_MAC_ALGORITHM : algorithm;
+				byte[] mac = keyedDigest(content, macAlgorithm);
+				print(mac, macAlgorithm + " keyed digest");
+				return 0;
+			}
+			String digestAlgorithm = algorithm == null ? DEFAULT_DIGEST_ALGORITHM : algorithm;
+			print(plainDigest(content, digestAlgorithm), digestAlgorithm + " digest");
+			return 0;
 		}
-		catch (NoSuchAlgorithmException exception)
+		catch (IllegalArgumentException wrongInput)
 		{
-			throw new IllegalArgumentException("unknown digest algorithm '" + algorithm
+			System.err.println(CliSupport.error(wrongInput.getMessage()));
+			return 2;
+		}
+	}
+
+	/**
+	 * Prints the result the way {@code sha256sum} does, the value first so it stays the first
+	 * whitespace-separated field, followed by what question it answers.
+	 *
+	 * @param result
+	 *            the digest or MAC bytes
+	 * @param label
+	 *            what was computed
+	 */
+	private void print(final byte[] result, final String label)
+	{
+		System.out
+			.println(CliSupport.HEX.formatHex(result) + "  " + label + " of " + file.getPath());
+	}
+
+	private static byte[] plainDigest(final byte[] content, final String digestAlgorithm)
+	{
+		try
+		{
+			return MessageDigest.getInstance(digestAlgorithm).digest(content);
+		}
+		catch (NoSuchAlgorithmException unknown)
+		{
+			throw new IllegalArgumentException("unknown digest algorithm '" + digestAlgorithm
 				+ "'. Use a JDK digest name such as MD5, SHA-1, SHA-256 or SHA-512.");
 		}
-		byte[] digest = messageDigest.digest(Files.readAllBytes(file.toPath()));
-		System.out.println(CliSupport.HEX.formatHex(digest));
-		return 0;
+	}
+
+	private byte[] keyedDigest(final byte[] content, final String macAlgorithm)
+	{
+		String macKey = CliSupport.resolvePassword(key, keyStdin);
+		try
+		{
+			Mac mac = Mac.getInstance(macAlgorithm);
+			mac.init(new SecretKeySpec(macKey.getBytes(StandardCharsets.UTF_8), macAlgorithm));
+			return mac.doFinal(content);
+		}
+		catch (NoSuchAlgorithmException unknown)
+		{
+			throw new IllegalArgumentException("unknown MAC algorithm '" + macAlgorithm
+				+ "'. Use a JDK MAC name such as HmacSHA256, HmacSHA512 or HmacSHA3-256. A plain "
+				+ "digest name like SHA-256 is not one: drop --hmac to compute that instead.");
+		}
+		catch (InvalidKeyException rejected)
+		{
+			throw new IllegalArgumentException("the MAC key was rejected: " + rejected.getMessage(),
+				rejected);
+		}
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
@@ -1,0 +1,235 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.key.KeyFileDescription;
+import io.github.astrapi69.mystic.crypt.key.KeyFileReader;
+import io.github.astrapi69.mystic.crypt.key.KeyFileWriter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Examines a key or certificate file, says what it is, and converts it between the encodings that
+ * make sense for it.
+ * <p>
+ * This replaces {@code der2pem}, which did one corner of the same job in one direction.
+ */
+@Command(name = "convert", mixinStandardHelpOptions = true, //
+	description = "Say what a key or certificate file is, and convert it between PEM and DER or "
+		+ "between PKCS#1 and PKCS#8. Exit code 0 = done, 2 = error.")
+public class ConvertCommand implements Callable<Integer>
+{
+
+	/**
+	 * Instantiates a new {@link ConvertCommand}.
+	 * <p>
+	 * Declared explicitly, and public, because picocli builds this subcommand reflectively through
+	 * its default factory when {@link MysticCryptCli} dispatches to it; the class must therefore
+	 * keep an accessible no-argument constructor.
+	 */
+	public ConvertCommand()
+	{
+	}
+
+	/** The targets a file can be converted to. */
+	public enum Target
+	{
+		/** Base64 between BEGIN and END lines. */
+		pem,
+		/** Raw DER bytes. */
+		der,
+		/** The traditional private key form, without the PKCS#8 wrapper. */
+		pkcs1,
+		/** The private key form that carries its algorithm in the structure. */
+		pkcs8
+	}
+
+	@Option(names = { "-i",
+			"--in" }, required = true, description = "The file to examine or convert.")
+	File in;
+
+	@Option(names = { "-o",
+			"--out" }, description = "The file to write. Without it the result is printed, which "
+				+ "only works for PEM.")
+	File out;
+
+	@Option(names = "--to", description = "What to convert to: ${COMPLETION-CANDIDATES}.")
+	Target to;
+
+	@Option(names = "--describe", description = "Only say what the file is, and convert nothing.")
+	boolean describe;
+
+	@Override
+	public Integer call()
+	{
+		try
+		{
+			KeyFileDescription description = KeyFileDescription.of(in);
+			System.out.println(in.getPath() + " is " + description.describe());
+			if (describe || to == null)
+			{
+				if (!describe)
+				{
+					System.out.println("nothing was converted: pass --to to say what to convert it "
+						+ "to, or --describe to ask only what it is");
+				}
+				return 0;
+			}
+			convert(description);
+			return 0;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
+	}
+
+	/**
+	 * One conversion result: either text to print or write, or bytes that only a file can hold.
+	 *
+	 * @param text
+	 *            the PEM text, or null when the result is binary
+	 * @param bytes
+	 *            the DER bytes, or null when the result is text
+	 * @param what
+	 *            what was produced, for the confirmation line
+	 */
+	private record Converted(String text, byte[] bytes, String what) {
+
+		static Converted text(String text, String what)
+		{
+			return new Converted(text, null, what);
+		}
+
+		static Converted bytes(byte[] bytes, String what)
+		{
+			return new Converted(null, bytes, what);
+		}
+	}
+
+	private void convert(KeyFileDescription description) throws Exception
+	{
+		Converted converted = switch (description.content())
+		{
+			case CERTIFICATE -> convertCertificate(description);
+			case PUBLIC_KEY -> convertPublicKey(description);
+			case PRIVATE_KEY_PKCS1, PRIVATE_KEY_PKCS8 -> convertPrivateKey(description);
+		};
+		emit(converted);
+	}
+
+	private Converted convertPrivateKey(KeyFileDescription description) throws Exception
+	{
+		PrivateKey privateKey = KeyFileReader.readPrivateKey(in, description.algorithm());
+		boolean wasPkcs1 = description.content() == KeyFileDescription.Content.PRIVATE_KEY_PKCS1;
+		return switch (to)
+		{
+			case der -> Converted.bytes(KeyFileWriter.toPkcs8(privateKey), "DER, PKCS#8");
+			case pkcs1 -> Converted.text(KeyFileWriter.toPem(privateKey, true), "PEM, PKCS#1");
+			case pkcs8 -> Converted.text(KeyFileWriter.toPem(privateKey, false), "PEM, PKCS#8");
+			// a private key asked for "pem" keeps the wrapping it already had, so that converting
+			// only the encoding does not silently change the structure as well
+			case pem -> Converted.text(KeyFileWriter.toPem(privateKey, wasPkcs1),
+				"PEM, " + (wasPkcs1 ? "PKCS#1" : "PKCS#8"));
+		};
+	}
+
+	private Converted convertPublicKey(KeyFileDescription description) throws Exception
+	{
+		PublicKey publicKey = KeyFileReader.readPublicKey(in, description.algorithm());
+		return switch (to)
+		{
+			case der -> Converted.bytes(publicKey.getEncoded(), "DER");
+			case pem -> Converted.text(KeyFileWriter.toPem(publicKey), "PEM");
+			case pkcs1, pkcs8 -> throw new IllegalArgumentException(
+				"PKCS#1 and PKCS#8 describe how "
+					+ "a private key is wrapped; a public key has neither. Use --to pem or --to der.");
+		};
+	}
+
+	private Converted convertCertificate(KeyFileDescription description) throws Exception
+	{
+		byte[] der = description.encoding() == KeyFileDescription.Encoding.DER
+			? Files.readAllBytes(in.toPath())
+			: certificateDerFromPem();
+		return switch (to)
+		{
+			case der -> Converted.bytes(der, "DER");
+			case pem -> Converted.text(KeyFileWriter.toPem("CERTIFICATE", der), "PEM");
+			case pkcs1, pkcs8 -> throw new IllegalArgumentException(
+				"PKCS#1 and PKCS#8 describe how "
+					+ "a private key is wrapped; a certificate has neither. Use --to pem or --to der.");
+		};
+	}
+
+	/**
+	 * Writes or prints the result. DER is binary, so it can only go to a file.
+	 *
+	 * @param converted
+	 *            what the conversion produced
+	 * @throws Exception
+	 *             if the file cannot be written
+	 */
+	private void emit(Converted converted) throws Exception
+	{
+		if (converted.text() == null)
+		{
+			if (out == null)
+			{
+				throw new IllegalArgumentException(
+					"DER is binary and cannot be printed; pass --out to write it to a file");
+			}
+			Files.write(out.toPath(), converted.bytes());
+		}
+		else if (out == null)
+		{
+			System.out.print(converted.text());
+			return;
+		}
+		else
+		{
+			Files.writeString(out.toPath(), converted.text(), StandardCharsets.UTF_8);
+		}
+		System.out.println("wrote " + converted.what() + " to " + out.getPath());
+	}
+
+	private byte[] certificateDerFromPem() throws Exception
+	{
+		try (org.bouncycastle.openssl.PEMParser parser = new org.bouncycastle.openssl.PEMParser(
+			new java.io.FileReader(in, StandardCharsets.UTF_8)))
+		{
+			return ((org.bouncycastle.cert.X509CertificateHolder)parser.readObject()).getEncoded();
+		}
+	}
+
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
@@ -1,0 +1,151 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.pw.PassphraseCryptor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Decrypts what {@link EncryptCommand} produced.
+ * <p>
+ * A wrong passphrase and altered data are the negative answer to "can this be opened with this
+ * passphrase", not a failure of the tool, so they exit with 1; an input that is not of this format
+ * at all, or a file that cannot be read, exits with 2.
+ */
+@Command(name = "decrypt", mixinStandardHelpOptions = true, //
+	description = "Decrypt a file or a text encrypted by 'encrypt'. Exit code 0 = decrypted, "
+		+ "1 = wrong passphrase or altered data, 2 = error.")
+public class DecryptCommand implements Callable<Integer>
+{
+
+	/**
+	 * Instantiates a new {@link DecryptCommand}.
+	 * <p>
+	 * Declared explicitly, and public, because picocli builds this subcommand reflectively through
+	 * its default factory when {@link MysticCryptCli} dispatches to it; the class must therefore
+	 * keep an accessible no-argument constructor.
+	 */
+	public DecryptCommand()
+	{
+	}
+
+	@Option(names = { "-i",
+			"--in" }, description = "The file to decrypt, or '-' for standard input.")
+	File in;
+
+	@Option(names = { "-o",
+			"--out" }, description = "The file to write. Without it the result is printed as text.")
+	File out;
+
+	@Option(names = { "-t",
+			"--text" }, description = "The base64 text to decrypt instead of a file.")
+	String text;
+
+	@Option(names = "--text-stdin", description = "Read the base64 text to decrypt from standard input.")
+	boolean textStdin;
+
+	@Option(names = { "-p",
+			"--passphrase" }, description = "The passphrase. Prefer --passphrase-stdin to keep it out of the process arguments.")
+	String passphrase;
+
+	@Option(names = "--passphrase-stdin", description = "Read the passphrase from the first line of standard input.")
+	boolean passphraseStdin;
+
+	@Override
+	public Integer call()
+	{
+		char[] resolvedPassphrase = null;
+		try
+		{
+			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
+			byte[] encrypted = readEncrypted();
+			resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
+				passphraseStdin);
+			byte[] decrypted = PassphraseCryptor.decrypt(resolvedPassphrase, encrypted);
+			String printed = PassphraseCryptSupport.writeOutput(out, decrypted,
+				PassphraseCryptSupport::asText);
+			if (printed == null)
+			{
+				System.out.println("decrypted " + decrypted.length + " bytes to " + out.getPath());
+			}
+			else
+			{
+				System.out.println(printed);
+			}
+			return 0;
+		}
+		catch (SecurityException wrongPassphraseOrAltered)
+		{
+			System.err.println(CliSupport.error(wrongPassphraseOrAltered.getMessage()));
+			return 1;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
+		finally
+		{
+			if (resolvedPassphrase != null)
+			{
+				Arrays.fill(resolvedPassphrase, '\0');
+			}
+		}
+	}
+
+	/**
+	 * Reads the encrypted bytes. A file holds them raw, while the {@code --text} form carries the
+	 * base64 that {@code encrypt} printed.
+	 *
+	 * @return the encrypted bytes
+	 * @throws java.io.IOException
+	 *             if the input file cannot be read
+	 */
+	private byte[] readEncrypted() throws java.io.IOException
+	{
+		if (in != null)
+		{
+			return CliSupport.readData(in);
+		}
+		String base64 = CliSupport.resolveText(text, textStdin).trim();
+		try
+		{
+			return Base64.getDecoder().decode(base64);
+		}
+		catch (IllegalArgumentException notBase64)
+		{
+			throw new IllegalArgumentException(
+				"the text to decrypt is not the base64 that 'encrypt' prints: "
+					+ notBase64.getMessage(),
+				notBase64);
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DerToPemCommand.java
@@ -36,7 +36,8 @@ import picocli.CommandLine.Option;
  * Converts a DER-encoded private key to PEM, printing it or writing it to a file.
  */
 @Command(name = "der2pem", mixinStandardHelpOptions = true, //
-	description = "Convert a DER-encoded private key to PEM.")
+	description = "Deprecated: use 'convert' instead, which detects what the file is and "
+		+ "converts in both directions. Convert a DER-encoded private key to PEM.")
 public class DerToPemCommand implements Callable<Integer>
 {
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
@@ -27,8 +27,6 @@ package io.github.astrapi69.mystic.crypt.cli;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import com.google.common.collect.HashBiMap;
-
 import io.github.astrapi69.mystic.crypt.obfuscation.simple.SimpleObfuscatorExtensions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -54,7 +52,7 @@ public class DisentangleCommand implements Callable<Integer>
 	}
 
 	@Option(names = "--rule", required = true, description = "A character substitution a=x (repeatable).")
-	Map<Character, Character> rules;
+	Map<Character, String> rules;
 
 	@Option(names = "--text", description = "The obfuscated text. Prefer --text-stdin for larger input.")
 	String text;
@@ -66,8 +64,10 @@ public class DisentangleCommand implements Callable<Integer>
 	public Integer call()
 	{
 		String input = CliSupport.resolveText(text, textStdin);
-		System.out
-			.println(SimpleObfuscatorExtensions.disentangleBiMap(HashBiMap.create(rules), input));
+		ObfuscationRuleSupport.Rules parsed = ObfuscationRuleSupport.parse(rules);
+		System.out.println(parsed.isOperated()
+			? ObfuscationRuleSupport.disentangleOperated(parsed.operated(), input)
+			: SimpleObfuscatorExtensions.disentangleBiMap(parsed.simple(), input));
 		return 0;
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.pw.PassphraseCryptor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Encrypts a file or a piece of text with a passphrase, using AES-GCM over a key derived with
+ * PBKDF2-HMAC-SHA256 and a salt that is fresh for every run.
+ */
+@Command(name = "encrypt", mixinStandardHelpOptions = true, //
+	description = "Encrypt a file or a text with a passphrase (AES-GCM, PBKDF2-HMAC-SHA256). "
+		+ "Exit code 0 = encrypted, 2 = error.")
+public class EncryptCommand implements Callable<Integer>
+{
+
+	/**
+	 * Instantiates a new {@link EncryptCommand}.
+	 * <p>
+	 * Declared explicitly, and public, because picocli builds this subcommand reflectively through
+	 * its default factory when {@link MysticCryptCli} dispatches to it; the class must therefore
+	 * keep an accessible no-argument constructor.
+	 */
+	public EncryptCommand()
+	{
+	}
+
+	@Option(names = { "-i",
+			"--in" }, description = "The file to encrypt, or '-' for standard input.")
+	File in;
+
+	@Option(names = { "-o",
+			"--out" }, description = "The file to write. Without it the result is printed as base64.")
+	File out;
+
+	@Option(names = { "-t", "--text" }, description = "The text to encrypt instead of a file.")
+	String text;
+
+	@Option(names = "--text-stdin", description = "Read the text to encrypt from standard input.")
+	boolean textStdin;
+
+	@Option(names = { "-p",
+			"--passphrase" }, description = "The passphrase. Prefer --passphrase-stdin to keep it out of the process arguments.")
+	String passphrase;
+
+	@Option(names = "--passphrase-stdin", description = "Read the passphrase from the first line of standard input.")
+	boolean passphraseStdin;
+
+	@Override
+	public Integer call()
+	{
+		char[] resolvedPassphrase = null;
+		try
+		{
+			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
+			byte[] plain = PassphraseCryptSupport.readInput(in, text, textStdin);
+			resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
+				passphraseStdin);
+			byte[] encrypted = PassphraseCryptor.encrypt(resolvedPassphrase, plain);
+			String printed = PassphraseCryptSupport.writeOutput(out, encrypted,
+				PassphraseCryptSupport::asBase64);
+			if (printed == null)
+			{
+				System.out.println("encrypted " + plain.length + " bytes to " + out.getPath());
+			}
+			else
+			{
+				System.out.println(printed);
+			}
+			return 0;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
+		finally
+		{
+			if (resolvedPassphrase != null)
+			{
+				Arrays.fill(resolvedPassphrase, '\0');
+			}
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/HashCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/HashCommand.java
@@ -64,9 +64,13 @@ public class HashCommand implements Callable<Integer>
 	{
 		String plainPassword = CliSupport.resolvePassword(password, passwordStdin);
 		PasswordEncryptor passwordEncryptor = PasswordEncryptor.getInstance();
-		String encodedHash = algorithm == PasswordAlgorithm.pbkdf2
-			? passwordEncryptor.hashPasswordPbkdf2(plainPassword)
-			: passwordEncryptor.hashPasswordArgon2id(plainPassword);
+		String encodedHash = switch (algorithm)
+		{
+			case pbkdf2 -> passwordEncryptor.hashPasswordPbkdf2(plainPassword);
+			case bcrypt -> passwordEncryptor.hashPasswordBcrypt(plainPassword);
+			case scrypt -> passwordEncryptor.hashPasswordScrypt(plainPassword);
+			case argon2id -> passwordEncryptor.hashPasswordArgon2id(plainPassword);
+		};
 		System.out.println(encodedHash);
 		return 0;
 	}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommand.java
@@ -1,0 +1,267 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.Callable;
+
+import javax.crypto.SecretKey;
+
+import io.github.astrapi69.mystic.crypt.key.KeyExchangeSupport;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * A key exchange between two people, as three separate runs.
+ * <p>
+ * Where {@code kem} plays both sides against itself and shows the mathematics, this is the exchange
+ * as it is used: each side holds only its own half, and what travels between them is a public key
+ * and a handshake.
+ */
+@Command(name = "keyx", mixinStandardHelpOptions = true, //
+	description = "Exchange a shared secret with another person: 'new' on the recipient's side, "
+		+ "'send' on the sender's, 'receive' back on the recipient's.", //
+	subcommands = { KeyExchangeCommand.NewCommand.class, KeyExchangeCommand.SendCommand.class,
+			KeyExchangeCommand.ReceiveCommand.class })
+public class KeyExchangeCommand implements Runnable
+{
+
+	/**
+	 * Instantiates a new {@link KeyExchangeCommand}.
+	 * <p>
+	 * Declared explicitly, and public, because picocli builds this subcommand reflectively through
+	 * its default factory when {@link MysticCryptCli} dispatches to it; the class must therefore
+	 * keep an accessible no-argument constructor.
+	 */
+	public KeyExchangeCommand()
+	{
+	}
+
+	@Override
+	public void run()
+	{
+		CommandLine.usage(this, System.out);
+	}
+
+	/** Writes the given text to a file, or prints it when no file was given. */
+	private static void emit(final File target, final String label, final String text)
+		throws IOException
+	{
+		if (target != null)
+		{
+			Files.writeString(target.toPath(), text + System.lineSeparator(),
+				StandardCharsets.UTF_8);
+			System.out.println(label + " written to " + target.getPath());
+		}
+		else
+		{
+			System.out.println(label + ": " + text);
+		}
+	}
+
+	/** Reads one envelope from a file, trimmed of the trailing newline a file carries. */
+	private static String readEnvelope(final File source) throws IOException
+	{
+		return Files.readString(source.toPath(), StandardCharsets.UTF_8).trim();
+	}
+
+	/**
+	 * Sets up the recipient's side of an exchange.
+	 */
+	@Command(name = "new", mixinStandardHelpOptions = true, //
+		description = "Generate this side's key pair. Exit code 0 = generated, 2 = error.")
+	public static class NewCommand implements Callable<Integer>
+	{
+
+		/**
+		 * Instantiates a new {@link NewCommand}.
+		 * <p>
+		 * Declared explicitly, and public, because picocli builds this subcommand reflectively
+		 * through its default factory; the class must keep an accessible no-argument constructor.
+		 */
+		public NewCommand()
+		{
+		}
+
+		@Option(names = { "-a", "--algorithm" }, defaultValue = KeyExchangeSupport.ML_KEM_768, //
+			description = "The exchange algorithm (default: ${DEFAULT-VALUE}).")
+		String algorithm;
+
+		@Option(names = { "-k",
+				"--key" }, required = true, description = "The file to write this side's private key to.")
+		File key;
+
+		@Option(names = { "-p",
+				"--public" }, description = "The file to write the public half to. Without it the public half is printed.")
+		File publicKey;
+
+		@Override
+		public Integer call()
+		{
+			try
+			{
+				KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(algorithm);
+				Files.writeString(key.toPath(),
+					KeyExchangeSupport.privateKeyOf(party) + System.lineSeparator(),
+					StandardCharsets.UTF_8);
+				System.out.println("algorithm: " + algorithm);
+				System.out.println("private key written to " + key.getPath()
+					+ " - this file is the secret half, hand out only the public one");
+				emit(publicKey, "public key", KeyExchangeSupport.publicKeyOf(party));
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				System.err.println(CliSupport.error(exception.getMessage()));
+				return 2;
+			}
+		}
+	}
+
+	/**
+	 * The sender's side: encapsulates against the recipient's public half.
+	 */
+	@Command(name = "send", mixinStandardHelpOptions = true, //
+		description = "Take the recipient's public key and produce a handshake and a shared "
+			+ "secret. Exit code 0 = done, 2 = error.")
+	public static class SendCommand implements Callable<Integer>
+	{
+
+		/**
+		 * Instantiates a new {@link SendCommand}.
+		 * <p>
+		 * Declared explicitly, and public, because picocli builds this subcommand reflectively
+		 * through its default factory; the class must keep an accessible no-argument constructor.
+		 */
+		public SendCommand()
+		{
+		}
+
+		@Option(names = { "-r",
+				"--recipient" }, required = true, description = "The file holding the recipient's public key.")
+		File recipient;
+
+		@Option(names = { "-m",
+				"--message" }, description = "A message to encrypt with the derived secret.")
+		String message;
+
+		@Option(names = { "-o",
+				"--out" }, description = "The file to write the handshake to. Without it the handshake is printed.")
+		File out;
+
+		@Option(names = { "-e",
+				"--encrypted" }, description = "The file to write the encrypted message to.")
+		File encrypted;
+
+		@Override
+		public Integer call()
+		{
+			try
+			{
+				String publicKey = readEnvelope(recipient);
+				KeyExchangeSupport.Handshake handshake = KeyExchangeSupport.encapsulate(publicKey);
+				System.out.println("algorithm: " + KeyExchangeSupport.algorithmOf(publicKey));
+				emit(out, "handshake", handshake.handshake());
+				System.out.println("shared secret fingerprint: "
+					+ KeyExchangeSupport.fingerprintOf(handshake.sharedSecret())
+					+ " - read it out to the other side to check that both match");
+				if (message != null)
+				{
+					emit(encrypted, "encrypted message", KeyExchangeSupport.encryptMessage(
+						handshake.sharedSecret(), message.getBytes(StandardCharsets.UTF_8)));
+				}
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				System.err.println(CliSupport.error(exception.getMessage()));
+				return 2;
+			}
+		}
+	}
+
+	/**
+	 * The recipient's side again: turns the handshake into the same secret.
+	 */
+	@Command(name = "receive", mixinStandardHelpOptions = true, //
+		description = "Take the handshake and arrive at the same shared secret. "
+			+ "Exit code 0 = done, 2 = error.")
+	public static class ReceiveCommand implements Callable<Integer>
+	{
+
+		/**
+		 * Instantiates a new {@link ReceiveCommand}.
+		 * <p>
+		 * Declared explicitly, and public, because picocli builds this subcommand reflectively
+		 * through its default factory; the class must keep an accessible no-argument constructor.
+		 */
+		public ReceiveCommand()
+		{
+		}
+
+		@Option(names = { "-k",
+				"--key" }, required = true, description = "The file holding this side's private key.")
+		File key;
+
+		@Option(names = { "-s",
+				"--handshake" }, required = true, description = "The file holding the handshake that came back.")
+		File handshake;
+
+		@Option(names = { "-e",
+				"--encrypted" }, description = "The file holding the encrypted message to read.")
+		File encrypted;
+
+		@Override
+		public Integer call()
+		{
+			try
+			{
+				KeyExchangeSupport.Party party = KeyExchangeSupport.partyFrom(readEnvelope(key));
+				SecretKey sharedSecret = KeyExchangeSupport.decapsulate(party,
+					readEnvelope(handshake));
+				System.out.println("algorithm: " + party.algorithm());
+				System.out.println(
+					"shared secret fingerprint: " + KeyExchangeSupport.fingerprintOf(sharedSecret)
+						+ " - it must match the one the other side read out");
+				if (encrypted != null)
+				{
+					byte[] plain = KeyExchangeSupport.decryptMessage(sharedSecret,
+						readEnvelope(encrypted));
+					System.out.println("message: " + new String(plain, StandardCharsets.UTF_8));
+				}
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				System.err.println(CliSupport.error(exception.getMessage()));
+				return 2;
+			}
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
@@ -25,21 +25,36 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.ECGenParameterSpec;
 import java.util.concurrent.Callable;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
 import io.github.astrapi69.crypt.data.factory.KeyPairFactory;
+import io.github.astrapi69.mystic.crypt.key.KeyFileWriter;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
  * Generates a key pair for a chosen algorithm and prints, or writes to files, its private and
- * public key in PEM format. Classical size-based algorithms (RSA, DSA) use {@code --size}; the
- * modern fixed-parameter algorithms (X25519/X448, ML-KEM, ML-DSA, ...) ignore it.
+ * public key in PEM format.
+ * <p>
+ * Classical size-based algorithms (RSA, DSA) use {@code --size}; elliptic curve keys use
+ * {@code --curve} to name the curve; the modern fixed-parameter algorithms (X25519/X448, ML-KEM,
+ * ML-DSA, ...) need neither.
  */
 @Command(name = "keygen", mixinStandardHelpOptions = true, //
-	description = "Generate a key pair and print (or write) its keys as PEM.")
+	description = "Generate a key pair and print (or write) its keys as PEM. "
+		+ "Exit code 0 = generated, 2 = error.")
 public class KeygenCommand implements Callable<Integer>
 {
 
@@ -54,14 +69,35 @@ public class KeygenCommand implements Callable<Integer>
 	{
 	}
 
+	/** The private key encodings {@code --format} offers. */
+	public enum Format
+	{
+		/** The wrapper that carries the key's algorithm inside the structure. */
+		pkcs8,
+		/** The traditional form, without that wrapper. */
+		pkcs1
+	}
+
 	@Option(names = { "-a", "--algorithm" }, defaultValue = "RSA", //
-		description = "Key algorithm, e.g. RSA, X25519, X448, ML-KEM-768, ML-DSA-65 "
+		description = "Key algorithm, e.g. RSA, EC, X25519, X448, ML-KEM-768, ML-DSA-65 "
 			+ "(dashes or underscores accepted; default: RSA).")
 	String algorithm;
 
 	@Option(names = { "-s", "--size" }, defaultValue = "2048", //
 		description = "Key size in bits for size-based algorithms like RSA (default: 2048).")
 	int size;
+
+	@Option(names = { "-c", "--curve" }, //
+		description = "The named curve for an EC key, e.g. secp256r1, secp384r1, secp521r1.")
+	String curve;
+
+	@Option(names = "--format", defaultValue = "pkcs8", //
+		description = "The private key encoding: ${COMPLETION-CANDIDATES} (default: pkcs8).")
+	Format format;
+
+	@Option(names = "--print-details", description = "Say what was generated: the algorithm, the "
+		+ "size or curve, and the encoding actually written.")
+	boolean printDetails;
 
 	@Option(names = "--out-private", description = "Write the private key PEM to this file instead of stdout.")
 	File outPrivate;
@@ -70,15 +106,122 @@ public class KeygenCommand implements Callable<Integer>
 	File outPublic;
 
 	@Override
-	public Integer call() throws Exception
+	public Integer call()
 	{
+		try
+		{
+			KeyPair keyPair = generate();
+			writePrivateKey(keyPair.getPrivate());
+			CliSupport.writePublicKeyPem(keyPair.getPublic(), outPublic);
+			if (printDetails)
+			{
+				System.out.println(details(keyPair.getPrivate()));
+			}
+			return 0;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
+	}
+
+	private KeyPair generate() throws Exception
+	{
+		if (curve != null)
+		{
+			return newEcKeyPair();
+		}
 		KeyPairGeneratorAlgorithm keyPairAlgorithm = CliSupport.parseKeyPairAlgorithm(algorithm);
-		KeyPair keyPair = CliSupport.isSizeBased(keyPairAlgorithm)
+		return CliSupport.isSizeBased(keyPairAlgorithm)
 			? KeyPairFactory.newKeyPair(keyPairAlgorithm, size)
 			: KeyPairFactory.newKeyPair(keyPairAlgorithm);
+	}
 
-		CliSupport.writePrivateKeyPem(keyPair.getPrivate(), outPrivate);
-		CliSupport.writePublicKeyPem(keyPair.getPublic(), outPublic);
-		return 0;
+	/**
+	 * Generates an elliptic curve key pair on the named curve, through Bouncy Castle so that the
+	 * key can afterwards be used to sign with the same provider.
+	 *
+	 * @return the key pair
+	 * @throws Exception
+	 *             if the curve is unknown or the key cannot be generated
+	 */
+	private KeyPair newEcKeyPair() throws Exception
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC",
+			BouncyCastleProvider.PROVIDER_NAME);
+		try
+		{
+			generator.initialize(new ECGenParameterSpec(curve));
+		}
+		catch (Exception unknownCurve)
+		{
+			throw new IllegalArgumentException(
+				"unknown curve '" + curve
+					+ "'. Use a named curve such as secp256r1, secp384r1 or secp521r1.",
+				unknownCurve);
+		}
+		return generator.generateKeyPair();
+	}
+
+	/**
+	 * Writes the private key in the requested encoding.
+	 * <p>
+	 * This does not go through the crypt-data writer, whose PKCS#8 option writes PKCS#1; see
+	 * {@link KeyFileWriter}.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @throws Exception
+	 *             if the key cannot be written
+	 */
+	private void writePrivateKey(PrivateKey privateKey) throws Exception
+	{
+		String pem = KeyFileWriter.toPem(privateKey, format == Format.pkcs1);
+		if (outPrivate == null)
+		{
+			System.out.print(pem);
+			return;
+		}
+		// deliberately silent: with output files the existing contract is that nothing goes to
+		// stdout, so a shell can redirect the printed form without a stray line in it
+		Files.writeString(outPrivate.toPath(), pem, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Says what was generated. The encoding named here is the one actually written, which is also
+	 * the honest way to see that a requested PKCS#8 really is PKCS#8.
+	 *
+	 * @param privateKey
+	 *            the generated private key
+	 * @return the detail line
+	 */
+	private String details(PrivateKey privateKey)
+	{
+		return "algorithm: " + privateKey.getAlgorithm() + ", " + sizeOrCurve(privateKey)
+			+ ", private key format: " + (format == Format.pkcs1 ? "PKCS#1" : "PKCS#8")
+			+ ", PEM label: " + labelOf(privateKey);
+	}
+
+	private String sizeOrCurve(PrivateKey privateKey)
+	{
+		if (privateKey instanceof ECPrivateKey ecPrivateKey)
+		{
+			return "curve: " + (curve == null ? "unnamed" : curve) + ", field size: "
+				+ ecPrivateKey.getParams().getCurve().getField().getFieldSize() + " bits";
+		}
+		if (privateKey instanceof RSAPrivateKey rsaPrivateKey)
+		{
+			return "size: " + rsaPrivateKey.getModulus().bitLength() + " bits";
+		}
+		return "fixed parameter set";
+	}
+
+	private String labelOf(PrivateKey privateKey)
+	{
+		return format == Format.pkcs1 && "RSA".equals(privateKey.getAlgorithm())
+			? KeyFileWriter.PKCS1_RSA_LABEL
+			: KeyFileWriter.PKCS8_LABEL;
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
@@ -48,7 +48,7 @@ import picocli.CommandLine.Command;
 			DisentangleCommand.class, CertificateCommand.class, KeystoreCommand.class,
 			SignCommand.class, VerifySignatureCommand.class, EncryptCommand.class,
 			DecryptCommand.class, ShareCommand.class, KeyExchangeCommand.class,
-			CommandLine.HelpCommand.class })
+			ConvertCommand.class, CommandLine.HelpCommand.class })
 public class MysticCryptCli implements Runnable
 {
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
@@ -47,7 +47,8 @@ import picocli.CommandLine.Command;
 			ChecksumCommand.class, DerToPemCommand.class, ObfuscateCommand.class,
 			DisentangleCommand.class, CertificateCommand.class, KeystoreCommand.class,
 			SignCommand.class, VerifySignatureCommand.class, EncryptCommand.class,
-			DecryptCommand.class, ShareCommand.class, CommandLine.HelpCommand.class })
+			DecryptCommand.class, ShareCommand.class, KeyExchangeCommand.class,
+			CommandLine.HelpCommand.class })
 public class MysticCryptCli implements Runnable
 {
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
@@ -46,7 +46,8 @@ import picocli.CommandLine.Command;
 	subcommands = { HashCommand.class, VerifyCommand.class, KeygenCommand.class, KemCommand.class,
 			ChecksumCommand.class, DerToPemCommand.class, ObfuscateCommand.class,
 			DisentangleCommand.class, CertificateCommand.class, KeystoreCommand.class,
-			SignCommand.class, VerifySignatureCommand.class, CommandLine.HelpCommand.class })
+			SignCommand.class, VerifySignatureCommand.class, EncryptCommand.class,
+			DecryptCommand.class, CommandLine.HelpCommand.class })
 public class MysticCryptCli implements Runnable
 {
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/MysticCryptCli.java
@@ -47,7 +47,7 @@ import picocli.CommandLine.Command;
 			ChecksumCommand.class, DerToPemCommand.class, ObfuscateCommand.class,
 			DisentangleCommand.class, CertificateCommand.class, KeystoreCommand.class,
 			SignCommand.class, VerifySignatureCommand.class, EncryptCommand.class,
-			DecryptCommand.class, CommandLine.HelpCommand.class })
+			DecryptCommand.class, ShareCommand.class, CommandLine.HelpCommand.class })
 public class MysticCryptCli implements Runnable
 {
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscateCommand.java
@@ -27,18 +27,21 @@ package io.github.astrapi69.mystic.crypt.cli;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import com.google.common.collect.HashBiMap;
-
+import io.github.astrapi69.mystic.crypt.obfuscation.character.ObfuscatorExtensions;
 import io.github.astrapi69.mystic.crypt.obfuscation.simple.SimpleObfuscatorExtensions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
  * Obfuscates text with a character-substitution map. Each {@code --rule a=x} maps a character to
- * its replacement; the inverse {@link DisentangleCommand} reverses it with the same rules.
+ * its replacement, and {@code --rule a=x:UPPERCASE@0,3} adds an operation that applies at the named
+ * positions instead of the plain replacement. The inverse {@link DisentangleCommand} reverses it
+ * with the same rules.
  */
 @Command(name = "obfuscate", mixinStandardHelpOptions = true, //
-	description = "Obfuscate text with a character-substitution map (--rule a=x, repeatable).")
+	description = "Obfuscate text with a character-substitution map (--rule a=x), optionally "
+		+ "with an operation at named positions (--rule a=x:UPPERCASE@0,3). "
+		+ "Exit code 0 = obfuscated, 2 = error.")
 public class ObfuscateCommand implements Callable<Integer>
 {
 
@@ -53,8 +56,10 @@ public class ObfuscateCommand implements Callable<Integer>
 	{
 	}
 
-	@Option(names = "--rule", required = true, description = "A character substitution a=x (repeatable).")
-	Map<Character, Character> rules;
+	@Option(names = "--rule", required = true, description = "A character substitution a=x, or an "
+		+ "operated one a=x:UPPERCASE@0,3 which writes the operated character at those positions "
+		+ "and the substitution everywhere else (repeatable).")
+	Map<Character, String> rules;
 
 	@Option(names = "--text", description = "The text to obfuscate. Prefer --text-stdin for larger input.")
 	String text;
@@ -65,9 +70,19 @@ public class ObfuscateCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		String input = CliSupport.resolveText(text, textStdin);
-		System.out
-			.println(SimpleObfuscatorExtensions.obfuscateBiMap(HashBiMap.create(rules), input));
-		return 0;
+		try
+		{
+			String input = CliSupport.resolveText(text, textStdin);
+			ObfuscationRuleSupport.Rules parsed = ObfuscationRuleSupport.parse(rules);
+			System.out.println(parsed.isOperated()
+				? ObfuscatorExtensions.obfuscateWith(parsed.operated(), input)
+				: SimpleObfuscatorExtensions.obfuscateBiMap(parsed.simple(), input));
+			return 0;
+		}
+		catch (Exception exception)
+		{
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
@@ -1,0 +1,249 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+import io.github.astrapi69.crypt.api.obfuscation.rule.Operation;
+import io.github.astrapi69.crypt.data.obfuscation.rule.ObfuscationOperationRule;
+
+/**
+ * Parses the {@code --rule} values of {@code obfuscate} and {@code disentangle}, which come in two
+ * shapes.
+ * <p>
+ * The plain shape is a substitution: {@code a=x} replaces every {@code a} with an {@code x}. The
+ * operated shape adds an operation and the positions it applies at: {@code a=x:UPPERCASE@0,3} still
+ * replaces {@code a} with {@code x} everywhere except at index 0 and index 3, where it writes the
+ * operated character - an uppercase {@code A} - instead.
+ * <p>
+ * A rule set is either all plain or contains at least one operated rule; the second case takes the
+ * whole set through the operated obfuscator, so the two shapes can be mixed in one run.
+ */
+final class ObfuscationRuleSupport
+{
+
+	/** Separates the replacement from the operation. */
+	private static final String OPERATION_SEPARATOR = ":";
+
+	/** Separates the operation from the indexes it applies at. */
+	private static final String INDEX_SEPARATOR = "@";
+
+	private ObfuscationRuleSupport()
+	{
+	}
+
+	/**
+	 * One parsed rule set.
+	 *
+	 * @param simple
+	 *            the plain substitutions, when no rule carries an operation
+	 * @param operated
+	 *            the operated rules, when at least one does
+	 */
+	record Rules(BiMap<Character, Character> simple,
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> operated) {
+
+		/**
+		 * Whether this rule set has to go through the operated obfuscator.
+		 *
+		 * @return true if any rule carries an operation
+		 */
+		boolean isOperated()
+		{
+			return operated != null;
+		}
+	}
+
+	/**
+	 * Parses the rule values as picocli collected them.
+	 *
+	 * @param rules
+	 *            the character to rule-text map
+	 * @return the parsed rules
+	 * @throws IllegalArgumentException
+	 *             if a rule is malformed
+	 */
+	static Rules parse(final Map<Character, String> rules)
+	{
+		boolean anyOperated = false;
+		for (final String value : rules.values())
+		{
+			anyOperated = anyOperated || value.contains(OPERATION_SEPARATOR);
+		}
+		if (!anyOperated)
+		{
+			final BiMap<Character, Character> simple = HashBiMap.create();
+			for (final Map.Entry<Character, String> entry : rules.entrySet())
+			{
+				simple.put(entry.getKey(), replacementOf(entry.getValue()));
+			}
+			return new Rules(simple, null);
+		}
+		final BiMap<Character, ObfuscationOperationRule<Character, Character>> operated = HashBiMap
+			.create();
+		for (final Map.Entry<Character, String> entry : rules.entrySet())
+		{
+			operated.put(entry.getKey(), operatedRuleOf(entry.getKey(), entry.getValue()));
+		}
+		return new Rules(null, operated);
+	}
+
+	/**
+	 * Reverses what
+	 * {@link io.github.astrapi69.mystic.crypt.obfuscation.character.ObfuscatorExtensions#obfuscateWith}
+	 * produced.
+	 * <p>
+	 * The library's own operated {@code disentangle} does not do this correctly: for the rules
+	 * {@code a=x:UPPERCASE@0} and {@code b=y} it turns {@code Ayx} back into {@code ayx} rather
+	 * than into {@code aba}, and {@code disentangleImproved} throws a NullPointerException on the
+	 * same input. Reversing this rule shape is completely determined - at a named position the
+	 * operated character stands for the original, everywhere else the replacement does - so it is
+	 * done here rather than on top of a reversal that does not reverse.
+	 *
+	 * @param rules
+	 *            the same rules the text was obfuscated with
+	 * @param obfuscated
+	 *            the obfuscated text
+	 * @return the original text
+	 */
+	static String disentangleOperated(
+		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
+		final String obfuscated)
+	{
+		final StringBuilder text = new StringBuilder(obfuscated.length());
+		for (int position = 0; position < obfuscated.length(); position++)
+		{
+			text.append(originalOf(rules, obfuscated.charAt(position), position));
+		}
+		return text.toString();
+	}
+
+	private static char originalOf(
+		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
+		final char obfuscated, final int position)
+	{
+		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			// a position the rule operates at carries the operated character, not the replacement
+			if (rule.getIndexes().contains(position)
+				&& Operation.operate(rule.getCharacter(), rule.getOperation()) == obfuscated)
+			{
+				return rule.getCharacter();
+			}
+		}
+		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			if (rule.getReplaceWith() == obfuscated)
+			{
+				return rule.getCharacter();
+			}
+		}
+		// a character no rule produced was never obfuscated, so it stands for itself
+		return obfuscated;
+	}
+
+	private static Character replacementOf(final String value)
+	{
+		if (value.length() != 1)
+		{
+			throw new IllegalArgumentException("a substitution replaces one character with one "
+				+ "character, as in a=x, but the replacement was '" + value + "'");
+		}
+		return value.charAt(0);
+	}
+
+	private static ObfuscationOperationRule<Character, Character> operatedRuleOf(
+		final Character character, final String value)
+	{
+		final int operationAt = value.indexOf(OPERATION_SEPARATOR);
+		if (operationAt < 0)
+		{
+			// a plain rule standing next to operated ones: it substitutes everywhere and operates
+			// nowhere, which is what an empty index set says
+			return ObfuscationOperationRule.<Character, Character> builder().character(character)
+				.replaceWith(replacementOf(value)).operation(Operation.NONE)
+				.indexes(new HashSet<>()).build();
+		}
+		final Character replaceWith = replacementOf(value.substring(0, operationAt));
+		final String rest = value.substring(operationAt + 1);
+		final int indexAt = rest.indexOf(INDEX_SEPARATOR);
+		final String operationName = indexAt < 0 ? rest : rest.substring(0, indexAt);
+		final Set<Integer> indexes = indexAt < 0
+			? new HashSet<>()
+			: parseIndexes(rest.substring(indexAt + 1));
+		return ObfuscationOperationRule.<Character, Character> builder().character(character)
+			.replaceWith(replaceWith).operation(parseOperation(operationName)).indexes(indexes)
+			.build();
+	}
+
+	private static Operation parseOperation(final String name)
+	{
+		try
+		{
+			return Operation.valueOf(name.trim().toUpperCase(Locale.ROOT));
+		}
+		catch (final IllegalArgumentException unknown)
+		{
+			throw new IllegalArgumentException("'" + name + "' is not an operation. Use UPPERCASE, "
+				+ "LOWERCASE, NEGATE or NONE.", unknown);
+		}
+	}
+
+	private static Set<Integer> parseIndexes(final String text)
+	{
+		final Set<Integer> indexes = new TreeSet<>();
+		for (final String part : text.split(","))
+		{
+			indexes.add(parseIndex(part.trim()));
+		}
+		return indexes;
+	}
+
+	private static Integer parseIndex(final String part)
+	{
+		try
+		{
+			final int index = Integer.parseInt(part);
+			if (index < 0)
+			{
+				throw new IllegalArgumentException(
+					"a position cannot be negative, but was " + index);
+			}
+			return index;
+		}
+		catch (final NumberFormatException notANumber)
+		{
+			throw new IllegalArgumentException("the positions after '" + INDEX_SEPARATOR
+				+ "' are numbers separated by commas, but one was '" + part + "'", notANumber);
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/PassphraseCryptSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/PassphraseCryptSupport.java
@@ -1,0 +1,169 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+
+/**
+ * Shared plumbing of the {@code encrypt} and {@code decrypt} commands: both resolve the same kind
+ * of input (a file or a piece of text), the same passphrase sources and the same output target, and
+ * differ only in the transformation between them.
+ */
+final class PassphraseCryptSupport
+{
+
+	private PassphraseCryptSupport()
+	{
+	}
+
+	/**
+	 * Resolves the passphrase from the option value or from standard input.
+	 * <p>
+	 * Reading it from standard input keeps it out of the process argument list, which is why the
+	 * plain option carries a warning in its own help text rather than being removed: scripts that
+	 * cannot pipe still need a way in.
+	 *
+	 * @param passphrase
+	 *            the value of {@code --passphrase}, or null
+	 * @param stdin
+	 *            whether to read the passphrase from standard input
+	 * @return the passphrase, to be zeroed by the caller
+	 * @throws IllegalArgumentException
+	 *             if neither source was given
+	 */
+	static char[] resolvePassphrase(final String passphrase, final boolean stdin)
+	{
+		if (stdin)
+		{
+			return CliSupport.resolvePassword(null, true).toCharArray();
+		}
+		if (passphrase == null)
+		{
+			throw new IllegalArgumentException(
+				"a passphrase is required: pass --passphrase or --passphrase-stdin");
+		}
+		return passphrase.toCharArray();
+	}
+
+	/**
+	 * Rejects the one option combination that cannot work: two options that both want to consume
+	 * standard input. Without this the second read silently returns nothing and the user is left
+	 * guessing why the passphrase was empty.
+	 *
+	 * @param textStdin
+	 *            whether the text is to be read from standard input
+	 * @param passphraseStdin
+	 *            whether the passphrase is to be read from standard input
+	 * @throws IllegalArgumentException
+	 *             if both are set
+	 */
+	static void requireOnlyOneStandardInputReader(final boolean textStdin,
+		final boolean passphraseStdin)
+	{
+		if (textStdin && passphraseStdin)
+		{
+			throw new IllegalArgumentException(
+				"--text-stdin and --passphrase-stdin both read standard input, so they cannot be "
+					+ "combined: pass the passphrase with --passphrase, or the text with --text");
+		}
+	}
+
+	/**
+	 * Reads the bytes to process, either from the given file or from the given text.
+	 *
+	 * @param in
+	 *            the input file, or null when text is used
+	 * @param text
+	 *            the value of {@code --text}, or null when a file is used
+	 * @param textStdin
+	 *            whether the text is to be read from standard input
+	 * @return the bytes to process
+	 * @throws IOException
+	 *             if the file cannot be read
+	 */
+	static byte[] readInput(final File in, final String text, final boolean textStdin)
+		throws IOException
+	{
+		if (in != null)
+		{
+			return CliSupport.readData(in);
+		}
+		return CliSupport.resolveText(text, textStdin).getBytes(StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Writes the result to the given file, or returns it for printing when no file was given.
+	 *
+	 * @param out
+	 *            the target file, or null to print
+	 * @param result
+	 *            the bytes to write
+	 * @param printable
+	 *            how to render the bytes when they are printed rather than written
+	 * @return the line to print, or null when the result was written to the file
+	 * @throws IOException
+	 *             if the file cannot be written
+	 */
+	static String writeOutput(final File out, final byte[] result, final Printable printable)
+		throws IOException
+	{
+		if (out != null)
+		{
+			Files.write(out.toPath(), result);
+			return null;
+		}
+		return printable.render(result);
+	}
+
+	/** Renders result bytes for printing to standard output. */
+	@FunctionalInterface
+	interface Printable
+	{
+		/**
+		 * Renders the given bytes as a line of text.
+		 *
+		 * @param result
+		 *            the bytes to render
+		 * @return the text to print
+		 */
+		String render(byte[] result);
+	}
+
+	/** Renders encrypted bytes as base64, the only printable form of arbitrary bytes. */
+	static String asBase64(final byte[] result)
+	{
+		return Base64.getEncoder().encodeToString(result);
+	}
+
+	/** Renders decrypted bytes as the UTF-8 text they were before encryption. */
+	static String asText(final byte[] result)
+	{
+		return new String(result, StandardCharsets.UTF_8);
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/PasswordAlgorithm.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/PasswordAlgorithm.java
@@ -25,12 +25,19 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 /**
- * The password hashing algorithms the {@code hash} and {@code verify} subcommands support.
+ * The password hashing algorithms the {@code hash} subcommand supports.
+ * <p>
+ * {@code verify} deliberately has no such option: every one of these writes what it is into the
+ * encoded hash, so the algorithm is read from the hash rather than named again.
  */
 public enum PasswordAlgorithm
 {
 	/** Argon2id (memory-hard, the recommended default). */
 	argon2id,
 	/** PBKDF2. */
-	pbkdf2
+	pbkdf2,
+	/** bcrypt. */
+	bcrypt,
+	/** scrypt. */
+	scrypt
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
@@ -1,0 +1,253 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.github.astrapi69.mystic.crypt.secret.SecretShare;
+import io.github.astrapi69.mystic.crypt.secret.SecretSharing;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Splits a secret into shares and puts it back together, exposing the library's Shamir secret
+ * sharing on the command line.
+ */
+@Command(name = "share", mixinStandardHelpOptions = true, //
+	description = "Split a secret into shares and combine them back (Shamir secret sharing).", //
+	subcommands = { ShareCommand.SplitCommand.class, ShareCommand.CombineCommand.class })
+public class ShareCommand implements Runnable
+{
+
+	/**
+	 * Instantiates a new {@link ShareCommand}.
+	 * <p>
+	 * Declared explicitly, and public, because picocli builds this subcommand reflectively through
+	 * its default factory when {@link MysticCryptCli} dispatches to it; the class must therefore
+	 * keep an accessible no-argument constructor.
+	 */
+	public ShareCommand()
+	{
+	}
+
+	@Override
+	public void run()
+	{
+		CommandLine.usage(this, System.out);
+	}
+
+	/**
+	 * Splits a secret into shares, one share per line.
+	 */
+	@Command(name = "split", mixinStandardHelpOptions = true, //
+		description = "Split a secret into shares, one per line. Exit code 0 = split, 2 = error.")
+	public static class SplitCommand implements Callable<Integer>
+	{
+
+		/**
+		 * Instantiates a new {@link SplitCommand}.
+		 * <p>
+		 * Declared explicitly, and public, because picocli builds this subcommand reflectively
+		 * through its default factory; the class must keep an accessible no-argument constructor.
+		 */
+		public SplitCommand()
+		{
+		}
+
+		@Option(names = "--secret", description = "The secret to split. Prefer --secret-stdin to keep it out of the process arguments.")
+		String secret;
+
+		@Option(names = "--secret-stdin", description = "Read the secret from the first line of standard input.")
+		boolean secretStdin;
+
+		@Option(names = "--file", description = "Split the contents of this file instead of a text secret.")
+		File file;
+
+		@Option(names = { "-t",
+				"--threshold" }, required = true, description = "How many shares are needed to reconstruct the secret.")
+		int threshold;
+
+		@Option(names = { "-n",
+				"--shares" }, required = true, description = "How many shares to produce.")
+		int shares;
+
+		@Option(names = { "-o",
+				"--out" }, description = "Write the shares to this file instead of printing them.")
+		File out;
+
+		@Override
+		public Integer call()
+		{
+			try
+			{
+				byte[] secretBytes = readSecret();
+				List<SecretShare> split = SecretSharing.split(secretBytes, threshold, shares);
+				StringBuilder lines = new StringBuilder();
+				for (SecretShare share : split)
+				{
+					lines.append(share.encode()).append(System.lineSeparator());
+				}
+				if (out != null)
+				{
+					Files.writeString(out.toPath(), lines.toString(), StandardCharsets.UTF_8);
+					System.out.println("wrote " + split.size() + " shares to " + out.getPath()
+						+ "; any " + threshold + " of them reconstruct the secret");
+				}
+				else
+				{
+					System.out.print(lines);
+				}
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				System.err.println(CliSupport.error(exception.getMessage()));
+				return 2;
+			}
+		}
+
+		private byte[] readSecret() throws java.io.IOException
+		{
+			if (file != null)
+			{
+				return CliSupport.readData(file);
+			}
+			if (secretStdin)
+			{
+				return CliSupport.resolvePassword(null, true).getBytes(StandardCharsets.UTF_8);
+			}
+			if (secret == null)
+			{
+				throw new IllegalArgumentException(
+					"a secret is required: pass --secret, --secret-stdin or --file");
+			}
+			return secret.getBytes(StandardCharsets.UTF_8);
+		}
+	}
+
+	/**
+	 * Combines shares back into the secret.
+	 */
+	@Command(name = "combine", mixinStandardHelpOptions = true, //
+		description = "Combine shares back into the secret. Exit code 0 = combined, "
+			+ "1 = the shares do not reconstruct a secret, 2 = error.")
+	public static class CombineCommand implements Callable<Integer>
+	{
+
+		/**
+		 * Instantiates a new {@link CombineCommand}.
+		 * <p>
+		 * Declared explicitly, and public, because picocli builds this subcommand reflectively
+		 * through its default factory; the class must keep an accessible no-argument constructor.
+		 */
+		public CombineCommand()
+		{
+		}
+
+		@Option(names = "--share", description = "A share line, repeatable.")
+		List<String> shareLines = new ArrayList<>();
+
+		@Option(names = "--file", description = "Read the share lines from this file, one per line.")
+		File file;
+
+		@Option(names = { "-o",
+				"--out" }, description = "Write the secret to this file instead of printing it.")
+		File out;
+
+		@Override
+		public Integer call()
+		{
+			// the two phases are kept apart because they answer different questions: reading the
+			// shares can fail before there is anything to reconstruct (exit 2), while combining
+			// them can succeed as an operation and still not produce a secret (exit 1)
+			List<SecretShare> shares;
+			try
+			{
+				shares = readShares();
+			}
+			catch (Exception cannotEvenRead)
+			{
+				System.err.println(CliSupport.error(cannotEvenRead.getMessage()));
+				return 2;
+			}
+			try
+			{
+				byte[] secret = SecretSharing.combine(shares);
+				if (out != null)
+				{
+					Files.write(out.toPath(), secret);
+					System.out.println("wrote the reconstructed secret to " + out.getPath());
+				}
+				else
+				{
+					System.out.println(new String(secret, StandardCharsets.UTF_8));
+				}
+				return 0;
+			}
+			catch (IllegalArgumentException cannotReconstruct)
+			{
+				System.err.println(CliSupport.error(cannotReconstruct.getMessage()));
+				return 1;
+			}
+			catch (Exception exception)
+			{
+				System.err.println(CliSupport.error(exception.getMessage()));
+				return 2;
+			}
+		}
+
+		private List<SecretShare> readShares() throws java.io.IOException
+		{
+			List<String> lines = new ArrayList<>(shareLines);
+			if (file != null)
+			{
+				for (String line : Files.readAllLines(file.toPath(), StandardCharsets.UTF_8))
+				{
+					if (!line.isBlank())
+					{
+						lines.add(line);
+					}
+				}
+			}
+			if (lines.isEmpty())
+			{
+				throw new IllegalArgumentException(
+					"no shares were given: pass --share <line> (repeatable) or --file <file>");
+			}
+			List<SecretShare> shares = new ArrayList<>(lines.size());
+			for (String line : lines)
+			{
+				shares.add(SecretShare.decode(line));
+			}
+			return shares;
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignCommand.java
@@ -30,16 +30,19 @@ import java.security.PrivateKey;
 import java.util.concurrent.Callable;
 
 import io.github.astrapi69.crypt.data.key.reader.PrivateKeyReader;
+import io.github.astrapi69.mystic.crypt.key.KeyFileReader;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Signs a file (or standard input) with an Ed25519, ML-DSA or SLH-DSA private key read from a PEM
- * file and writes the raw signature bytes to a file. The matching {@code verify-signature}
- * subcommand checks such a signature.
+ * Signs a file (or standard input) with a private key read from a PEM or DER file and writes the
+ * raw signature bytes to a file. RSA, ECDSA and DSA are signed through Bouncy Castle, as are their
+ * keys decoded; Ed25519, ML-DSA and SLH-DSA go through their own signer classes. The matching
+ * {@code verify-signature} subcommand checks such a signature.
  */
 @Command(name = "sign", mixinStandardHelpOptions = true, //
-	description = "Sign a file (or standard input) with an Ed25519, ML-DSA or SLH-DSA private key.")
+	description = "Sign a file (or standard input) with an RSA, ECDSA, DSA, Ed25519, ML-DSA or "
+		+ "SLH-DSA private key, from a PEM or DER file.")
 public class SignCommand implements Callable<Integer>
 {
 
@@ -55,12 +58,13 @@ public class SignCommand implements Callable<Integer>
 	}
 
 	@Option(names = { "-a", "--algorithm" }, required = true, //
-		description = "Signature algorithm: Ed25519, ML-DSA-44, ML-DSA-65, ML-DSA-87 or an "
-			+ "SLH-DSA parameter set such as SLH-DSA-SHA2-128S (dashes or underscores accepted).")
+		description = "Signature algorithm: RSA, EC (or ECDSA), DSA, Ed25519, ML-DSA-44, ML-DSA-65, "
+			+ "ML-DSA-87, an SLH-DSA parameter set such as SLH-DSA-SHA2-128S, or a JCA name such "
+			+ "as SHA512withRSA (dashes or underscores accepted).")
 	String algorithm;
 
 	@Option(names = "--key", required = true, //
-		description = "The PEM file with the private key.")
+		description = "The file with the private key, PEM or DER.")
 	File key;
 
 	@Option(names = "--in", required = true, //
@@ -84,19 +88,38 @@ public class SignCommand implements Callable<Integer>
 		}
 		String keyFactoryAlgorithm = SignatureSupport.keyFactoryAlgorithm(algorithm);
 		byte[] data = CliSupport.readData(in);
-		PrivateKey privateKey;
+		PrivateKey privateKey = readPrivateKey(keyFactoryAlgorithm);
+		byte[] signatureBytes = SignatureSupport.sign(algorithm, privateKey, data);
+		Files.write(signature.toPath(), signatureBytes);
+		System.out.println("wrote signature to " + signature);
+		return 0;
+	}
+
+	/**
+	 * Reads the signing key, accepting PEM and DER alike.
+	 * <p>
+	 * The classical families go through {@link KeyFileReader}, which decodes with the same Bouncy
+	 * Castle provider that signs; the post-quantum and Ed25519 families keep the crypt-data reader
+	 * they already used, whose provider lookup is not in question for them.
+	 *
+	 * @param keyFactoryAlgorithm
+	 *            the key algorithm the signature algorithm implies
+	 * @return the private key
+	 */
+	private PrivateKey readPrivateKey(String keyFactoryAlgorithm)
+	{
 		try
 		{
-			privateKey = PrivateKeyReader.readPemPrivateKey(key, keyFactoryAlgorithm);
+			if (SignatureSupport.isClassical(algorithm))
+			{
+				return KeyFileReader.readPrivateKey(key, keyFactoryAlgorithm);
+			}
+			return PrivateKeyReader.readPemPrivateKey(key, keyFactoryAlgorithm);
 		}
 		catch (Exception exception)
 		{
 			throw new IllegalArgumentException("could not read a " + keyFactoryAlgorithm
 				+ " private key from '" + key + "': " + exception, exception);
 		}
-		byte[] signatureBytes = SignatureSupport.sign(algorithm, privateKey, data);
-		Files.write(signature.toPath(), signatureBytes);
-		System.out.println("wrote signature to " + signature);
-		return 0;
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupport.java
@@ -26,6 +26,11 @@ package io.github.astrapi69.mystic.crypt.cli;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.Signature;
+import java.util.Locale;
+import java.util.Map;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
 import io.github.astrapi69.mystic.crypt.key.Ed25519Signer;
@@ -34,6 +39,7 @@ import io.github.astrapi69.mystic.crypt.key.MlDsaSigner;
 import io.github.astrapi69.mystic.crypt.key.MlDsaVerifier;
 import io.github.astrapi69.mystic.crypt.key.SlhDsaSigner;
 import io.github.astrapi69.mystic.crypt.key.SlhDsaVerifier;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
 
 /**
  * One entry point for the three signature families the library provides: the classical Ed25519 and
@@ -48,8 +54,61 @@ final class SignatureSupport
 	/** the name under which the Ed25519 signature family is offered */
 	static final String ED25519 = "Ed25519";
 
+	/**
+	 * The classical families, mapped from the name a user gives to the JCA signature algorithm and
+	 * the key factory algorithm that decodes their keys. {@code ECDSA} and {@code EC} name the same
+	 * thing - a private key file reports one and a certificate the other - so both are accepted.
+	 */
+	private static final Map<String, Classical> CLASSICAL = Map.of(//
+		"RSA", new Classical("SHA256withRSA", "RSA"), //
+		"EC", new Classical("SHA256withECDSA", "EC"), //
+		"ECDSA", new Classical("SHA256withECDSA", "EC"), //
+		"DSA", new Classical("SHA256withDSA", "DSA"));
+
+	/**
+	 * One classical signature family.
+	 *
+	 * @param signatureAlgorithm
+	 *            the JCA signature algorithm used when the user names only the key algorithm
+	 * @param keyAlgorithm
+	 *            the key factory algorithm that decodes keys of this family
+	 */
+	private record Classical(String signatureAlgorithm, String keyAlgorithm) {
+	}
+
 	private SignatureSupport()
 	{
+	}
+
+	/**
+	 * Whether the given name selects one of the classical families, either by naming the key
+	 * algorithm ({@code RSA}, {@code EC}, {@code ECDSA}, {@code DSA}) or by naming a JCA signature
+	 * algorithm of one of them outright ({@code SHA512withRSA}).
+	 *
+	 * @param algorithm
+	 *            the name the user gave
+	 * @return true if this is a classical signature algorithm
+	 */
+	static boolean isClassical(String algorithm)
+	{
+		return classicalOf(algorithm) != null;
+	}
+
+	private static Classical classicalOf(String algorithm)
+	{
+		final String normalized = algorithm.trim().toUpperCase(Locale.ROOT);
+		final Classical named = CLASSICAL.get(normalized);
+		if (named != null)
+		{
+			return named;
+		}
+		final int with = normalized.indexOf("WITH");
+		if (with < 0)
+		{
+			return null;
+		}
+		final Classical family = CLASSICAL.get(normalized.substring(with + "WITH".length()));
+		return family == null ? null : new Classical(algorithm.trim(), family.keyAlgorithm());
 	}
 
 	/** Whether the given algorithm name selects the Ed25519 family. */
@@ -74,6 +133,11 @@ final class SignatureSupport
 		{
 			return ED25519;
 		}
+		Classical classical = classicalOf(algorithm);
+		if (classical != null)
+		{
+			return classical.keyAlgorithm();
+		}
 		return parse(algorithm).getAlgorithm();
 	}
 
@@ -95,6 +159,14 @@ final class SignatureSupport
 		if (isEd25519(algorithm))
 		{
 			return new Ed25519Signer(privateKey).sign(data);
+		}
+		Classical classical = classicalOf(algorithm);
+		if (classical != null)
+		{
+			Signature signer = newClassicalSignature(classical);
+			signer.initSign(privateKey);
+			signer.update(data);
+			return signer.sign();
 		}
 		KeyPairGeneratorAlgorithm parsed = parse(algorithm);
 		return parsed.name().startsWith("ML_DSA")
@@ -124,6 +196,14 @@ final class SignatureSupport
 		{
 			return new Ed25519Verifier(publicKey).verify(data, signature);
 		}
+		Classical classical = classicalOf(algorithm);
+		if (classical != null)
+		{
+			Signature verifier = newClassicalSignature(classical);
+			verifier.initVerify(publicKey);
+			verifier.update(data);
+			return verifier.verify(signature);
+		}
 		KeyPairGeneratorAlgorithm parsed = parse(algorithm);
 		return parsed.name().startsWith("ML_DSA")
 			? new MlDsaVerifier(publicKey, parsed).verify(data, signature)
@@ -135,14 +215,31 @@ final class SignatureSupport
 	 * algorithms that cannot sign at all - is rejected with a clear message. Ed25519 never reaches
 	 * this method because its callers branch on {@link #isEd25519(String)} first.
 	 */
+	/**
+	 * Builds the signature object for a classical family, naming Bouncy Castle explicitly.
+	 * <p>
+	 * The provider is not incidental. An elliptic-curve key on a named curve, as Bouncy Castle
+	 * generates them, is rejected by the JDK's own SunEC provider when it signs ("Curve not
+	 * supported"), and verification with such a key returns false rather than throwing - a valid
+	 * signature then reads as an invalid one with nothing saying why. Signing, verifying and
+	 * decoding all go through the same provider so that mismatch cannot arise.
+	 */
+	private static Signature newClassicalSignature(Classical classical) throws Exception
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+		return Signature.getInstance(classical.signatureAlgorithm(),
+			BouncyCastleProvider.PROVIDER_NAME);
+	}
+
 	private static KeyPairGeneratorAlgorithm parse(String algorithm)
 	{
 		KeyPairGeneratorAlgorithm parsed = CliSupport.parseKeyPairAlgorithm(algorithm);
 		if (!parsed.name().startsWith("ML_DSA") && !parsed.name().startsWith("SLH_DSA"))
 		{
 			throw new IllegalArgumentException("'" + algorithm
-				+ "' is not a supported signature algorithm. Use Ed25519, ML-DSA-44, ML-DSA-65, "
-				+ "ML-DSA-87 or an SLH-DSA parameter set such as SLH-DSA-SHA2-128S.");
+				+ "' is not a supported signature algorithm. Use RSA, EC (or ECDSA), DSA, Ed25519, "
+				+ "ML-DSA-44, ML-DSA-65, ML-DSA-87, an SLH-DSA parameter set such as "
+				+ "SLH-DSA-SHA2-128S, or a JCA name such as SHA512withRSA.");
 		}
 		return parsed;
 	}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommand.java
@@ -27,16 +27,19 @@ package io.github.astrapi69.mystic.crypt.cli;
 import java.util.concurrent.Callable;
 
 import io.github.astrapi69.mystic.crypt.pw.PasswordEncryptor;
+import io.github.astrapi69.mystic.crypt.pw.PasswordHashFormat;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Verifies a password against an encoded Argon2id/PBKDF2 hash. Exit code 0 means the password
- * matches, 1 means it does not.
+ * Verifies a password against an encoded hash, reading from the hash which algorithm produced it.
+ * Exit code 0 means the password matches, 1 means it does not, and 2 means the hash belongs to no
+ * algorithm this tool knows.
  */
 @Command(name = "verify", mixinStandardHelpOptions = true, //
-	description = "Verify a password against an encoded Argon2id/PBKDF2 hash. "
-		+ "Exit code 0 = matches, 1 = does not match.")
+	description = "Verify a password against an encoded hash. The algorithm is read from "
+		+ "the hash itself. Exit code 0 = matches, 1 = does not match, 2 = the hash is not of a "
+		+ "known algorithm.")
 public class VerifyCommand implements Callable<Integer>
 {
 
@@ -51,11 +54,8 @@ public class VerifyCommand implements Callable<Integer>
 	{
 	}
 
-	@Option(names = { "-a",
-			"--algorithm" }, defaultValue = "argon2id", description = "Hashing algorithm: ${COMPLETION-CANDIDATES} (default: argon2id).")
-	PasswordAlgorithm algorithm;
-
-	@Option(names = "--hash", required = true, description = "The encoded hash to verify against.")
+	@Option(names = "--hash", required = true, description = "The encoded hash to verify against. "
+		+ "Which algorithm produced it is read from the hash itself.")
 	String hash;
 
 	@Option(names = "--password", description = "The password to verify. Prefer --password-stdin.")
@@ -67,12 +67,20 @@ public class VerifyCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		String plainPassword = CliSupport.resolvePassword(password, passwordStdin);
-		PasswordEncryptor passwordEncryptor = PasswordEncryptor.getInstance();
-		boolean matches = algorithm == PasswordAlgorithm.pbkdf2
-			? passwordEncryptor.matchPbkdf2(plainPassword, hash)
-			: passwordEncryptor.matchArgon2id(plainPassword, hash);
-		System.out.println(matches ? "matches" : "does not match");
-		return matches ? 0 : 1;
+		try
+		{
+			String plainPassword = CliSupport.resolvePassword(password, passwordStdin);
+			PasswordHashFormat format = PasswordHashFormat.of(hash);
+			boolean matches = PasswordEncryptor.getInstance().matchEncodedHash(plainPassword, hash);
+			System.out.println((matches ? "matches" : "does not match") + " (" + format + ")");
+			return matches ? 0 : 1;
+		}
+		catch (Exception exception)
+		{
+			// an encoding that belongs to no known algorithm is not "the password does not match";
+			// answering 1 there would send the reader after the password instead of after the hash
+			System.err.println(CliSupport.error(exception.getMessage()));
+			return 2;
+		}
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifySignatureCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/VerifySignatureCommand.java
@@ -30,6 +30,7 @@ import java.security.PublicKey;
 import java.util.concurrent.Callable;
 
 import io.github.astrapi69.crypt.data.key.reader.PublicKeyReader;
+import io.github.astrapi69.mystic.crypt.key.KeyFileReader;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -58,12 +59,13 @@ public class VerifySignatureCommand implements Callable<Integer>
 	}
 
 	@Option(names = { "-a", "--algorithm" }, required = true, //
-		description = "Signature algorithm: Ed25519, ML-DSA-44, ML-DSA-65, ML-DSA-87 or an "
-			+ "SLH-DSA parameter set such as SLH-DSA-SHA2-128S (dashes or underscores accepted).")
+		description = "Signature algorithm: RSA, EC (or ECDSA), DSA, Ed25519, ML-DSA-44, ML-DSA-65, "
+			+ "ML-DSA-87, an SLH-DSA parameter set such as SLH-DSA-SHA2-128S, or a JCA name such "
+			+ "as SHA512withRSA (dashes or underscores accepted).")
 	String algorithm;
 
 	@Option(names = "--key", required = true, //
-		description = "The PEM file with the public key.")
+		description = "The file with the public key, PEM or DER.")
 	File key;
 
 	@Option(names = "--in", required = true, //
@@ -83,16 +85,7 @@ public class VerifySignatureCommand implements Callable<Integer>
 			String keyFactoryAlgorithm = SignatureSupport.keyFactoryAlgorithm(algorithm);
 			byte[] data = CliSupport.readData(in);
 			byte[] signatureBytes = Files.readAllBytes(signature.toPath());
-			PublicKey publicKey;
-			try
-			{
-				publicKey = PublicKeyReader.readPemPublicKey(key, keyFactoryAlgorithm);
-			}
-			catch (Exception exception)
-			{
-				throw new IllegalArgumentException("could not read a " + keyFactoryAlgorithm
-					+ " public key from '" + key + "': " + exception, exception);
-			}
+			PublicKey publicKey = readPublicKey(keyFactoryAlgorithm);
 			valid = SignatureSupport.verify(algorithm, publicKey, data, signatureBytes);
 		}
 		catch (Exception exception)
@@ -104,5 +97,30 @@ public class VerifySignatureCommand implements Callable<Integer>
 		}
 		System.out.println(valid ? "signature is valid" : "signature is invalid");
 		return valid ? 0 : 1;
+	}
+
+	/**
+	 * Reads the verification key, accepting PEM and DER alike, through the same provider that will
+	 * verify with it for the classical families.
+	 *
+	 * @param keyFactoryAlgorithm
+	 *            the key algorithm the signature algorithm implies
+	 * @return the public key
+	 */
+	private PublicKey readPublicKey(String keyFactoryAlgorithm)
+	{
+		try
+		{
+			if (SignatureSupport.isClassical(algorithm))
+			{
+				return KeyFileReader.readPublicKey(key, keyFactoryAlgorithm);
+			}
+			return PublicKeyReader.readPemPublicKey(key, keyFactoryAlgorithm);
+		}
+		catch (Exception exception)
+		{
+			throw new IllegalArgumentException("could not read a " + keyFactoryAlgorithm
+				+ " public key from '" + key + "': " + exception, exception);
+		}
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupport.java
@@ -1,0 +1,475 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+
+import javax.crypto.SecretKey;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.mystic.crypt.aead.KeyCommittingAeadEncryptor;
+
+/**
+ * A key exchange between two people who each hold only their own half, in three steps that can run
+ * in three separate invocations:
+ * <ul>
+ * <li>the recipient generates a key pair and hands out the public half</li>
+ * <li>the sender takes that public half, encapsulates against it, and gets a secret plus a
+ * handshake to send back</li>
+ * <li>the recipient feeds the handshake to its private half and arrives at the same secret</li>
+ * </ul>
+ * <p>
+ * The three families differ in what actually travels, and this is what hides the difference. ML-KEM
+ * produces a ciphertext. X25519 has no ciphertext at all: the sender makes an ephemeral key pair
+ * and its public half is what travels. The hybrid does both and mixes the results. Every piece of
+ * text carries the algorithm it belongs to, so nobody has to know which of the three they are
+ * holding.
+ * <p>
+ * Nothing here is a secret in transit: what travels is a public key and a handshake, and someone
+ * who reads both still cannot derive the shared secret.
+ */
+public final class KeyExchangeSupport
+{
+
+	/** What every stored key and every handshake of this tool starts with. */
+	public static final String PREFIX = "MCKX1";
+
+	/** The elliptic-curve algorithm, which has no ciphertext. */
+	public static final String X25519 = "X25519";
+
+	/** The ML-KEM parameter sets. */
+	public static final String ML_KEM_512 = "ML-KEM-512";
+
+	/** The ML-KEM parameter set of medium strength, and the one the hybrid uses. */
+	public static final String ML_KEM_768 = "ML-KEM-768";
+
+	/** The strongest ML-KEM parameter set. */
+	public static final String ML_KEM_1024 = "ML-KEM-1024";
+
+	/** The hybrid of the classical and the post-quantum exchange. */
+	public static final String HYBRID = "Hybrid X25519 + ML-KEM-768";
+
+	/** Length in bytes of the derived shared secret, an AES-256 key. */
+	public static final int SECRET_LENGTH = 32;
+
+	/** The envelope kind of a public key. */
+	private static final String PUBLIC_KIND = "PUB";
+
+	/** The envelope kind of a stored private key. */
+	private static final String PRIVATE_KIND = "PRV";
+
+	/** The envelope kind of a handshake. */
+	private static final String HANDSHAKE_KIND = "HS";
+
+	/** The field separator inside an envelope. */
+	private static final String SEPARATOR = "$";
+
+	private KeyExchangeSupport()
+	{
+	}
+
+	/**
+	 * What one side keeps to itself. The public half is handed out with
+	 * {@link #publicKeyOf(Party)}.
+	 *
+	 * @param algorithm
+	 *            one of {@link #algorithms()}
+	 * @param first
+	 *            the key pair, or the X25519 half of a hybrid one
+	 * @param second
+	 *            the ML-KEM half of a hybrid key pair, null for the other algorithms
+	 */
+	public record Party(String algorithm, KeyPair first, KeyPair second) {
+	}
+
+	/**
+	 * What the sender ends up with: a secret to use, and a handshake for the other side.
+	 *
+	 * @param sharedSecret
+	 *            the secret both sides will hold
+	 * @param handshake
+	 *            the text to send back to the recipient
+	 */
+	public record Handshake(SecretKey sharedSecret, String handshake) {
+	}
+
+	/**
+	 * The algorithms this exchange offers, in the order they are shown.
+	 *
+	 * @return the algorithm names
+	 */
+	public static List<String> algorithms()
+	{
+		return List.of(ML_KEM_768, ML_KEM_512, ML_KEM_1024, X25519, HYBRID);
+	}
+
+	/**
+	 * Sets up one side of an exchange.
+	 *
+	 * @param algorithm
+	 *            one of {@link #algorithms()}
+	 * @return the party, whose public half is handed to the other side
+	 * @throws Exception
+	 *             if this machine cannot produce such a key pair
+	 */
+	public static Party newParty(final String algorithm) throws Exception
+	{
+		if (X25519.equals(algorithm))
+		{
+			return new Party(algorithm, X25519KeyExchange.newKeyPair(), null);
+		}
+		if (HYBRID.equals(algorithm))
+		{
+			final HybridKemKeyExchange.HybridKeyPair hybrid = HybridKemKeyExchange
+				.newHybridKeyPair(KeyPairGeneratorAlgorithm.ML_KEM_768);
+			return new Party(algorithm, hybrid.getX25519KeyPair(), hybrid.getMlKemKeyPair());
+		}
+		return new Party(algorithm, MlKemKeyExchange.newKeyPair(mlKemAlgorithm(algorithm)), null);
+	}
+
+	/**
+	 * The public half of a party, as one line of text to hand to the other side.
+	 *
+	 * @param party
+	 *            the party
+	 * @return the public key as text
+	 */
+	public static String publicKeyOf(final Party party)
+	{
+		if (party.second() != null)
+		{
+			return envelope(PUBLIC_KIND, party.algorithm(), party.first().getPublic().getEncoded(),
+				party.second().getPublic().getEncoded());
+		}
+		return envelope(PUBLIC_KIND, party.algorithm(), party.first().getPublic().getEncoded(),
+			null);
+	}
+
+	/**
+	 * The whole of one side, private halves included, as one line of text, so a party can be put
+	 * away and taken up again in another run of the command line.
+	 * <p>
+	 * This text is the private key. Whoever holds it can read everything that was ever sent to this
+	 * party, so it belongs where a private key belongs and not next to the public one.
+	 *
+	 * @param party
+	 *            the party
+	 * @return the party as text
+	 */
+	public static String privateKeyOf(final Party party)
+	{
+		final StringBuilder text = new StringBuilder(PREFIX).append(SEPARATOR).append(PRIVATE_KIND)
+			.append(SEPARATOR).append(party.algorithm()).append(SEPARATOR)
+			.append(encode(party.first().getPrivate().getEncoded())).append(SEPARATOR)
+			.append(encode(party.first().getPublic().getEncoded()));
+		if (party.second() != null)
+		{
+			text.append(SEPARATOR).append(encode(party.second().getPrivate().getEncoded()))
+				.append(SEPARATOR).append(encode(party.second().getPublic().getEncoded()));
+		}
+		return text.toString();
+	}
+
+	/**
+	 * Takes up a party that {@link #privateKeyOf(Party)} put away.
+	 *
+	 * @param text
+	 *            what {@link #privateKeyOf(Party)} produced
+	 * @return the party, ready to decapsulate again
+	 * @throws Exception
+	 *             if the text is not a stored party or its keys cannot be read
+	 */
+	public static Party partyFrom(final String text) throws Exception
+	{
+		final String[] parts = text == null ? new String[0] : text.trim().split("\\$");
+		// The kind is read before the length, and that order is the whole point: a public key has
+		// fewer parts than a private one, so a length check first would call a perfectly good
+		// public key "not a key of this tool" and send the reader looking in the wrong place.
+		if (parts.length < 2 || !PREFIX.equals(parts[0]))
+		{
+			throw new IllegalArgumentException("this is not a stored key of this tool");
+		}
+		if (!PRIVATE_KIND.equals(parts[1]))
+		{
+			throw new IllegalArgumentException(
+				"this is the public half; the private key of this side is needed here");
+		}
+		if (parts.length < 5)
+		{
+			throw new IllegalArgumentException("this stored key is incomplete");
+		}
+		final String algorithm = parts[2];
+		final boolean hybrid = HYBRID.equals(algorithm);
+		if (hybrid && parts.length < 7)
+		{
+			throw new IllegalArgumentException(
+				"a stored hybrid key carries two halves and this one carries one");
+		}
+		final String first = hybrid ? X25519 : algorithm;
+		final KeyPair firstPair = new KeyPair(toPublicKey(decode(parts[4]), first),
+			toPrivateKey(decode(parts[3]), first));
+		if (!hybrid)
+		{
+			return new Party(algorithm, firstPair, null);
+		}
+		final KeyPair secondPair = new KeyPair(toPublicKey(decode(parts[6]), ML_KEM_768),
+			toPrivateKey(decode(parts[5]), ML_KEM_768));
+		return new Party(algorithm, firstPair, secondPair);
+	}
+
+	/**
+	 * The sender's side: takes the recipient's public half and produces a secret and a handshake.
+	 *
+	 * @param recipientPublicKey
+	 *            what the recipient handed out
+	 * @return the shared secret and the handshake to send back
+	 * @throws Exception
+	 *             if the public key cannot be read or the exchange fails
+	 */
+	public static Handshake encapsulate(final String recipientPublicKey) throws Exception
+	{
+		final String[] parts = read(PUBLIC_KIND, recipientPublicKey);
+		final String algorithm = parts[2];
+		final byte[] firstKey = decode(parts[3]);
+		if (X25519.equals(algorithm))
+		{
+			// there is no ciphertext in an elliptic curve exchange: the sender makes an ephemeral
+			// key pair, and its public half is what travels
+			final KeyPair ephemeral = X25519KeyExchange.newKeyPair();
+			final SecretKey secret = X25519KeyExchange.deriveSharedSecret(ephemeral.getPrivate(),
+				toPublicKey(firstKey, X25519), SECRET_LENGTH);
+			return new Handshake(secret,
+				envelope(HANDSHAKE_KIND, algorithm, ephemeral.getPublic().getEncoded(), null));
+		}
+		if (HYBRID.equals(algorithm))
+		{
+			final byte[] secondKey = decode(parts[4]);
+			final HybridKemKeyExchange.HybridEncapsulation encapsulation = HybridKemKeyExchange
+				.hybridEncapsulate(toPublicKey(firstKey, X25519),
+					toPublicKey(secondKey, ML_KEM_768), KeyPairGeneratorAlgorithm.ML_KEM_768,
+					SECRET_LENGTH);
+			return new Handshake(encapsulation.getSharedSecret(),
+				envelope(HANDSHAKE_KIND, algorithm, encapsulation.getMlKemCiphertext(),
+					encapsulation.getSenderX25519PublicKey().getEncoded()));
+		}
+		final MlKemKeyExchange.Encapsulation encapsulation = MlKemKeyExchange
+			.encapsulate(toPublicKey(firstKey, algorithm), mlKemAlgorithm(algorithm));
+		return new Handshake(encapsulation.getSharedSecret(),
+			envelope(HANDSHAKE_KIND, algorithm, encapsulation.getCiphertext(), null));
+	}
+
+	/**
+	 * The recipient's side: takes the handshake and arrives at the same secret.
+	 *
+	 * @param party
+	 *            the recipient, holding the private half
+	 * @param handshake
+	 *            what came back from the sender
+	 * @return the shared secret, the same one the sender holds
+	 * @throws Exception
+	 *             if the handshake does not belong to this party or cannot be read
+	 */
+	public static SecretKey decapsulate(final Party party, final String handshake) throws Exception
+	{
+		final String[] parts = read(HANDSHAKE_KIND, handshake);
+		final String algorithm = parts[2];
+		if (!party.algorithm().equals(algorithm))
+		{
+			throw new IllegalArgumentException("this handshake is for " + algorithm
+				+ " and these keys are for " + party.algorithm());
+		}
+		final byte[] first = decode(parts[3]);
+		if (X25519.equals(algorithm))
+		{
+			return X25519KeyExchange.deriveSharedSecret(party.first().getPrivate(),
+				toPublicKey(first, X25519), SECRET_LENGTH);
+		}
+		if (HYBRID.equals(algorithm))
+		{
+			final byte[] senderPublicKey = decode(parts[4]);
+			return HybridKemKeyExchange.hybridDecapsulate(party.first().getPrivate(),
+				party.second().getPrivate(), toPublicKey(senderPublicKey, X25519), first,
+				KeyPairGeneratorAlgorithm.ML_KEM_768, SECRET_LENGTH);
+		}
+		return MlKemKeyExchange.decapsulate(party.first().getPrivate(), first,
+			mlKemAlgorithm(algorithm));
+	}
+
+	/**
+	 * Encrypts a message with a shared secret, so the secret is used for something rather than only
+	 * looked at.
+	 *
+	 * @param sharedSecret
+	 *            the secret both sides hold
+	 * @param message
+	 *            what to encrypt
+	 * @return the encrypted message as base64
+	 * @throws Exception
+	 *             if encrypting fails
+	 */
+	public static String encryptMessage(final SecretKey sharedSecret, final byte[] message)
+		throws Exception
+	{
+		return encode(new KeyCommittingAeadEncryptor(sharedSecret).encrypt(message));
+	}
+
+	/**
+	 * Decrypts what {@link #encryptMessage(SecretKey, byte[])} produced. A secret that is not the
+	 * same one fails here rather than producing rubbish.
+	 *
+	 * @param sharedSecret
+	 *            the secret
+	 * @param encrypted
+	 *            the encrypted message as base64
+	 * @return the message
+	 * @throws Exception
+	 *             if the secret is wrong or the message was changed
+	 */
+	public static byte[] decryptMessage(final SecretKey sharedSecret, final String encrypted)
+		throws Exception
+	{
+		return new KeyCommittingAeadEncryptor(sharedSecret).decrypt(decode(encrypted.trim()));
+	}
+
+	/**
+	 * A short value over a secret, so two sides can compare that they arrived at the same one by
+	 * reading it out, without either of them showing the secret itself.
+	 *
+	 * @param sharedSecret
+	 *            the secret
+	 * @return eight hex characters
+	 * @throws Exception
+	 *             if the digest is unavailable
+	 */
+	public static String fingerprintOf(final SecretKey sharedSecret) throws Exception
+	{
+		final byte[] digest = MessageDigest.getInstance("SHA-256")
+			.digest(sharedSecret.getEncoded());
+		return HexFormat.of().formatHex(digest).substring(0, 8);
+	}
+
+	/**
+	 * Which algorithm a public key or a handshake belongs to.
+	 *
+	 * @param envelope
+	 *            the text
+	 * @return the algorithm name
+	 */
+	public static String algorithmOf(final String envelope)
+	{
+		final String[] parts = envelope == null ? new String[0] : envelope.trim().split("\\$");
+		if (parts.length < 3 || !PREFIX.equals(parts[0]))
+		{
+			throw new IllegalArgumentException("'" + envelope + "' is not from this tool");
+		}
+		return parts[2];
+	}
+
+	private static String encode(final byte[] bytes)
+	{
+		return Base64.getEncoder().encodeToString(bytes);
+	}
+
+	private static byte[] decode(final String text)
+	{
+		return Base64.getDecoder().decode(text);
+	}
+
+	private static String envelope(final String kind, final String algorithm, final byte[] first,
+		final byte[] second)
+	{
+		final StringBuilder text = new StringBuilder(PREFIX).append(SEPARATOR).append(kind)
+			.append(SEPARATOR).append(algorithm).append(SEPARATOR).append(encode(first));
+		if (second != null)
+		{
+			text.append(SEPARATOR).append(encode(second));
+		}
+		return text.toString();
+	}
+
+	private static String[] read(final String expectedKind, final String envelope)
+	{
+		if (envelope == null || envelope.isBlank())
+		{
+			throw new IllegalArgumentException("there is nothing to read");
+		}
+		final String[] parts = envelope.trim().split("\\$");
+		if (parts.length < 4 || !PREFIX.equals(parts[0]))
+		{
+			throw new IllegalArgumentException("'" + envelope + "' is not from this tool");
+		}
+		if (!expectedKind.equals(parts[1]))
+		{
+			throw new IllegalArgumentException("this is " + (PUBLIC_KIND.equals(parts[1])
+				? "a public key, and a handshake was " + "expected"
+				: "a handshake, and a public key was expected"));
+		}
+		if (HYBRID.equals(parts[2]) && parts.length < 5)
+		{
+			throw new IllegalArgumentException("a hybrid " + expectedKind.toLowerCase(Locale.ROOT)
+				+ " carries two halves and this one carries one");
+		}
+		return parts;
+	}
+
+	private static PublicKey toPublicKey(final byte[] encoded, final String algorithm)
+		throws Exception
+	{
+		return keyFactory(algorithm).generatePublic(new X509EncodedKeySpec(encoded));
+	}
+
+	private static PrivateKey toPrivateKey(final byte[] encoded, final String algorithm)
+		throws Exception
+	{
+		return keyFactory(algorithm).generatePrivate(new PKCS8EncodedKeySpec(encoded));
+	}
+
+	private static KeyFactory keyFactory(final String algorithm) throws Exception
+	{
+		return KeyFactory.getInstance(algorithm.startsWith("ML-KEM") ? "ML-KEM" : algorithm);
+	}
+
+	private static KeyPairGeneratorAlgorithm mlKemAlgorithm(final String algorithm)
+	{
+		return switch (algorithm)
+		{
+			case ML_KEM_512 -> KeyPairGeneratorAlgorithm.ML_KEM_512;
+			case ML_KEM_768 -> KeyPairGeneratorAlgorithm.ML_KEM_768;
+			case ML_KEM_1024 -> KeyPairGeneratorAlgorithm.ML_KEM_1024;
+			default -> throw new IllegalArgumentException(
+				"'" + algorithm + "' is not one of " + String.join(", ", algorithms()));
+		};
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileDescription.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileDescription.java
@@ -1,0 +1,191 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+
+/**
+ * What a key or certificate file turns out to be, so a conversion can say what it found before it
+ * changes anything.
+ *
+ * @param encoding
+ *            whether the file is PEM or DER
+ * @param content
+ *            what the file holds
+ * @param algorithm
+ *            the key algorithm, as the object identifier the file carries
+ */
+public record KeyFileDescription(Encoding encoding, Content content, String algorithm) {
+
+	/** How the bytes are wrapped. */
+	public enum Encoding
+	{
+		/** Base64 between BEGIN and END lines. */
+		PEM,
+		/** Raw DER bytes. */
+		DER
+	}
+
+	/** What the file holds. */
+	public enum Content
+	{
+		/** A private key in the PKCS#8 wrapper. */
+		PRIVATE_KEY_PKCS8,
+		/** A private key in the traditional form, without the PKCS#8 wrapper. */
+		PRIVATE_KEY_PKCS1,
+		/** A public key. */
+		PUBLIC_KEY,
+		/** An X.509 certificate. */
+		CERTIFICATE
+	}
+
+	/**
+	 * Examines the given file.
+	 *
+	 * @param file
+	 *            the file to examine
+	 * @return what it holds
+	 * @throws IOException
+	 *             if the file cannot be read
+	 * @throws IllegalArgumentException
+	 *             if the file is neither a key nor a certificate this tool recognises
+	 */
+	public static KeyFileDescription of(final File file) throws IOException
+	{
+		return KeyFileReader.isPem(file) ? describePem(file) : describeDer(file);
+	}
+
+	/**
+	 * A sentence naming what was found, for a user who asked what a file is.
+	 *
+	 * @return the description as one line
+	 */
+	public String describe()
+	{
+		final String what = switch (content)
+		{
+			case PRIVATE_KEY_PKCS8 -> "a private key in PKCS#8";
+			case PRIVATE_KEY_PKCS1 -> "a private key in PKCS#1, the traditional form";
+			case PUBLIC_KEY -> "a public key";
+			case CERTIFICATE -> "an X.509 certificate";
+		};
+		return what + ", " + encoding + " encoded, algorithm " + algorithm;
+	}
+
+	private static KeyFileDescription describePem(final File file) throws IOException
+	{
+		final Object pemObject = readPem(file);
+		if (pemObject instanceof PEMKeyPair pemKeyPair)
+		{
+			return new KeyFileDescription(Encoding.PEM, Content.PRIVATE_KEY_PKCS1,
+				algorithmOf(pemKeyPair.getPrivateKeyInfo()));
+		}
+		if (pemObject instanceof PrivateKeyInfo privateKeyInfo)
+		{
+			return new KeyFileDescription(Encoding.PEM, Content.PRIVATE_KEY_PKCS8,
+				algorithmOf(privateKeyInfo));
+		}
+		if (pemObject instanceof SubjectPublicKeyInfo publicKeyInfo)
+		{
+			return new KeyFileDescription(Encoding.PEM, Content.PUBLIC_KEY,
+				publicKeyInfo.getAlgorithm().getAlgorithm().getId());
+		}
+		if (pemObject instanceof X509CertificateHolder certificate)
+		{
+			return new KeyFileDescription(Encoding.PEM, Content.CERTIFICATE,
+				certificate.getSubjectPublicKeyInfo().getAlgorithm().getAlgorithm().getId());
+		}
+		throw new IllegalArgumentException("'" + file + "' holds "
+			+ (pemObject == null ? "no PEM object" : "a " + pemObject.getClass().getSimpleName())
+			+ ", which is not a key or a certificate this tool converts");
+	}
+
+	private static KeyFileDescription describeDer(final File file) throws IOException
+	{
+		final byte[] der = Files.readAllBytes(file.toPath());
+		try
+		{
+			return new KeyFileDescription(Encoding.DER, Content.PRIVATE_KEY_PKCS8,
+				algorithmOf(PrivateKeyInfo.getInstance(der)));
+		}
+		catch (final RuntimeException notPkcs8)
+		{
+			// fall through to the next shape
+		}
+		try
+		{
+			final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(der);
+			return new KeyFileDescription(Encoding.DER, Content.PUBLIC_KEY,
+				publicKeyInfo.getAlgorithm().getAlgorithm().getId());
+		}
+		catch (final RuntimeException notAPublicKey)
+		{
+			// fall through to the next shape
+		}
+		try
+		{
+			final X509CertificateHolder certificate = new X509CertificateHolder(der);
+			return new KeyFileDescription(Encoding.DER, Content.CERTIFICATE,
+				certificate.getSubjectPublicKeyInfo().getAlgorithm().getAlgorithm().getId());
+		}
+		catch (final RuntimeException | IOException notACertificate)
+		{
+			throw new IllegalArgumentException("'" + file
+				+ "' is not a DER private key, public key or X.509 certificate this tool converts");
+		}
+	}
+
+	private static Object readPem(final File file) throws IOException
+	{
+		try (PEMParser parser = new PEMParser(new FileReader(file, StandardCharsets.UTF_8)))
+		{
+			try
+			{
+				return parser.readObject();
+			}
+			catch (final IOException malformed)
+			{
+				throw new IllegalArgumentException(
+					"could not read a PEM object from '" + file + "': " + malformed.getMessage(),
+					malformed);
+			}
+		}
+	}
+
+	private static String algorithmOf(final PrivateKeyInfo privateKeyInfo)
+	{
+		return privateKeyInfo.getPrivateKeyAlgorithm().getAlgorithm().getId();
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileReader.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileReader.java
@@ -1,0 +1,241 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Reads a private or public key from a file that may be PEM or DER, always through Bouncy Castle.
+ * <p>
+ * The provider is not an incidental choice. An elliptic-curve key generated on a <em>named
+ * curve</em> by Bouncy Castle is rejected by the JDK's own SunEC provider when it is used to sign
+ * ("Curve not supported"), and - worse - verification with such a key returns {@code false} instead
+ * of throwing, so a perfectly good signature reads as an invalid one and nothing says why. Decoding
+ * the key with the same provider that will sign and verify with it keeps that mismatch from
+ * arising, which is why this exists next to the readers in crypt-data: those call
+ * {@code KeyFactory.getInstance(algorithm)} without naming a provider, and for {@code EC} the JDK's
+ * own provider wins that lookup.
+ */
+public final class KeyFileReader
+{
+
+	private KeyFileReader()
+	{
+	}
+
+	/**
+	 * Reads a private key from a PEM or DER file.
+	 *
+	 * @param file
+	 *            the key file
+	 * @param algorithm
+	 *            the key algorithm, e.g. {@code RSA}, {@code EC} or {@code DSA}
+	 * @return the private key
+	 * @throws IOException
+	 *             if the file cannot be read
+	 * @throws IllegalArgumentException
+	 *             if the file holds no private key this provider can decode
+	 */
+	public static PrivateKey readPrivateKey(final File file, final String algorithm)
+		throws IOException
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+		if (isPem(file))
+		{
+			return privateKeyFromPem(file);
+		}
+		try
+		{
+			return keyFactory(algorithm)
+				.generatePrivate(new PKCS8EncodedKeySpec(Files.readAllBytes(file.toPath())));
+		}
+		catch (final Exception notADerPrivateKey)
+		{
+			throw new IllegalArgumentException("could not read a " + algorithm
+				+ " private key from '" + file + "': " + notADerPrivateKey.getMessage(),
+				notADerPrivateKey);
+		}
+	}
+
+	/**
+	 * Reads a public key from a PEM or DER file.
+	 *
+	 * @param file
+	 *            the key file
+	 * @param algorithm
+	 *            the key algorithm, e.g. {@code RSA}, {@code EC} or {@code DSA}
+	 * @return the public key
+	 * @throws IOException
+	 *             if the file cannot be read
+	 * @throws IllegalArgumentException
+	 *             if the file holds no public key this provider can decode
+	 */
+	public static PublicKey readPublicKey(final File file, final String algorithm)
+		throws IOException
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+		if (isPem(file))
+		{
+			return publicKeyFromPem(file);
+		}
+		try
+		{
+			return keyFactory(algorithm)
+				.generatePublic(new X509EncodedKeySpec(Files.readAllBytes(file.toPath())));
+		}
+		catch (final Exception notADerPublicKey)
+		{
+			throw new IllegalArgumentException("could not read a " + algorithm
+				+ " public key from '" + file + "': " + notADerPublicKey.getMessage(),
+				notADerPublicKey);
+		}
+	}
+
+	/**
+	 * Whether the given file is PEM rather than DER, decided by the armour a PEM file carries.
+	 *
+	 * @param file
+	 *            the file to look at
+	 * @return true if the file is PEM
+	 * @throws IOException
+	 *             if the file cannot be read
+	 */
+	public static boolean isPem(final File file) throws IOException
+	{
+		final byte[] head = Files.readAllBytes(file.toPath());
+		final int lookAhead = Math.min(head.length, 64);
+		return new String(head, 0, lookAhead, java.nio.charset.StandardCharsets.US_ASCII)
+			.contains("-----BEGIN");
+	}
+
+	private static PrivateKey privateKeyFromPem(final File file) throws IOException
+	{
+		final Object pemObject = firstPemObject(file);
+		final JcaPEMKeyConverter converter = converter();
+		try
+		{
+			if (pemObject instanceof PEMKeyPair pemKeyPair)
+			{
+				return converter.getKeyPair(pemKeyPair).getPrivate();
+			}
+			if (pemObject instanceof PrivateKeyInfo privateKeyInfo)
+			{
+				return converter.getPrivateKey(privateKeyInfo);
+			}
+		}
+		catch (final Exception cannotConvert)
+		{
+			throw new IllegalArgumentException(
+				"could not read a private key from '" + file + "': " + cannotConvert.getMessage(),
+				cannotConvert);
+		}
+		throw new IllegalArgumentException(
+			"'" + file + "' holds " + describe(pemObject) + ", not a private key");
+	}
+
+	private static PublicKey publicKeyFromPem(final File file) throws IOException
+	{
+		final Object pemObject = firstPemObject(file);
+		final JcaPEMKeyConverter converter = converter();
+		try
+		{
+			if (pemObject instanceof SubjectPublicKeyInfo publicKeyInfo)
+			{
+				return converter.getPublicKey(publicKeyInfo);
+			}
+			if (pemObject instanceof PEMKeyPair pemKeyPair)
+			{
+				// a PEM holding a whole key pair also answers "what is the public half"
+				return converter.getKeyPair(pemKeyPair).getPublic();
+			}
+		}
+		catch (final Exception cannotConvert)
+		{
+			throw new IllegalArgumentException(
+				"could not read a public key from '" + file + "': " + cannotConvert.getMessage(),
+				cannotConvert);
+		}
+		throw new IllegalArgumentException(
+			"'" + file + "' holds " + describe(pemObject) + ", not a public key");
+	}
+
+	/**
+	 * Reads the first PEM object out of the file.
+	 * <p>
+	 * A body that is not valid for the armour around it makes Bouncy Castle throw out of
+	 * {@code readObject} itself, before there is any object to look at. That is still "this file
+	 * does not hold the key you asked for", so it is reported the same way rather than escaping as
+	 * an IOException that reads like the file could not be opened. Only the opening itself keeps
+	 * that meaning.
+	 */
+	private static Object firstPemObject(final File file) throws IOException
+	{
+		try (PEMParser parser = new PEMParser(new FileReader(file)))
+		{
+			try
+			{
+				return parser.readObject();
+			}
+			catch (final IOException malformed)
+			{
+				throw new IllegalArgumentException(
+					"could not read a PEM object from '" + file + "': " + malformed.getMessage(),
+					malformed);
+			}
+		}
+	}
+
+	private static String describe(final Object pemObject)
+	{
+		return pemObject == null ? "no PEM object" : "a " + pemObject.getClass().getSimpleName();
+	}
+
+	private static JcaPEMKeyConverter converter()
+	{
+		return new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
+	}
+
+	private static KeyFactory keyFactory(final String algorithm) throws Exception
+	{
+		return KeyFactory.getInstance(algorithm, BouncyCastleProvider.PROVIDER_NAME);
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileReader.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileReader.java
@@ -28,11 +28,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
 
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
@@ -85,8 +82,11 @@ public final class KeyFileReader
 		}
 		try
 		{
-			return keyFactory(algorithm)
-				.generatePrivate(new PKCS8EncodedKeySpec(Files.readAllBytes(file.toPath())));
+			// DER carries its own algorithm in the PKCS#8 structure, so it is read from there
+			// rather than from the name the caller passed; the name is only used to say what was
+			// expected if this fails
+			return converter()
+				.getPrivateKey(PrivateKeyInfo.getInstance(Files.readAllBytes(file.toPath())));
 		}
 		catch (final Exception notADerPrivateKey)
 		{
@@ -119,8 +119,9 @@ public final class KeyFileReader
 		}
 		try
 		{
-			return keyFactory(algorithm)
-				.generatePublic(new X509EncodedKeySpec(Files.readAllBytes(file.toPath())));
+			// as above: the algorithm comes out of the SubjectPublicKeyInfo itself
+			return converter()
+				.getPublicKey(SubjectPublicKeyInfo.getInstance(Files.readAllBytes(file.toPath())));
 		}
 		catch (final Exception notADerPublicKey)
 		{
@@ -234,8 +235,4 @@ public final class KeyFileReader
 		return new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
 	}
 
-	private static KeyFactory keyFactory(final String algorithm) throws Exception
-	{
-		return KeyFactory.getInstance(algorithm, BouncyCastleProvider.PROVIDER_NAME);
-	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileWriter.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/key/KeyFileWriter.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+
+/**
+ * Writes a key as PEM or DER, in the encoding that was actually asked for.
+ * <p>
+ * This exists because {@code PrivateKeyWriter.write(..., KeyFormat.PKCS_8)} in crypt-data does not
+ * write PKCS#8: it routes through {@code PrivateKeyExtensions.toPemFormat}, which calls
+ * {@code toPKCS1Format} for every key type and so strips the PKCS#8 wrapper before armouring the
+ * result. Asking for PKCS#8 there yields PKCS#1 under an RSA PRIVATE KEY header. Until that is
+ * fixed at its source, the commands that let a user choose the encoding use this instead, so what
+ * the option says is what lands in the file.
+ */
+public final class KeyFileWriter
+{
+
+	/** The PEM label of a PKCS#8 private key, which carries its algorithm inside the structure. */
+	public static final String PKCS8_LABEL = "PRIVATE KEY";
+
+	/** The PEM label of a traditional RSA private key. */
+	public static final String PKCS1_RSA_LABEL = "RSA PRIVATE KEY";
+
+	/** The PEM label of a public key. */
+	public static final String PUBLIC_LABEL = "PUBLIC KEY";
+
+	private KeyFileWriter()
+	{
+	}
+
+	/**
+	 * The PKCS#8 encoding of the given private key, which is what {@code getEncoded} already
+	 * returns.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @return the DER bytes in PKCS#8
+	 */
+	public static byte[] toPkcs8(final PrivateKey privateKey)
+	{
+		return privateKey.getEncoded();
+	}
+
+	/**
+	 * The PKCS#1 encoding of the given private key, the inner structure with the PKCS#8 wrapper
+	 * removed.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @return the DER bytes in PKCS#1
+	 * @throws IOException
+	 *             if the key cannot be re-encoded
+	 */
+	public static byte[] toPkcs1(final PrivateKey privateKey) throws IOException
+	{
+		final PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+		final ASN1Primitive inner = privateKeyInfo.parsePrivateKey().toASN1Primitive();
+		return inner.getEncoded();
+	}
+
+	/**
+	 * Renders a private key as PEM in the requested encoding.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @param pkcs1
+	 *            true for the traditional PKCS#1 form, false for PKCS#8
+	 * @return the PEM text
+	 * @throws IOException
+	 *             if the key cannot be re-encoded
+	 */
+	public static String toPem(final PrivateKey privateKey, final boolean pkcs1) throws IOException
+	{
+		return pkcs1
+			? toPem(labelFor(privateKey), toPkcs1(privateKey))
+			: toPem(PKCS8_LABEL, toPkcs8(privateKey));
+	}
+
+	/**
+	 * Renders a public key as PEM.
+	 *
+	 * @param publicKey
+	 *            the public key
+	 * @return the PEM text
+	 * @throws IOException
+	 *             if the key cannot be written
+	 */
+	public static String toPem(final PublicKey publicKey) throws IOException
+	{
+		return toPem(PUBLIC_LABEL, publicKey.getEncoded());
+	}
+
+	/**
+	 * Renders the given DER bytes as PEM under the given label.
+	 *
+	 * @param label
+	 *            the PEM label, e.g. {@code PRIVATE KEY}
+	 * @param der
+	 *            the DER bytes
+	 * @return the PEM text
+	 * @throws IOException
+	 *             if the text cannot be written
+	 */
+	public static String toPem(final String label, final byte[] der) throws IOException
+	{
+		final StringWriter text = new StringWriter();
+		try (PemWriter writer = new PemWriter(text))
+		{
+			writer.writeObject(new PemObject(label, der));
+		}
+		return text.toString();
+	}
+
+	/**
+	 * The PEM label a traditional private key of this algorithm is written under. Only RSA has a
+	 * widely used traditional label of its own; anything else keeps the PKCS#8 label, because there
+	 * is no traditional form for it to be mistaken for.
+	 *
+	 * @param privateKey
+	 *            the private key
+	 * @return the PEM label
+	 */
+	private static String labelFor(final PrivateKey privateKey)
+	{
+		return "RSA".equals(privateKey.getAlgorithm()) ? PKCS1_RSA_LABEL : PKCS8_LABEL;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
@@ -1,0 +1,218 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import io.github.astrapi69.mystic.crypt.aead.KeyCommittingAeadEncryptor;
+import io.github.astrapi69.random.number.RandomByteFactory;
+
+/**
+ * Passphrase-based authenticated encryption of arbitrary bytes, the operation behind the
+ * {@code encrypt} and {@code decrypt} commands.
+ * <p>
+ * A key is derived from the passphrase with PBKDF2-HMAC-SHA256 over a salt that is fresh for every
+ * call, and the payload is sealed with AES-GCM through {@link KeyCommittingAeadEncryptor}, so a
+ * wrong passphrase is rejected by the key commitment instead of producing plausible looking
+ * rubbish.
+ * <p>
+ * The output carries its own header:
+ *
+ * <pre>
+ * "MCRYPT" (6) | version (1) | iterations (4, big endian) | salt (16) | AES-GCM payload
+ * </pre>
+ *
+ * The marker makes the format recognisable ({@link #isEncrypted(byte[])}) and the version byte
+ * leaves room to change the construction later. The iteration count travels with the payload, so
+ * raising {@link #DEFAULT_ITERATIONS} does not strand anything encrypted with the old default.
+ * <p>
+ * As everywhere in this package, the given passphrase array is zeroed before returning, on success
+ * and on failure alike; callers must not reuse it.
+ */
+public final class PassphraseCryptor
+{
+
+	/** The marker every output starts with, so the format can be recognised. */
+	public static final byte[] MAGIC = { 'M', 'C', 'R', 'Y', 'P', 'T' };
+
+	/** The version of the format described in the class javadoc. */
+	public static final byte FORMAT_VERSION = 1;
+
+	/** Salt length in bytes. */
+	public static final int SALT_LENGTH = 16;
+
+	/** Length of the header that precedes the AES-GCM payload. */
+	public static final int HEADER_LENGTH = MAGIC.length + 1 + Integer.BYTES + SALT_LENGTH;
+
+	/**
+	 * Number of PBKDF2 iterations for new output, per the OWASP Password Storage Cheat Sheet
+	 * guidance for PBKDF2-HMAC-SHA256.
+	 */
+	public static final int DEFAULT_ITERATIONS = 600_000;
+
+	/** Derived key length in bits, an AES-256 key. */
+	private static final int KEY_LENGTH_BITS = 256;
+
+	private PassphraseCryptor()
+	{
+	}
+
+	/**
+	 * Encrypts the given bytes with a key derived from the given passphrase.
+	 *
+	 * @param passphrase
+	 *            the passphrase, zeroed before this method returns
+	 * @param plain
+	 *            the bytes to encrypt
+	 * @return the header followed by the AES-GCM payload
+	 */
+	public static byte[] encrypt(final char[] passphrase, final byte[] plain)
+	{
+		try
+		{
+			final byte[] salt = RandomByteFactory.randomByteArray(SALT_LENGTH);
+			final SecretKey key = deriveKey(passphrase, salt, DEFAULT_ITERATIONS);
+			final byte[] payload = new KeyCommittingAeadEncryptor(key).encrypt(plain);
+			return ByteBuffer.allocate(HEADER_LENGTH + payload.length).put(MAGIC)
+				.put(FORMAT_VERSION).putInt(DEFAULT_ITERATIONS).put(salt).put(payload).array();
+		}
+		catch (final Exception sealingFailed)
+		{
+			throw new IllegalStateException(
+				"could not encrypt the given input: " + sealingFailed.getMessage(), sealingFailed);
+		}
+		finally
+		{
+			Arrays.fill(passphrase, '\0');
+		}
+	}
+
+	/**
+	 * Decrypts what {@link #encrypt(char[], byte[])} produced.
+	 *
+	 * @param passphrase
+	 *            the passphrase, zeroed before this method returns
+	 * @param encrypted
+	 *            the header followed by the AES-GCM payload
+	 * @return the decrypted bytes
+	 * @throws IllegalArgumentException
+	 *             if the input does not carry this format's header
+	 * @throws SecurityException
+	 *             if the passphrase is wrong or the payload was altered
+	 */
+	public static byte[] decrypt(final char[] passphrase, final byte[] encrypted)
+	{
+		try
+		{
+			// the header check runs outside the catch below on purpose: "this is not our format at
+			// all" is a different answer from "this is our format and it would not open", and the
+			// caller distinguishes the two by exception type
+			requireOwnFormat(encrypted);
+			final int iterations = iterationsOf(encrypted);
+			final byte[] salt = Arrays.copyOfRange(encrypted, MAGIC.length + 1 + Integer.BYTES,
+				HEADER_LENGTH);
+			final byte[] payload = Arrays.copyOfRange(encrypted, HEADER_LENGTH, encrypted.length);
+			final SecretKey key = deriveKey(passphrase, salt, iterations);
+			try
+			{
+				return new KeyCommittingAeadEncryptor(key).decrypt(payload);
+			}
+			catch (final Exception openingFailed)
+			{
+				throw new SecurityException(
+					"could not decrypt: the passphrase is wrong or the data was altered",
+					openingFailed);
+			}
+		}
+		finally
+		{
+			Arrays.fill(passphrase, '\0');
+		}
+	}
+
+	/**
+	 * Answers whether the given bytes start with this format's marker and version. Used to tell an
+	 * encrypted file from any other file before asking for a passphrase.
+	 *
+	 * @param candidate
+	 *            the bytes to inspect
+	 * @return true if the bytes carry this format's header
+	 */
+	public static boolean isEncrypted(final byte[] candidate)
+	{
+		if (candidate == null || candidate.length < HEADER_LENGTH)
+		{
+			return false;
+		}
+		return Arrays.equals(Arrays.copyOf(candidate, MAGIC.length), MAGIC)
+			&& candidate[MAGIC.length] == FORMAT_VERSION;
+	}
+
+	/**
+	 * Reads the PBKDF2 iteration count the given output was produced with.
+	 *
+	 * @param encrypted
+	 *            the encrypted bytes
+	 * @return the iteration count stored in the header
+	 * @throws IllegalArgumentException
+	 *             if the input does not carry this format's header
+	 */
+	public static int iterationsOf(final byte[] encrypted)
+	{
+		requireOwnFormat(encrypted);
+		return ByteBuffer.wrap(encrypted, MAGIC.length + 1, Integer.BYTES).getInt();
+	}
+
+	private static void requireOwnFormat(final byte[] encrypted)
+	{
+		if (!isEncrypted(encrypted))
+		{
+			throw new IllegalArgumentException(
+				"not a mystic-crypt encrypted input: it does not start with the marker '"
+					+ new String(MAGIC, StandardCharsets.US_ASCII) + "' and format version "
+					+ FORMAT_VERSION);
+		}
+	}
+
+	private static SecretKey deriveKey(final char[] passphrase, final byte[] salt,
+		final int iterations)
+	{
+		final byte[] keyBytes = Pbkdf2Support.deriveKey(passphrase, salt, iterations,
+			KEY_LENGTH_BITS);
+		try
+		{
+			return new SecretKeySpec(keyBytes, "AES");
+		}
+		finally
+		{
+			Arrays.fill(keyBytes, (byte)0);
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/PasswordEncryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/PasswordEncryptor.java
@@ -41,6 +41,7 @@ import javax.crypto.NoSuchPaddingException;
 
 import io.github.astrapi69.crypt.api.algorithm.HashAlgorithm;
 import io.github.astrapi69.crypt.data.hash.HashExtensions;
+import io.github.astrapi69.mystic.crypt.sha.BcryptHasher;
 import io.github.astrapi69.mystic.crypt.sha.Hasher;
 import io.github.astrapi69.random.object.RandomObjectFactory;
 import io.github.astrapi69.random.object.RandomWebObjectFactory;
@@ -278,6 +279,96 @@ public class PasswordEncryptor implements Serializable
 	public boolean matchPbkdf2(final String password, final String encodedHash)
 	{
 		return Pbkdf2Support.verify(password.toCharArray(), encodedHash);
+	}
+
+	/**
+	 * Hashes the given password with bcrypt. The salt and cost travel inside the returned
+	 * {@code $2a$} string, so {@link #matchBcrypt(String, String)} needs only the password and this
+	 * string.
+	 * <p>
+	 * Prefer {@link #hashPasswordArgon2id(String)} for new code: bcrypt is not memory-hard in the
+	 * way Argon2id is, and it silently truncates passwords beyond 72 bytes. This exists for interop
+	 * with systems that already store bcrypt hashes.
+	 *
+	 * @param password
+	 *            the password
+	 * @return the encoded bcrypt hash
+	 */
+	public String hashPasswordBcrypt(final String password)
+	{
+		return BcryptHasher.hash(password.toCharArray());
+	}
+
+	/**
+	 * Verifies the given password against a hash previously produced by
+	 * {@link #hashPasswordBcrypt(String)}.
+	 *
+	 * @param password
+	 *            the password to check
+	 * @param encodedHash
+	 *            the encoded bcrypt hash to check against
+	 * @return true if the password matches
+	 */
+	public boolean matchBcrypt(final String password, final String encodedHash)
+	{
+		return BcryptHasher.verify(password.toCharArray(), encodedHash);
+	}
+
+	/**
+	 * Hashes the given password with scrypt. A fresh random salt is generated per call; the salt
+	 * and the three cost parameters are encoded together with the hash in the returned string, so
+	 * {@link #matchScrypt(String, String)} needs only the password and this string.
+	 *
+	 * @param password
+	 *            the password
+	 * @return the encoded scrypt hash
+	 */
+	public String hashPasswordScrypt(final String password)
+	{
+		return ScryptSupport.hash(password.toCharArray());
+	}
+
+	/**
+	 * Verifies the given password against a hash previously produced by
+	 * {@link #hashPasswordScrypt(String)}.
+	 *
+	 * @param password
+	 *            the password to check
+	 * @param encodedHash
+	 *            the encoded scrypt hash to check against
+	 * @return true if the password matches
+	 */
+	public boolean matchScrypt(final String password, final String encodedHash)
+	{
+		return ScryptSupport.verify(password.toCharArray(), encodedHash);
+	}
+
+	/**
+	 * Verifies the given password against an encoded hash of any algorithm this class produces,
+	 * reading which one it is from the hash itself.
+	 * <p>
+	 * A stored hash already says how it was made, so asking the caller to name the algorithm again
+	 * only creates a way to get it wrong: naming the wrong one turns "this is a bcrypt hash" into
+	 * "the password does not match", which sends the reader after the password instead of after the
+	 * mismatch.
+	 *
+	 * @param password
+	 *            the password to check
+	 * @param encodedHash
+	 *            the encoded hash, of any supported algorithm
+	 * @return true if the password matches
+	 * @throws IllegalArgumentException
+	 *             if the encoding belongs to no algorithm this class knows
+	 */
+	public boolean matchEncodedHash(final String password, final String encodedHash)
+	{
+		return switch (PasswordHashFormat.of(encodedHash))
+		{
+			case ARGON2ID -> matchArgon2id(password, encodedHash);
+			case PBKDF2 -> matchPbkdf2(password, encodedHash);
+			case BCRYPT -> matchBcrypt(password, encodedHash);
+			case SCRYPT -> matchScrypt(password, encodedHash);
+		};
 	}
 
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/PasswordHashFormat.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/PasswordHashFormat.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+/**
+ * The password hash encodings this library produces, and how to tell which one a stored hash is.
+ * <p>
+ * Every one of them writes what it is into the hash itself, so the algorithm never has to be
+ * supplied a second time when verifying. Asking for it again only creates a way to get it wrong:
+ * naming the wrong algorithm turns "this is a bcrypt hash" into "the password does not match",
+ * which sends the reader after the password instead of after the mismatch.
+ */
+public enum PasswordHashFormat
+{
+
+	/** Argon2id, encoded in the standard PHC format as {@code $argon2id$...}. */
+	ARGON2ID("$argon2id$"),
+
+	/** PBKDF2-HMAC-SHA256, encoded as {@code $pbkdf2-sha256$...}. */
+	PBKDF2("$pbkdf2-sha256$"),
+
+	/** scrypt, encoded as {@code $scrypt$...}. */
+	SCRYPT(ScryptSupport.PREFIX),
+
+	/**
+	 * bcrypt, encoded in its own modular crypt format. All three of the {@code 2a}, {@code 2b} and
+	 * {@code 2y} revisions are the same construction with different revision letters, and hashes of
+	 * all three are found in the wild, so all three are recognised.
+	 */
+	BCRYPT("$2a$", "$2b$", "$2y$");
+
+	private final String[] prefixes;
+
+	PasswordHashFormat(final String... prefixes)
+	{
+		this.prefixes = prefixes;
+	}
+
+	/**
+	 * Reads from an encoded hash which algorithm produced it.
+	 *
+	 * @param encodedHash
+	 *            the encoded hash
+	 * @return the format the hash is in
+	 * @throws IllegalArgumentException
+	 *             if the encoding belongs to none of these formats
+	 */
+	public static PasswordHashFormat of(final String encodedHash)
+	{
+		if (encodedHash != null)
+		{
+			for (final PasswordHashFormat format : values())
+			{
+				if (format.matches(encodedHash))
+				{
+					return format;
+				}
+			}
+		}
+		throw new IllegalArgumentException("'" + encodedHash
+			+ "' is not an encoded hash of a known algorithm: it starts with none of $argon2id$, "
+			+ "$pbkdf2-sha256$, $scrypt$, $2a$, $2b$ or $2y$");
+	}
+
+	private boolean matches(final String encodedHash)
+	{
+		for (final String prefix : prefixes)
+		{
+			if (encodedHash.startsWith(prefix))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/Pbkdf2Support.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/Pbkdf2Support.java
@@ -177,9 +177,38 @@ final class Pbkdf2Support
 	static byte[] rawHash(final char[] password, final byte[] salt, final int iterations,
 		final String algorithm)
 	{
+		return derive(password, salt, iterations, HASH_LENGTH_BITS, algorithm);
+	}
+
+	/**
+	 * Derives a key of the given length from the given password with the fixed
+	 * {@code PBKDF2WithHmacSHA256} algorithm. Unlike {@link #hash(char[])} and
+	 * {@link #verify(char[], String)} this does not zero the password: it is a building block for
+	 * callers such as {@link PassphraseCryptor} that own the array and clear it themselves once
+	 * they are done with it.
+	 *
+	 * @param password
+	 *            the password to derive from, left untouched
+	 * @param salt
+	 *            the salt
+	 * @param iterations
+	 *            the iteration count
+	 * @param keyLengthBits
+	 *            the length of the derived key in bits
+	 * @return the derived key
+	 */
+	static byte[] deriveKey(final char[] password, final byte[] salt, final int iterations,
+		final int keyLengthBits)
+	{
+		return derive(password, salt, iterations, keyLengthBits, ALGORITHM);
+	}
+
+	private static byte[] derive(final char[] password, final byte[] salt, final int iterations,
+		final int keyLengthBits, final String algorithm)
+	{
 		try
 		{
-			final PBEKeySpec spec = new PBEKeySpec(password, salt, iterations, HASH_LENGTH_BITS);
+			final PBEKeySpec spec = new PBEKeySpec(password, salt, iterations, keyLengthBits);
 			final SecretKeyFactory factory = SecretKeyFactory.getInstance(algorithm);
 			return factory.generateSecret(spec).getEncoded();
 		}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
@@ -1,0 +1,223 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+import io.github.astrapi69.mystic.crypt.sha.ScryptHasher;
+import io.github.astrapi69.random.number.RandomByteFactory;
+
+/**
+ * Package-private helper for scrypt password hashing, encoded in a PHC-like string format so the
+ * parameters travel with the hash:
+ *
+ * <pre>
+ * $scrypt$ln=&lt;log2 of n&gt;,r=&lt;r&gt;,p=&lt;p&gt;$&lt;salt&gt;$&lt;hash&gt;
+ * </pre>
+ *
+ * <p>
+ * {@link ScryptHasher} produces raw bytes and verifies against them, which means the caller has to
+ * keep the salt and the three cost parameters somewhere else. That is exactly what a stored
+ * password hash cannot rely on, so this wraps it in the same self-describing form that
+ * {@link Argon2Support} and {@link Pbkdf2Support} use, and it is what lets {@code verify} recognise
+ * a scrypt hash by its own encoding.
+ * <p>
+ * The cost is written as {@code ln}, the base-2 logarithm of n, which is how scrypt's cost is
+ * conventionally written and keeps the field short.
+ * <p>
+ * Both {@link #hash(char[])} and {@link #verify(char[], String)} zero the given {@code password}
+ * array before returning; callers must not reuse the array afterwards.
+ */
+final class ScryptSupport
+{
+
+	/** The prefix every encoded scrypt hash of this library starts with. */
+	static final String PREFIX = "$scrypt$";
+
+	/** Salt length in bytes. */
+	static final int SALT_LENGTH = 16;
+
+	/** Output hash length in bytes. */
+	static final int HASH_LENGTH = 32;
+
+	/** Default CPU and memory cost, as the base-2 logarithm of n. */
+	static final int DEFAULT_LOG_N = 15;
+
+	/** Default block size. */
+	static final int DEFAULT_R = 8;
+
+	/** Default parallelism. */
+	static final int DEFAULT_P = 1;
+
+	private ScryptSupport()
+	{
+	}
+
+	/**
+	 * Hashes the given password with a fresh random salt and the default parameters.
+	 *
+	 * @param password
+	 *            the password
+	 * @return the encoded hash
+	 */
+	static String hash(final char[] password)
+	{
+		Objects.requireNonNull(password);
+		try
+		{
+			final byte[] salt = RandomByteFactory.randomByteArray(SALT_LENGTH);
+			final byte[] hash = ScryptHasher.hashWithSalt(password.clone(), salt,
+				1 << DEFAULT_LOG_N, DEFAULT_R, DEFAULT_P, HASH_LENGTH);
+			final Base64.Encoder encoder = Base64.getEncoder().withoutPadding();
+			return PREFIX + "ln=" + DEFAULT_LOG_N + ",r=" + DEFAULT_R + ",p=" + DEFAULT_P + "$"
+				+ encoder.encodeToString(salt) + "$" + encoder.encodeToString(hash);
+		}
+		finally
+		{
+			Arrays.fill(password, '\0');
+		}
+	}
+
+	/**
+	 * Verifies the given password against a previously encoded hash.
+	 *
+	 * @param password
+	 *            the password to check
+	 * @param encoded
+	 *            the previously encoded hash, as produced by {@link #hash(char[])}
+	 * @return true if the password matches, false if it does not match or {@code encoded} is
+	 *         malformed
+	 */
+	static boolean verify(final char[] password, final String encoded)
+	{
+		Objects.requireNonNull(password);
+		Objects.requireNonNull(encoded);
+		try
+		{
+			return decodeAndCompare(password, encoded);
+		}
+		finally
+		{
+			Arrays.fill(password, '\0');
+		}
+	}
+
+	/**
+	 * Decodes {@code encoded} and compares its hash against one computed for {@code password} with
+	 * the decoded parameters. Split out of {@link #verify(char[], String)} for the same reason as
+	 * in {@link Argon2Support}: a {@code return false} that is the last statement of a {@code try}
+	 * with a {@code finally} compiles through a local variable, which defeats PIT's
+	 * equivalent-constant filter.
+	 *
+	 * @param password
+	 *            the password to check
+	 * @param encoded
+	 *            the previously encoded hash
+	 * @return true if the password matches
+	 */
+	private static boolean decodeAndCompare(final char[] password, final String encoded)
+	{
+		final Decoded decoded;
+		try
+		{
+			decoded = decode(encoded);
+		}
+		catch (final RuntimeException malformed)
+		{
+			return false;
+		}
+		return ScryptHasher.verify(password.clone(), decoded.salt, decoded.hash, 1 << decoded.logN,
+			decoded.r, decoded.p);
+	}
+
+	private static Decoded decode(final String encoded)
+	{
+		final String[] parts = encoded.split("\\$");
+		// parts[0] is empty (string starts with '$'); parts[1]="scrypt";
+		// parts[2]="ln=..,r=..,p=.."; parts[3]=salt; parts[4]=hash
+		if (parts.length != 5 || !"scrypt".equals(parts[1]))
+		{
+			throw new IllegalArgumentException("not a valid scrypt encoded hash");
+		}
+		final String[] params = parts[2].split(",");
+		int logN = -1;
+		int r = -1;
+		int p = -1;
+		for (final String param : params)
+		{
+			final String[] keyValue = param.split("=");
+			if (keyValue.length != 2)
+			{
+				throw new IllegalArgumentException("not a valid scrypt encoded hash");
+			}
+			switch (keyValue[0])
+			{
+				case "ln" :
+					logN = Integer.parseInt(keyValue[1]);
+					break;
+				case "r" :
+					r = Integer.parseInt(keyValue[1]);
+					break;
+				case "p" :
+					p = Integer.parseInt(keyValue[1]);
+					break;
+				default :
+					throw new IllegalArgumentException("not a valid scrypt encoded hash");
+			}
+		}
+		// scrypt requires n to be a power of two greater than one, and r and p at least one; a
+		// value outside that would make Bouncy Castle throw from the hasher instead of verify()
+		// answering false for a malformed hash. The upper bound on ln keeps 1 << logN from
+		// overflowing into a negative n.
+		if (logN < 1 || logN > 30 || r < 1 || p < 1)
+		{
+			throw new IllegalArgumentException("not a valid scrypt encoded hash");
+		}
+		final byte[] salt = Base64.getDecoder().decode(parts[3]);
+		final byte[] hash = Base64.getDecoder().decode(parts[4]);
+		return new Decoded(salt, hash, logN, r, p);
+	}
+
+	private static final class Decoded
+	{
+		private final byte[] salt;
+		private final byte[] hash;
+		private final int logN;
+		private final int r;
+		private final int p;
+
+		private Decoded(final byte[] salt, final byte[] hash, final int logN, final int r,
+			final int p)
+		{
+			this.salt = salt;
+			this.hash = hash;
+			this.logN = logN;
+			this.r = r;
+			this.p = p;
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/secret/SecretShare.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/secret/SecretShare.java
@@ -1,0 +1,265 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.secret;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * One line of a secret split, and the text format it is written in.
+ * <p>
+ * Shamir's scheme by itself has no integrity check: combining shares that belong to different
+ * splits, or fewer shares than the split's threshold, silently yields a wrong secret instead of
+ * failing. This format carries what is needed to catch both.
+ *
+ * <pre>
+ * mcs1:&lt;splitId&gt;:&lt;threshold&gt;:&lt;total&gt;:&lt;index&gt;:&lt;value&gt;:&lt;checksum&gt;
+ * </pre>
+ *
+ * <ul>
+ * <li>{@code splitId} is random per split, so shares of two different splits cannot be combined by
+ * accident</li>
+ * <li>{@code threshold} travels with every share, so "fewer shares than the split needs" is a
+ * statement the tool can make rather than a wrong secret it hands back</li>
+ * <li>{@code checksum} covers the fields before it, so a share mistyped while being copied is
+ * rejected where it is entered</li>
+ * </ul>
+ *
+ * The checksum deliberately covers the share, not the secret: a digest of the secret in every share
+ * would let anyone holding a single share test guesses against it offline.
+ */
+public final class SecretShare
+{
+
+	/** The prefix and format version every share line starts with. */
+	public static final String PREFIX = "mcs1";
+
+	/** The field separator inside a share line. */
+	private static final String SEPARATOR = ":";
+
+	/** Number of fields a well formed share line has. */
+	private static final int FIELD_COUNT = 7;
+
+	/** Length in bytes of the truncated digest used as the per-share checksum. */
+	private static final int CHECKSUM_LENGTH = 4;
+
+	/** The digest the per-share checksum is computed with. */
+	private static final String CHECKSUM_ALGORITHM = "SHA-256";
+
+	/** Length in bytes of the random identifier shared by all shares of one split. */
+	static final int SPLIT_ID_LENGTH = 8;
+
+	private final String splitId;
+	private final int threshold;
+	private final int total;
+	private final int index;
+	private final byte[] value;
+
+	/**
+	 * Instantiates a new {@link SecretShare}.
+	 *
+	 * @param splitId
+	 *            the identifier common to all shares of one split
+	 * @param threshold
+	 *            the number of shares needed to reconstruct the secret
+	 * @param total
+	 *            the number of shares the split produced
+	 * @param index
+	 *            the 1-based index of this share
+	 * @param value
+	 *            the share value bytes
+	 */
+	public SecretShare(final String splitId, final int threshold, final int total, final int index,
+		final byte[] value)
+	{
+		this.splitId = splitId;
+		this.threshold = threshold;
+		this.total = total;
+		this.index = index;
+		this.value = value.clone();
+	}
+
+	/**
+	 * Gets the identifier common to all shares of one split.
+	 *
+	 * @return the split identifier
+	 */
+	public String getSplitId()
+	{
+		return splitId;
+	}
+
+	/**
+	 * Gets the number of shares needed to reconstruct the secret.
+	 *
+	 * @return the threshold
+	 */
+	public int getThreshold()
+	{
+		return threshold;
+	}
+
+	/**
+	 * Gets the number of shares the split produced.
+	 *
+	 * @return the total number of shares
+	 */
+	public int getTotal()
+	{
+		return total;
+	}
+
+	/**
+	 * Gets the 1-based index of this share.
+	 *
+	 * @return the share index
+	 */
+	public int getIndex()
+	{
+		return index;
+	}
+
+	/**
+	 * Gets the share value bytes.
+	 *
+	 * @return a copy of the share value bytes
+	 */
+	public byte[] getValue()
+	{
+		return value.clone();
+	}
+
+	/**
+	 * Renders this share as the single line that a holder keeps.
+	 *
+	 * @return the share line
+	 */
+	public String encode()
+	{
+		final String body = body();
+		return body + SEPARATOR + checksumOf(body);
+	}
+
+	/**
+	 * Parses a share line produced by {@link #encode()}.
+	 *
+	 * @param line
+	 *            the share line
+	 * @return the parsed share
+	 * @throws IllegalArgumentException
+	 *             if the line is not a share line, or its checksum does not match
+	 */
+	public static SecretShare decode(final String line)
+	{
+		final String trimmed = line == null ? "" : line.trim();
+		final String[] fields = trimmed.split(SEPARATOR, -1);
+		if (fields.length != FIELD_COUNT || !PREFIX.equals(fields[0]))
+		{
+			throw new IllegalArgumentException("not a mystic-crypt share: a share line looks like '"
+				+ PREFIX + ":<splitId>:<threshold>:<total>:<index>:<value>:<checksum>' but was '"
+				+ trimmed + "'");
+		}
+		final SecretShare share = new SecretShare(fields[1], parseNumber(fields[2], "threshold"),
+			parseNumber(fields[3], "total"), parseNumber(fields[4], "index"),
+			decodeValue(fields[5]));
+		final String expected = checksumOf(share.body());
+		if (!expected.equals(fields[6]))
+		{
+			throw new IllegalArgumentException("share " + fields[4] + " of split " + fields[1]
+				+ " does not match its own checksum, so it was altered or mistyped");
+		}
+		return share;
+	}
+
+	private String body()
+	{
+		return PREFIX + SEPARATOR + splitId + SEPARATOR + threshold + SEPARATOR + total + SEPARATOR
+			+ index + SEPARATOR + Base64.getUrlEncoder().withoutPadding().encodeToString(value);
+	}
+
+	private static int parseNumber(final String field, final String name)
+	{
+		try
+		{
+			return Integer.parseInt(field);
+		}
+		catch (final NumberFormatException notANumber)
+		{
+			throw new IllegalArgumentException(
+				"the " + name + " of a share must be a number, but was '" + field + "'",
+				notANumber);
+		}
+	}
+
+	private static byte[] decodeValue(final String field)
+	{
+		try
+		{
+			return Base64.getUrlDecoder().decode(field);
+		}
+		catch (final IllegalArgumentException notBase64)
+		{
+			throw new IllegalArgumentException(
+				"the value of a share must be base64url, but was '" + field + "'", notBase64);
+		}
+	}
+
+	private static String checksumOf(final String body)
+	{
+		return checksumOf(body, CHECKSUM_ALGORITHM);
+	}
+
+	/**
+	 * Computes the per-share checksum with the given digest algorithm. The algorithm is a parameter
+	 * only so that the compiler-mandated handling of {@link NoSuchAlgorithmException} - which the
+	 * fixed {@code SHA-256} can never actually trigger - stays reachable and testable through a
+	 * bogus name, the same way {@code Pbkdf2Support#rawHash} does it.
+	 *
+	 * @param body
+	 *            the share line up to but excluding the checksum field
+	 * @param algorithm
+	 *            the {@link MessageDigest} algorithm name
+	 * @return the truncated digest, hex encoded
+	 * @throws IllegalStateException
+	 *             if the algorithm is unavailable
+	 */
+	static String checksumOf(final String body, final String algorithm)
+	{
+		try
+		{
+			final byte[] digest = MessageDigest.getInstance(algorithm)
+				.digest(body.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(Arrays.copyOf(digest, CHECKSUM_LENGTH));
+		}
+		catch (final NoSuchAlgorithmException impossible)
+		{
+			throw new IllegalStateException(impossible);
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/secret/SecretSharing.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/secret/SecretSharing.java
@@ -1,0 +1,165 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.secret;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+
+import io.github.astrapi69.crypt.data.factory.ShamirSecretSharingFactory;
+
+/**
+ * Splits a secret into shares and puts it back together, on top of
+ * {@link ShamirSecretSharingFactory}.
+ * <p>
+ * What this adds to the bare scheme is the part that makes it usable by hand: every share knows
+ * which split it belongs to and how many shares that split needs, so {@link #combine(List)} can say
+ * "this share is from a different split" and "this is fewer shares than the split needs" instead of
+ * silently returning a wrong secret, which is what Shamir on its own does in both cases.
+ */
+public final class SecretSharing
+{
+
+	private SecretSharing()
+	{
+	}
+
+	/**
+	 * Splits the given secret into {@code shares} shares of which any {@code threshold} suffice to
+	 * reconstruct it.
+	 *
+	 * @param secret
+	 *            the secret to split
+	 * @param threshold
+	 *            the number of shares needed to reconstruct the secret
+	 * @param shares
+	 *            the number of shares to produce
+	 * @return the shares, in index order
+	 * @throws IllegalArgumentException
+	 *             if the numbers do not describe a usable split
+	 */
+	public static List<SecretShare> split(final byte[] secret, final int threshold,
+		final int shares)
+	{
+		requireUsableNumbers(threshold, shares);
+		final SecureRandom random = new SecureRandom();
+		final byte[] splitIdBytes = new byte[SecretShare.SPLIT_ID_LENGTH];
+		random.nextBytes(splitIdBytes);
+		final String splitId = HexFormat.of().formatHex(splitIdBytes);
+
+		final List<ShamirSecretSharingFactory.Share> raw = ShamirSecretSharingFactory.split(secret,
+			threshold, shares, random);
+		final List<SecretShare> result = new ArrayList<>(raw.size());
+		for (final ShamirSecretSharingFactory.Share share : raw)
+		{
+			result.add(
+				new SecretShare(splitId, threshold, shares, share.getIndex(), share.getValue()));
+		}
+		return result;
+	}
+
+	/**
+	 * Reconstructs the secret from the given shares.
+	 *
+	 * @param shares
+	 *            the shares to combine, at least as many as the split's threshold
+	 * @return the reconstructed secret
+	 * @throws IllegalArgumentException
+	 *             if the shares are empty, belong to more than one split, repeat an index, or are
+	 *             fewer than the split needs
+	 */
+	public static byte[] combine(final List<SecretShare> shares)
+	{
+		if (shares == null || shares.isEmpty())
+		{
+			throw new IllegalArgumentException("no shares were given to combine");
+		}
+		final SecretShare first = shares.get(0);
+		requireOneSplit(shares, first);
+		requireDistinctIndices(shares);
+		requireEnoughShares(shares, first);
+
+		final List<ShamirSecretSharingFactory.Share> raw = new ArrayList<>(shares.size());
+		for (final SecretShare share : shares)
+		{
+			raw.add(new ShamirSecretSharingFactory.Share(share.getIndex(), share.getValue()));
+		}
+		return ShamirSecretSharingFactory.combine(raw);
+	}
+
+	private static void requireUsableNumbers(final int threshold, final int shares)
+	{
+		if (threshold < 2)
+		{
+			throw new IllegalArgumentException("the threshold must be at least 2, but was "
+				+ threshold + ": a split that one share alone can undo is not a split");
+		}
+		if (shares < threshold)
+		{
+			throw new IllegalArgumentException(
+				"the number of shares (" + shares + ") must be at least the threshold (" + threshold
+					+ "), otherwise the secret can never be reconstructed");
+		}
+	}
+
+	private static void requireOneSplit(final List<SecretShare> shares, final SecretShare first)
+	{
+		for (final SecretShare share : shares)
+		{
+			if (!first.getSplitId().equals(share.getSplitId()))
+			{
+				throw new IllegalArgumentException("these shares belong to different splits: "
+					+ first.getSplitId() + " and " + share.getSplitId()
+					+ ". Combining them would rebuild nonsense rather than either secret");
+			}
+		}
+	}
+
+	private static void requireDistinctIndices(final List<SecretShare> shares)
+	{
+		final Set<Integer> seen = new HashSet<>();
+		for (final SecretShare share : shares)
+		{
+			if (!seen.add(share.getIndex()))
+			{
+				throw new IllegalArgumentException("share " + share.getIndex()
+					+ " was given more than once; the same share twice does not count twice");
+			}
+		}
+	}
+
+	private static void requireEnoughShares(final List<SecretShare> shares, final SecretShare first)
+	{
+		if (shares.size() < first.getThreshold())
+		{
+			throw new IllegalArgumentException(
+				"this split needs " + first.getThreshold() + " shares, but " + shares.size()
+					+ (shares.size() == 1 ? " was" : " were") + " given");
+		}
+	}
+}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactory.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactory.java
@@ -1,0 +1,305 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.ssl;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Builds a self-signed X.509 certificate that carries the extensions which make a certificate mean
+ * something: basic constraints, key usage and subject alternative names.
+ * <p>
+ * A certificate without them is of limited use - a verifier cannot tell a CA from an end entity,
+ * cannot tell what the key may be used for, and cannot match the certificate to a host name.
+ */
+public final class SelfSignedCertificateFactory
+{
+
+	/** The key algorithm whose signatures RFC 4055 requires to be PSS. */
+	private static final String RSASSA_PSS = "RSASSA-PSS";
+
+	private SelfSignedCertificateFactory()
+	{
+	}
+
+	/**
+	 * What kind of certificate this is, and how deep a chain below it may go.
+	 *
+	 * @param certificateAuthority
+	 *            whether this certificate may sign other certificates
+	 * @param pathLength
+	 *            how many CAs may appear below it, or null for no limit
+	 */
+	public record BasicConstraintsSpec(boolean certificateAuthority, Integer pathLength) {
+	}
+
+	/**
+	 * One subject alternative name.
+	 *
+	 * @param type
+	 *            the kind of name: {@code dns}, {@code ip}, {@code email} or {@code uri}
+	 * @param value
+	 *            the name itself
+	 */
+	public record SubjectAlternativeName(String type, String value) {
+
+		/**
+		 * Parses a name written as {@code type:value}.
+		 *
+		 * @param text
+		 *            the text to parse
+		 * @return the parsed name
+		 * @throws IllegalArgumentException
+		 *             if the text has no type or an unknown one
+		 */
+		public static SubjectAlternativeName parse(final String text)
+		{
+			final int colon = text == null ? -1 : text.indexOf(':');
+			if (colon < 1 || colon == text.length() - 1)
+			{
+				throw new IllegalArgumentException("a subject alternative name is written as "
+					+ "type:value, e.g. dns:example.org, ip:10.0.0.1, email:someone@example.org "
+					+ "or uri:https://example.org, but was '" + text + "'");
+			}
+			return new SubjectAlternativeName(text.substring(0, colon).toLowerCase(Locale.ROOT),
+				text.substring(colon + 1));
+		}
+
+		/**
+		 * The tag this name carries inside the extension.
+		 *
+		 * @return the general name tag
+		 */
+		public int tag()
+		{
+			return switch (type)
+			{
+				case "dns" -> GeneralName.dNSName;
+				case "ip" -> GeneralName.iPAddress;
+				case "email" -> GeneralName.rfc822Name;
+				case "uri" -> GeneralName.uniformResourceIdentifier;
+				default -> throw new IllegalArgumentException("'" + type + "' is not a subject "
+					+ "alternative name type. Use dns, ip, email or uri.");
+			};
+		}
+	}
+
+	/**
+	 * Everything a caller can put into the certificate beyond the name and the validity.
+	 *
+	 * @param basicConstraints
+	 *            the basic constraints, or null to leave the extension out
+	 * @param keyUsages
+	 *            the key usage names, empty to leave the extension out
+	 * @param subjectAlternativeNames
+	 *            the subject alternative names, empty to leave the extension out
+	 * @param criticalExtensions
+	 *            the names of the extensions to mark critical, from {@code basic-constraints},
+	 *            {@code key-usage} and {@code san}
+	 */
+	public record Extensions(BasicConstraintsSpec basicConstraints, List<String> keyUsages,
+		List<SubjectAlternativeName> subjectAlternativeNames, List<String> criticalExtensions) {
+	}
+
+	/**
+	 * Creates a self-signed certificate for the given key pair.
+	 *
+	 * @param keyPair
+	 *            the key pair whose public half the certificate carries and whose private half
+	 *            signs it
+	 * @param distinguishedName
+	 *            the name that is both issuer and subject
+	 * @param days
+	 *            how long the certificate is valid, from now
+	 * @param signatureAlgorithm
+	 *            the signature algorithm, e.g. {@code SHA256withRSA}
+	 * @param extensions
+	 *            the extensions to write
+	 * @return the certificate
+	 * @throws Exception
+	 *             if the certificate cannot be built or signed
+	 */
+	public static X509Certificate create(final KeyPair keyPair, final X500Name distinguishedName,
+		final int days, final String signatureAlgorithm, final Extensions extensions)
+		throws Exception
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+		requireSignatureFitsTheKey(keyPair, signatureAlgorithm);
+
+		final Instant now = Instant.now();
+		final JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+			distinguishedName, newSerialNumber(), Date.from(now),
+			Date.from(now.plus(days, ChronoUnit.DAYS)), distinguishedName, keyPair.getPublic());
+		addExtensions(builder, extensions);
+
+		final ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm)
+			.setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+		return new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME)
+			.getCertificate(builder.build(signer));
+	}
+
+	/**
+	 * Refuses a signature algorithm that the key cannot legitimately be used with.
+	 * <p>
+	 * RFC 4055 requires an RSASSA-PSS key to be used with a PSS signature; signing with
+	 * {@code SHA256withRSA} instead produces a certificate that some verifiers reject, and it does
+	 * so quietly. This is the mistake that was made in the UI and caught in review, so the library
+	 * refuses the combination rather than producing that certificate.
+	 *
+	 * @param keyPair
+	 *            the key pair that will sign
+	 * @param signatureAlgorithm
+	 *            the signature algorithm asked for
+	 * @throws IllegalArgumentException
+	 *             if the combination is not valid
+	 */
+	static void requireSignatureFitsTheKey(final KeyPair keyPair, final String signatureAlgorithm)
+	{
+		final String keyAlgorithm = keyPair.getPrivate().getAlgorithm();
+		if (!RSASSA_PSS.equalsIgnoreCase(keyAlgorithm))
+		{
+			return;
+		}
+		final String normalized = signatureAlgorithm.toUpperCase(Locale.ROOT);
+		if (normalized.contains("MGF1") || normalized.contains("PSS"))
+		{
+			return;
+		}
+		throw new IllegalArgumentException("an " + RSASSA_PSS + " key must be used with a PSS "
+			+ "signature: RFC 4055 requires SHA256withRSAandMGF1 (or another ...andMGF1 name), "
+			+ "not '" + signatureAlgorithm + "'. A certificate signed the other way is rejected by "
+			+ "some verifiers.");
+	}
+
+	private static void addExtensions(final JcaX509v3CertificateBuilder builder,
+		final Extensions extensions) throws Exception
+	{
+		final BasicConstraintsSpec basicConstraints = extensions.basicConstraints();
+		if (basicConstraints != null)
+		{
+			builder.addExtension(Extension.basicConstraints,
+				extensions.criticalExtensions().contains("basic-constraints"),
+				newBasicConstraints(basicConstraints));
+		}
+		if (!extensions.keyUsages().isEmpty())
+		{
+			builder.addExtension(Extension.keyUsage,
+				extensions.criticalExtensions().contains("key-usage"),
+				new KeyUsage(keyUsageBits(extensions.keyUsages())));
+		}
+		if (!extensions.subjectAlternativeNames().isEmpty())
+		{
+			builder.addExtension(Extension.subjectAlternativeName,
+				extensions.criticalExtensions().contains("san"),
+				newGeneralNames(extensions.subjectAlternativeNames()));
+		}
+	}
+
+	private static BasicConstraints newBasicConstraints(final BasicConstraintsSpec specification)
+	{
+		if (!specification.certificateAuthority())
+		{
+			return new BasicConstraints(false);
+		}
+		return specification.pathLength() == null
+			? new BasicConstraints(true)
+			: new BasicConstraints(specification.pathLength());
+	}
+
+	private static GeneralNames newGeneralNames(final List<SubjectAlternativeName> names)
+	{
+		final List<GeneralName> generalNames = new ArrayList<>(names.size());
+		for (final SubjectAlternativeName name : names)
+		{
+			generalNames.add(new GeneralName(name.tag(), name.value()));
+		}
+		return new GeneralNames(generalNames.toArray(new GeneralName[0]));
+	}
+
+	/**
+	 * Turns the key usage names into the bit set the extension carries.
+	 *
+	 * @param names
+	 *            the key usage names
+	 * @return the combined bits
+	 * @throws IllegalArgumentException
+	 *             if a name is not a key usage
+	 */
+	static int keyUsageBits(final List<String> names)
+	{
+		int bits = 0;
+		for (final String name : names)
+		{
+			bits |= keyUsageBit(name.trim());
+		}
+		return bits;
+	}
+
+	private static int keyUsageBit(final String name)
+	{
+		return switch (name.toLowerCase(Locale.ROOT))
+		{
+			case "digitalsignature" -> KeyUsage.digitalSignature;
+			case "nonrepudiation", "contentcommitment" -> KeyUsage.nonRepudiation;
+			case "keyencipherment" -> KeyUsage.keyEncipherment;
+			case "dataencipherment" -> KeyUsage.dataEncipherment;
+			case "keyagreement" -> KeyUsage.keyAgreement;
+			case "keycertsign" -> KeyUsage.keyCertSign;
+			case "crlsign" -> KeyUsage.cRLSign;
+			case "encipheronly" -> KeyUsage.encipherOnly;
+			case "decipheronly" -> KeyUsage.decipherOnly;
+			default -> throw new IllegalArgumentException("'" + name + "' is not a key usage. Use "
+				+ "digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, "
+				+ "keyAgreement, keyCertSign, cRLSign, encipherOnly or decipherOnly.");
+		};
+	}
+
+	private static BigInteger newSerialNumber()
+	{
+		return new BigInteger(159, new SecureRandom());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateExtensionsCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateExtensionsCommandTest.java
@@ -1,0 +1,263 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for the extensions {@code cert} gained: basic constraints, key usage and subject
+ * alternative names, read back out of the written certificate rather than out of the run's own
+ * output.
+ */
+class CertificateExtensionsCommandTest extends AbstractCliTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	private static X509Certificate read(File pem) throws Exception
+	{
+		try (FileInputStream stream = new FileInputStream(pem))
+		{
+			return (X509Certificate)CertificateFactory.getInstance("X.509")
+				.generateCertificate(stream);
+		}
+	}
+
+	@Test
+	void writesBasicConstraintsForACaWithAPathLength(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "ca.pem");
+
+		assertEquals(0, run("cert", "--subject", "CN=a-ca", "--days", "1", "--basic-constraints",
+			"ca,pathlen=1", "--out", pem.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(1, read(pem).getBasicConstraints(),
+			"getBasicConstraints returns the path length for a CA");
+		assertTrue(out.contains("basic constraints"), "stdout was: '" + out + "'");
+	}
+
+	@Test
+	void writesBasicConstraintsForAnEndEntity(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "leaf.pem");
+
+		assertEquals(0, run("cert", "--subject", "CN=a-leaf", "--days", "1", "--basic-constraints",
+			"end-entity", "--out", pem.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(-1, read(pem).getBasicConstraints(),
+			"getBasicConstraints returns -1 when the certificate is not a CA");
+	}
+
+	@Test
+	void aCaWithoutAPathLengthHasNoLimit(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "ca.pem");
+
+		assertEquals(0, run("cert", "--subject", "CN=a-ca", "--days", "1", "--basic-constraints",
+			"ca", "--out", pem.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(Integer.MAX_VALUE, read(pem).getBasicConstraints(),
+			"an unlimited path length is reported as Integer.MAX_VALUE");
+	}
+
+	/** The nine key usages, each in the bit position the extension gives it. */
+	@ParameterizedTest
+	@CsvSource({ "digitalSignature, 0", "nonRepudiation, 1", "keyEncipherment, 2",
+			"dataEncipherment, 3", "keyAgreement, 4", "keyCertSign, 5", "cRLSign, 6",
+			"encipherOnly, 7", "decipherOnly, 8" })
+	void writesEachKeyUsageInItsOwnBit(String usage, int bit, @TempDir File tempDir)
+		throws Exception
+	{
+		File pem = new File(tempDir, "usage.pem");
+
+		assertEquals(0, run("cert", "--subject", "CN=usage", "--days", "1", "--key-usage", usage,
+			"--out", pem.getPath()), "stderr was: '" + err + "'");
+
+		boolean[] keyUsage = read(pem).getKeyUsage();
+		assertNotNull(keyUsage, "the key usage extension must be present");
+		assertTrue(keyUsage[bit], usage + " must set bit " + bit);
+	}
+
+	@Test
+	void writesSeveralKeyUsagesAtOnce(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "usage.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=usage", "--days", "1", "--key-usage",
+				"digitalSignature,keyCertSign", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		boolean[] keyUsage = read(pem).getKeyUsage();
+		assertTrue(keyUsage[0] && keyUsage[5], "both usages must be set");
+		assertFalse(keyUsage[2], "an unnamed usage must not be set");
+	}
+
+	@Test
+	void writesEveryKindOfSubjectAlternativeName(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "san.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=san", "--days", "1", "--san", "dns:example.org", "--san",
+				"ip:10.0.0.1", "--san", "email:someone@example.org", "--san",
+				"uri:https://example.org", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		List<String> names = read(pem).getSubjectAlternativeNames().stream()
+			.map(entry -> String.valueOf(entry.get(1))).toList();
+		assertTrue(names.contains("example.org"), "names were: " + names);
+		assertTrue(names.contains("10.0.0.1"), "names were: " + names);
+		assertTrue(names.contains("someone@example.org"), "names were: " + names);
+		assertTrue(names.contains("https://example.org"), "names were: " + names);
+	}
+
+	@Test
+	void marksTheNamedExtensionsCritical(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "critical.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=critical", "--days", "1", "--basic-constraints", "ca",
+				"--key-usage", "keyCertSign", "--san", "dns:example.org", "--critical",
+				"basic-constraints,key-usage", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		X509Certificate certificate = read(pem);
+		assertTrue(certificate.getCriticalExtensionOIDs().contains("2.5.29.19"),
+			"basic constraints must be critical");
+		assertTrue(certificate.getCriticalExtensionOIDs().contains("2.5.29.15"),
+			"key usage must be critical");
+		assertTrue(certificate.getNonCriticalExtensionOIDs().contains("2.5.29.17"),
+			"the subject alternative names were not named, so they must not be critical");
+	}
+
+	@Test
+	void withoutTheOptionsNoExtensionsAreWritten(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "plain.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=plain", "--days", "1", "--out", pem.getPath()));
+
+		X509Certificate certificate = read(pem);
+		assertEquals(-1, certificate.getBasicConstraints());
+		assertNull(certificate.getKeyUsage());
+		assertNull(certificate.getSubjectAlternativeNames());
+	}
+
+	/**
+	 * The mistake this refuses: RFC 4055 requires an RSASSA-PSS key to be used with a PSS
+	 * signature. Signing with SHA256withRSA instead yields a certificate some verifiers reject, and
+	 * it does so quietly, so the library refuses rather than producing it.
+	 */
+	@Test
+	void anRsassaPssKeySignedWithPlainRsaIsRefusedWithTheRfcReason(@TempDir File tempDir)
+	{
+		int exitCode = run("cert", "--subject", "CN=pss", "--days", "1", "-a", "RSASSA-PSS",
+			"--signature-algorithm", "SHA256withRSA", "--out",
+			new File(tempDir, "x.pem").getPath());
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("RFC 4055") && err.contains("MGF1"),
+			"the message must say what to use instead, but was: '" + err + "'");
+	}
+
+	@Test
+	void anRsassaPssKeySignedWithMgf1IsAccepted(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "pss.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=pss", "--days", "1", "-a", "RSASSA-PSS",
+				"--signature-algorithm", "SHA256withRSAandMGF1", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertNotNull(read(pem), "the certificate must be readable");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neither", "ca,pathlen=notanumber", "ca,pathlen=-1", "ca,nonsense",
+			"end-entity,pathlen=1" })
+	void basicConstraintsThatDoNotMakeSenseAreRefusedWithTheReason(String value,
+		@TempDir File tempDir)
+	{
+		assertEquals(2, run("cert", "--subject", "CN=x", "--days", "1", "--basic-constraints",
+			value, "--out", new File(tempDir, "x.pem").getPath()));
+		assertFalse(err.isBlank(), "the failure must be explained for '" + value + "'");
+	}
+
+	@Test
+	void anUnknownKeyUsageListsTheOnesThatExist(@TempDir File tempDir)
+	{
+		assertEquals(2, run("cert", "--subject", "CN=x", "--days", "1", "--key-usage",
+			"signAllTheThings", "--out", new File(tempDir, "x.pem").getPath()));
+
+		assertTrue(err.contains("is not a key usage") && err.contains("digitalSignature"),
+			"the message must list the usages, but was: '" + err + "'");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "example.org", "dns:", ":example.org", "ftp:example.org" })
+	void aSubjectAlternativeNameWithoutAKnownTypeIsRefused(String value, @TempDir File tempDir)
+	{
+		assertEquals(2, run("cert", "--subject", "CN=x", "--days", "1", "--san", value, "--out",
+			new File(tempDir, "x.pem").getPath()));
+		assertFalse(err.isBlank(), "the failure must be explained for '" + value + "'");
+	}
+
+	@Test
+	void theCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("cert", "--help"));
+		assertTrue(
+			out.contains("--basic-constraints") && out.contains("--key-usage")
+				&& out.contains("--san") && out.contains("--critical"),
+			"stdout was: '" + out + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ChecksumCommandTest.java
@@ -26,8 +26,10 @@ package io.github.astrapi69.mystic.crypt.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
@@ -37,10 +39,25 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Unit tests for the {@code checksum} subcommand, asserting the well-known digests of the string
- * "abc" for each algorithm.
+ * "abc" for each algorithm, and the keyed answer next to them.
+ * <p>
+ * The value is the first whitespace-separated field of the output, as with {@code sha256sum}, and
+ * the rest of the line says which of the two questions was answered.
  */
 class ChecksumCommandTest extends AbstractCliTest
 {
+
+	private static File abcFile(File tempDir) throws IOException
+	{
+		File abc = new File(tempDir, "abc.txt");
+		Files.writeString(abc.toPath(), "abc");
+		return abc;
+	}
+
+	private String value()
+	{
+		return out.strip().split("\\s+")[0];
+	}
 
 	@ParameterizedTest
 	@CsvSource({ "MD5,900150983cd24fb0d6963f7d28e17f72",
@@ -50,27 +67,128 @@ class ChecksumCommandTest extends AbstractCliTest
 	void computesKnownDigestOfAbc(String algorithm, String expected, @TempDir File tempDir)
 		throws Exception
 	{
-		File abc = new File(tempDir, "abc.txt");
-		Files.writeString(abc.toPath(), "abc");
+		File abc = abcFile(tempDir);
+
 		assertEquals(0, run("checksum", "--algorithm", algorithm, abc.getAbsolutePath()));
-		assertEquals(expected, out.strip());
+
+		assertEquals(expected, value());
+		assertTrue(out.contains(algorithm + " digest"),
+			"the line must say which question was answered, but was: '" + out + "'");
 	}
 
 	@Test
 	void defaultAlgorithmIsSha256(@TempDir File tempDir) throws Exception
 	{
-		File abc = new File(tempDir, "abc.txt");
-		Files.writeString(abc.toPath(), "abc");
+		File abc = abcFile(tempDir);
+
 		assertEquals(0, run("checksum", abc.getAbsolutePath()));
-		assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-			out.strip());
+
+		assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", value());
 	}
 
 	@Test
 	void unknownAlgorithmFails(@TempDir File tempDir) throws Exception
 	{
-		File abc = new File(tempDir, "abc.txt");
-		Files.writeString(abc.toPath(), "abc");
-		assertNotEquals(0, run("checksum", "--algorithm", "NOPE-1", abc.getAbsolutePath()));
+		File abc = abcFile(tempDir);
+
+		assertEquals(2, run("checksum", "--algorithm", "NOPE-1", abc.getAbsolutePath()));
+		assertTrue(err.contains("unknown digest algorithm"), "stderr was: '" + err + "'");
+	}
+
+	/** RFC 4231 test case 1, so the keyed answer is pinned to a published vector. */
+	@Test
+	void computesTheRfc4231HmacSha256Vector(@TempDir File tempDir) throws Exception
+	{
+		File data = new File(tempDir, "data.bin");
+		Files.write(data.toPath(), "Hi There".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+		// the published key for case 1 is twenty bytes of 0x0b, which a key can carry through
+		// standard input because it is not a line terminator
+		String key = "\u000b".repeat(20);
+
+		assertEquals(0,
+			runWithStdin(key + "\n", "checksum", "--hmac", "--key-stdin", data.getAbsolutePath()),
+			"stderr was: '" + err + "'");
+
+		assertEquals("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", value(),
+			"RFC 4231 case 1 for HMAC-SHA-256");
+	}
+
+	@Test
+	void theKeyedAnswerSaysItIsKeyedAndDiffersFromThePlainDigest(@TempDir File tempDir)
+		throws Exception
+	{
+		File abc = abcFile(tempDir);
+
+		assertEquals(0, run("checksum", abc.getAbsolutePath()));
+		String plain = value();
+
+		assertEquals(0, run("checksum", "--hmac", "--key", "the key", abc.getAbsolutePath()));
+		String keyed = value();
+
+		assertNotEquals(plain, keyed, "a keyed answer must not equal the plain digest");
+		assertTrue(out.contains("HmacSHA256 keyed digest"),
+			"the line must say the answer is keyed, but was: '" + out + "'");
+	}
+
+	@Test
+	void adifferentKeyGivesADifferentAnswer(@TempDir File tempDir) throws Exception
+	{
+		File abc = abcFile(tempDir);
+
+		assertEquals(0, run("checksum", "--hmac", "--key", "one key", abc.getAbsolutePath()));
+		String first = value();
+		assertEquals(0, run("checksum", "--hmac", "--key", "another key", abc.getAbsolutePath()));
+
+		assertNotEquals(first, value(),
+			"that is the whole point of the keyed answer: without the key it cannot be reproduced");
+	}
+
+	@Test
+	void aDigestNameUnderHmacSaysWhatToDoInstead(@TempDir File tempDir) throws Exception
+	{
+		File abc = abcFile(tempDir);
+
+		assertEquals(2,
+			run("checksum", "--hmac", "-a", "SHA-256", "--key", "k", abc.getAbsolutePath()));
+
+		assertTrue(err.contains("drop --hmac"),
+			"the message must say how to get the plain digest, but was: '" + err + "'");
+	}
+
+	@Test
+	void aMissingKeyUnderHmacNamesTheOptions(@TempDir File tempDir) throws Exception
+	{
+		File abc = abcFile(tempDir);
+
+		assertEquals(2, run("checksum", "--hmac", abc.getAbsolutePath()));
+
+		assertTrue(err.contains("--password") || err.contains("--key"),
+			"the message must name how to pass the key, but was: '" + err + "'");
+	}
+
+	/**
+	 * A password-based MAC exists under a JDK name but cannot take a plain key: SunJCE answers
+	 * "Missing password" for HmacPBESHA1 given a SecretKeySpec. That is a different failure from an
+	 * unknown algorithm and has to read differently.
+	 */
+	@Test
+	void aMacThatCannotTakeAPlainKeySaysTheKeyWasRejected(@TempDir File tempDir) throws Exception
+	{
+		File abc = abcFile(tempDir);
+
+		assertEquals(2,
+			run("checksum", "--hmac", "-a", "HmacPBESHA1", "--key", "k", abc.getAbsolutePath()));
+
+		assertTrue(err.contains("MAC key was rejected"),
+			"the message must separate a rejected key from an unknown algorithm, but was: '" + err
+				+ "'");
+	}
+
+	@Test
+	void theCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("checksum", "--help"));
+		assertTrue(out.contains("--hmac"), "stdout was: '" + out + "'");
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ClassicalSignatureCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ClassicalSignatureCommandTest.java
@@ -1,0 +1,266 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.crypt.data.key.writer.PrivateKeyWriter;
+import io.github.astrapi69.crypt.data.key.writer.PublicKeyWriter;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for {@code sign} and {@code verify-signature} with the classical families, which the
+ * commands gained alongside the post-quantum ones, and with key files in DER as well as PEM.
+ */
+class ClassicalSignatureCommandTest extends AbstractCliTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	/** Generates a key pair through Bouncy Castle, as the UI and the commands do. */
+	private static KeyPair newKeyPair(String keyAlgorithm) throws Exception
+	{
+		KeyPairGenerator generator = KeyPairGenerator.getInstance(keyAlgorithm,
+			BouncyCastleProvider.PROVIDER_NAME);
+		if ("EC".equals(keyAlgorithm))
+		{
+			// a NAMED curve, which is the shape SunEC rejects when it is asked to sign with it
+			generator.initialize(new ECGenParameterSpec("secp256r1"));
+		}
+		else
+		{
+			generator.initialize("DSA".equals(keyAlgorithm) ? 2048 : 2048);
+		}
+		return generator.generateKeyPair();
+	}
+
+	private static File[] writePem(File tempDir, KeyPair keyPair) throws Exception
+	{
+		File privatePem = new File(tempDir, "private.pem");
+		File publicPem = new File(tempDir, "public.pem");
+		PrivateKeyWriter.writeInPemFormat(keyPair.getPrivate(), privatePem);
+		PublicKeyWriter.writeInPemFormat(keyPair.getPublic(), publicPem);
+		return new File[] { privatePem, publicPem };
+	}
+
+	private static File[] writeDer(File tempDir, KeyPair keyPair) throws Exception
+	{
+		File privateDer = new File(tempDir, "private.der");
+		File publicDer = new File(tempDir, "public.der");
+		Files.write(privateDer.toPath(), keyPair.getPrivate().getEncoded());
+		Files.write(publicDer.toPath(), keyPair.getPublic().getEncoded());
+		return new File[] { privateDer, publicDer };
+	}
+
+	private static File dataFile(File tempDir) throws Exception
+	{
+		File data = new File(tempDir, "data.txt");
+		Files.writeString(data.toPath(), "the bytes that get signed", StandardCharsets.UTF_8);
+		return data;
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "RSA, RSA", "EC, EC", "ECDSA, EC", "DSA, DSA", "SHA512withRSA, RSA" })
+	void signAndVerifyRoundTripWithPemKeys(String algorithm, String keyAlgorithm,
+		@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = newKeyPair(keyAlgorithm);
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+
+		assertEquals(0, run("sign", "-a", algorithm, "--key", keys[0].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(0, run("verify-signature", "-a", algorithm, "--key", keys[1].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()), "stderr was: '" + err + "'");
+		assertTrue(out.contains("signature is valid"), "stdout was: '" + out + "'");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "RSA", "EC", "DSA" })
+	void signAndVerifyRoundTripWithDerKeys(String keyAlgorithm, @TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = newKeyPair(keyAlgorithm);
+		File[] keys = writeDer(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+
+		assertEquals(0, run("sign", "-a", keyAlgorithm, "--key", keys[0].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(0, run("verify-signature", "-a", keyAlgorithm, "--key", keys[1].getPath(),
+			"--in", data.getPath(), "--signature", signature.getPath()),
+			"stderr was: '" + err + "'");
+		assertTrue(out.contains("signature is valid"));
+	}
+
+	/**
+	 * The trap this pins: an EC key on a named curve, generated by Bouncy Castle, is rejected by
+	 * the JDK's SunEC provider when it signs, and verification with it returns false rather than
+	 * throwing - a valid signature would read as an invalid one with nothing saying why. Signing,
+	 * verifying and decoding all go through Bouncy Castle so this round trip holds.
+	 */
+	@Test
+	void anEcKeyOnANamedCurveSignsAndVerifiesRatherThanReadingAsInvalid(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = newKeyPair("EC");
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+
+		assertEquals(0, run("sign", "-a", "EC", "--key", keys[0].getPath(), "--in", data.getPath(),
+			"--signature", signature.getPath()), "stderr was: '" + err + "'");
+		int exitCode = run("verify-signature", "-a", "EC", "--key", keys[1].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath());
+
+		assertEquals(0, exitCode,
+			"a named-curve EC signature must read as valid, not as invalid; stdout was: '" + out
+				+ "', stderr was: '" + err + "'");
+		assertTrue(out.contains("signature is valid"));
+	}
+
+	/** ECDSA and EC name the same family, so a key written under one verifies under the other. */
+	@Test
+	void ecdsaAndEcNameTheSameFamily(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = newKeyPair("EC");
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+
+		assertEquals(0, run("sign", "-a", "ECDSA", "--key", keys[0].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()), "stderr was: '" + err + "'");
+
+		assertEquals(0, run("verify-signature", "-a", "EC", "--key", keys[1].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void aSignatureOfAnotherKeyIsInvalidRatherThanAnError(@TempDir File tempDir) throws Exception
+	{
+		KeyPair signing = newKeyPair("RSA");
+		KeyPair other = newKeyPair("RSA");
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+		File privatePem = new File(tempDir, "signing-private.pem");
+		File otherPublicPem = new File(tempDir, "other-public.pem");
+		PrivateKeyWriter.writeInPemFormat(signing.getPrivate(), privatePem);
+		PublicKeyWriter.writeInPemFormat(other.getPublic(), otherPublicPem);
+
+		assertEquals(0, run("sign", "-a", "RSA", "--key", privatePem.getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()));
+
+		assertEquals(1,
+			run("verify-signature", "-a", "RSA", "--key", otherPublicPem.getPath(), "--in",
+				data.getPath(), "--signature", signature.getPath()),
+			"a signature of another key is the negative answer, stderr was: '" + err + "'");
+		assertTrue(out.contains("signature is invalid"));
+	}
+
+	@Test
+	void alteredDataMakesTheSignatureInvalid(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = newKeyPair("EC");
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File signature = new File(tempDir, "data.sig");
+		assertEquals(0, run("sign", "-a", "EC", "--key", keys[0].getPath(), "--in", data.getPath(),
+			"--signature", signature.getPath()));
+
+		Files.writeString(data.toPath(), "the bytes that got changed", StandardCharsets.UTF_8);
+
+		assertEquals(1, run("verify-signature", "-a", "EC", "--key", keys[1].getPath(), "--in",
+			data.getPath(), "--signature", signature.getPath()));
+	}
+
+	@Test
+	void twoRsaSignaturesOfTheSameDataAreTheSameBecauseRsaIsDeterministic(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = newKeyPair("RSA");
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+		File first = new File(tempDir, "first.sig");
+		File second = new File(tempDir, "second.sig");
+
+		assertEquals(0, run("sign", "-a", "RSA", "--key", keys[0].getPath(), "--in", data.getPath(),
+			"--signature", first.getPath()));
+		assertEquals(0, run("sign", "-a", "RSA", "--key", keys[0].getPath(), "--in", data.getPath(),
+			"--signature", second.getPath()));
+
+		assertEquals(java.util.HexFormat.of().formatHex(Files.readAllBytes(first.toPath())),
+			java.util.HexFormat.of().formatHex(Files.readAllBytes(second.toPath())),
+			"PKCS#1 v1.5 RSA signing is deterministic, unlike ECDSA and DSA");
+	}
+
+	@Test
+	void aKeyFileThatHoldsNoKeyIsNamedAsSuch(@TempDir File tempDir) throws Exception
+	{
+		File notAKey = new File(tempDir, "not-a-key.pem");
+		Files.writeString(notAKey.toPath(), "just some text", StandardCharsets.UTF_8);
+		File data = dataFile(tempDir);
+
+		assertNotEquals(0, run("sign", "-a", "RSA", "--key", notAKey.getPath(), "--in",
+			data.getPath(), "--signature", new File(tempDir, "x.sig").getPath()));
+		assertTrue(err.contains("private key"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void aPublicKeyWhereThePrivateOneBelongsIsRefused(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = newKeyPair("RSA");
+		File[] keys = writePem(tempDir, keyPair);
+		File data = dataFile(tempDir);
+
+		assertNotEquals(0, run("sign", "-a", "RSA", "--key", keys[1].getPath(), "--in",
+			data.getPath(), "--signature", new File(tempDir, "x.sig").getPath()));
+		assertTrue(err.contains("not a private key") || err.contains("private key"),
+			"stderr was: '" + err + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
@@ -1,0 +1,399 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.key.KeyFileReader;
+import io.github.astrapi69.mystic.crypt.key.KeyFileWriter;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for the {@code convert} subcommand: what it says a file is, and what it turns it into.
+ */
+class ConvertCommandTest extends AbstractCliTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	private static KeyPair keyPair(String algorithm) throws Exception
+	{
+		KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm,
+			BouncyCastleProvider.PROVIDER_NAME);
+		generator.initialize(2048);
+		return generator.generateKeyPair();
+	}
+
+	private static File writeDerPrivate(File tempDir, KeyPair keyPair) throws Exception
+	{
+		File der = new File(tempDir, "private.der");
+		Files.write(der.toPath(), keyPair.getPrivate().getEncoded());
+		return der;
+	}
+
+	@Test
+	void describesADerPrivateKeyWithoutChangingIt(@TempDir File tempDir) throws Exception
+	{
+		File der = writeDerPrivate(tempDir, keyPair("RSA"));
+		byte[] before = Files.readAllBytes(der.toPath());
+
+		assertEquals(0, run("convert", "--in", der.getPath(), "--describe"),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("private key in PKCS#8"), "stdout was: '" + out + "'");
+		assertTrue(out.contains("DER"), "stdout was: '" + out + "'");
+		assertArrayEquals(before, Files.readAllBytes(der.toPath()),
+			"--describe must change nothing");
+	}
+
+	@Test
+	void namesWhatItFoundBeforeConverting(@TempDir File tempDir) throws Exception
+	{
+		File der = writeDerPrivate(tempDir, keyPair("RSA"));
+		File pem = new File(tempDir, "private.pem");
+
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pkcs8", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("is a private key in PKCS#8"),
+			"the run must say what it found first, but was: '" + out + "'");
+		assertTrue(out.contains("wrote PEM"), "stdout was: '" + out + "'");
+	}
+
+	/**
+	 * The defect this pins: asking for PKCS#8 must produce PKCS#8. crypt-data's PrivateKeyWriter
+	 * strips the wrapper and writes PKCS#1 under an RSA PRIVATE KEY header instead, which is why
+	 * the writing here does not go through it.
+	 */
+	@Test
+	void askingForPkcs8ProducesPkcs8AndAskingForPkcs1ProducesPkcs1(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = keyPair("RSA");
+		File der = writeDerPrivate(tempDir, keyPair);
+		File asPkcs8 = new File(tempDir, "pkcs8.pem");
+		File asPkcs1 = new File(tempDir, "pkcs1.pem");
+
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pkcs8", "--out", asPkcs8.getPath()));
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pkcs1", "--out", asPkcs1.getPath()));
+
+		String pkcs8 = Files.readString(asPkcs8.toPath(), StandardCharsets.UTF_8);
+		String pkcs1 = Files.readString(asPkcs1.toPath(), StandardCharsets.UTF_8);
+
+		assertTrue(pkcs8.contains("-----BEGIN " + KeyFileWriter.PKCS8_LABEL + "-----"),
+			"PKCS#8 must be written under the PRIVATE KEY header, but was: '" + pkcs8 + "'");
+		assertTrue(pkcs1.contains("-----BEGIN " + KeyFileWriter.PKCS1_RSA_LABEL + "-----"),
+			"PKCS#1 must be written under the RSA PRIVATE KEY header, but was: '" + pkcs1 + "'");
+
+		// and both are still the same key
+		assertArrayEquals(keyPair.getPrivate().getEncoded(),
+			KeyFileReader.readPrivateKey(asPkcs8, "RSA").getEncoded());
+		assertArrayEquals(keyPair.getPrivate().getEncoded(),
+			KeyFileReader.readPrivateKey(asPkcs1, "RSA").getEncoded());
+	}
+
+	@Test
+	void aPrivateKeyRoundTripsThroughPemAndBackToDer(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = keyPair("RSA");
+		File der = writeDerPrivate(tempDir, keyPair);
+		File pem = new File(tempDir, "round.pem");
+		File backToDer = new File(tempDir, "round.der");
+
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pem", "--out", pem.getPath()));
+		assertEquals(0,
+			run("convert", "--in", pem.getPath(), "--to", "der", "--out", backToDer.getPath()));
+
+		assertArrayEquals(Files.readAllBytes(der.toPath()), Files.readAllBytes(backToDer.toPath()),
+			"a round trip through PEM must give back the same DER bytes");
+	}
+
+	@Test
+	void aPublicKeyConvertsBothWays(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = keyPair("RSA");
+		File der = new File(tempDir, "public.der");
+		Files.write(der.toPath(), keyPair.getPublic().getEncoded());
+		File pem = new File(tempDir, "public.pem");
+		File backToDer = new File(tempDir, "public-back.der");
+
+		assertEquals(0, run("convert", "--in", der.getPath(), "--describe"));
+		assertTrue(out.contains("a public key"), "stdout was: '" + out + "'");
+
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pem", "--out", pem.getPath()));
+		assertEquals(0,
+			run("convert", "--in", pem.getPath(), "--to", "der", "--out", backToDer.getPath()));
+		assertArrayEquals(keyPair.getPublic().getEncoded(), Files.readAllBytes(backToDer.toPath()));
+	}
+
+	@Test
+	void aCertificateConvertsBothWays(@TempDir File tempDir) throws Exception
+	{
+		File certificatePem = new File(tempDir, "cert.pem");
+		assertEquals(0, run("cert", "--subject", "CN=convert-test", "--days", "1", "--out",
+			certificatePem.getPath()), "stderr was: '" + err + "'");
+		File certificateDer = new File(tempDir, "cert.der");
+		File backToPem = new File(tempDir, "cert-back.pem");
+
+		assertEquals(0, run("convert", "--in", certificatePem.getPath(), "--describe"));
+		assertTrue(out.contains("X.509 certificate"), "stdout was: '" + out + "'");
+
+		assertEquals(0, run("convert", "--in", certificatePem.getPath(), "--to", "der", "--out",
+			certificateDer.getPath()), "stderr was: '" + err + "'");
+		assertEquals(0, run("convert", "--in", certificateDer.getPath(), "--to", "pem", "--out",
+			backToPem.getPath()), "stderr was: '" + err + "'");
+
+		assertTrue(Files.readString(backToPem.toPath()).contains("-----BEGIN CERTIFICATE-----"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "pkcs1", "pkcs8" })
+	void askingForAPrivateKeyWrappingOfAPublicKeySaysWhyThatMakesNoSense(String target,
+		@TempDir File tempDir) throws Exception
+	{
+		File der = new File(tempDir, "public.der");
+		Files.write(der.toPath(), keyPair("RSA").getPublic().getEncoded());
+
+		assertEquals(2, run("convert", "--in", der.getPath(), "--to", target, "--out",
+			new File(tempDir, "x").getPath()));
+		assertTrue(err.contains("PRIVATE key") || err.contains("private key"),
+			"the message must explain the mismatch, but was: '" + err + "'");
+	}
+
+	@Test
+	void derCannotBePrintedAndSaysSo(@TempDir File tempDir) throws Exception
+	{
+		File der = writeDerPrivate(tempDir, keyPair("RSA"));
+
+		assertEquals(2, run("convert", "--in", der.getPath(), "--to", "der"));
+		assertTrue(err.contains("--out"),
+			"the message must say how to get it, but was: '" + err + "'");
+	}
+
+	@Test
+	void withoutATargetItSaysWhatItIsAndThatNothingWasConverted(@TempDir File tempDir)
+		throws Exception
+	{
+		File der = writeDerPrivate(tempDir, keyPair("RSA"));
+
+		assertEquals(0, run("convert", "--in", der.getPath()));
+
+		assertTrue(out.contains("nothing was converted"), "stdout was: '" + out + "'");
+		assertTrue(out.contains("--to"), "stdout was: '" + out + "'");
+	}
+
+	@Test
+	void aFileThatIsNeitherKeyNorCertificateIsNamedAsSuch(@TempDir File tempDir) throws Exception
+	{
+		File rubbish = new File(tempDir, "rubbish.bin");
+		Files.write(rubbish.toPath(), new byte[] { 9, 9, 9, 9 });
+
+		assertEquals(2, run("convert", "--in", rubbish.getPath(), "--describe"));
+		assertTrue(err.contains("not a DER"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void printedPemGoesToStandardOutputWhenNoFileIsGiven(@TempDir File tempDir) throws Exception
+	{
+		File der = writeDerPrivate(tempDir, keyPair("RSA"));
+
+		assertEquals(0, run("convert", "--in", der.getPath(), "--to", "pkcs8"));
+
+		assertTrue(out.contains("-----BEGIN PRIVATE KEY-----"), "stdout was: '" + out + "'");
+	}
+
+	@Test
+	void der2pemStillWorksAndSaysItIsDeprecated()
+	{
+		assertEquals(0, run("der2pem", "--help"));
+		assertTrue(out.contains("Deprecated"),
+			"the old command must point at the new one, but was: '" + out + "'");
+	}
+
+	/**
+	 * A traditional PKCS#1 PEM is the other private key shape a file arrives in, and every target
+	 * has to work from it too. Converting only the encoding must keep the wrapping it had, so that
+	 * asking for PEM does not silently restructure the key as well.
+	 */
+	@Test
+	void aPkcs1PemConvertsToEveryTargetAndKeepsItsWrappingUnderPem(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = keyPair("RSA");
+		File pkcs1 = new File(tempDir, "pkcs1.pem");
+		Files.writeString(pkcs1.toPath(), KeyFileWriter.toPem(keyPair.getPrivate(), true),
+			StandardCharsets.UTF_8);
+
+		assertEquals(0, run("convert", "--in", pkcs1.getPath(), "--describe"));
+		assertTrue(out.contains("PKCS#1"), "stdout was: '" + out + "'");
+
+		File stillPkcs1 = new File(tempDir, "still-pkcs1.pem");
+		assertEquals(0,
+			run("convert", "--in", pkcs1.getPath(), "--to", "pem", "--out", stillPkcs1.getPath()),
+			"stderr was: '" + err + "'");
+		assertTrue(
+			Files.readString(stillPkcs1.toPath())
+				.contains("-----BEGIN " + KeyFileWriter.PKCS1_RSA_LABEL + "-----"),
+			"--to pem must not change the wrapping");
+
+		File asPkcs8 = new File(tempDir, "as-pkcs8.pem");
+		assertEquals(0,
+			run("convert", "--in", pkcs1.getPath(), "--to", "pkcs8", "--out", asPkcs8.getPath()));
+		assertTrue(Files.readString(asPkcs8.toPath())
+			.contains("-----BEGIN " + KeyFileWriter.PKCS8_LABEL + "-----"));
+
+		File asDer = new File(tempDir, "as.der");
+		assertEquals(0,
+			run("convert", "--in", pkcs1.getPath(), "--to", "der", "--out", asDer.getPath()));
+		assertArrayEquals(keyPair.getPrivate().getEncoded(), Files.readAllBytes(asDer.toPath()));
+	}
+
+	/**
+	 * Only RSA has a traditional label of its own; an EC key asked for PKCS#1 keeps the PKCS#8
+	 * label, because there is no traditional form for it to be mistaken for.
+	 */
+	@Test
+	void aNonRsaKeyAskedForPkcs1KeepsThePkcs8Label(@TempDir File tempDir) throws Exception
+	{
+		java.security.KeyPairGenerator generator = java.security.KeyPairGenerator.getInstance("EC",
+			BouncyCastleProvider.PROVIDER_NAME);
+		generator.initialize(new java.security.spec.ECGenParameterSpec("secp256r1"));
+		KeyPair keyPair = generator.generateKeyPair();
+		File der = new File(tempDir, "ec.der");
+		Files.write(der.toPath(), keyPair.getPrivate().getEncoded());
+		File pem = new File(tempDir, "ec-pkcs1.pem");
+
+		assertEquals(0,
+			run("convert", "--in", der.getPath(), "--to", "pkcs1", "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(
+			Files.readString(pem.toPath())
+				.contains("-----BEGIN " + KeyFileWriter.PKCS8_LABEL + "-----"),
+			"an EC key has no traditional label of its own");
+	}
+
+	@Test
+	void aCertificateHasNoPrivateKeyWrappingToAskFor(@TempDir File tempDir) throws Exception
+	{
+		File certificatePem = new File(tempDir, "cert.pem");
+		assertEquals(0, run("cert", "--subject", "CN=convert-test", "--days", "1", "--out",
+			certificatePem.getPath()));
+
+		assertEquals(2, run("convert", "--in", certificatePem.getPath(), "--to", "pkcs8", "--out",
+			new File(tempDir, "x").getPath()));
+		assertTrue(err.contains("certificate has neither"),
+			"the message must explain the mismatch, but was: '" + err + "'");
+	}
+
+	@Test
+	void aCertificateCanBeRewrittenAsPemFromPem(@TempDir File tempDir) throws Exception
+	{
+		File certificatePem = new File(tempDir, "cert.pem");
+		assertEquals(0, run("cert", "--subject", "CN=convert-test", "--days", "1", "--out",
+			certificatePem.getPath()));
+		File rewritten = new File(tempDir, "cert-again.pem");
+
+		assertEquals(0, run("convert", "--in", certificatePem.getPath(), "--to", "pem", "--out",
+			rewritten.getPath()), "stderr was: '" + err + "'");
+
+		assertTrue(Files.readString(rewritten.toPath()).contains("-----BEGIN CERTIFICATE-----"));
+	}
+
+	@Test
+	void aPemHoldingSomethingThatIsNeitherKeyNorCertificateIsNamed(@TempDir File tempDir)
+		throws Exception
+	{
+		File pem = new File(tempDir, "odd.pem");
+		Files.writeString(pem.toPath(), "text -----BEGIN something odd" + System.lineSeparator(),
+			StandardCharsets.UTF_8);
+
+		assertEquals(2, run("convert", "--in", pem.getPath(), "--describe"));
+		assertTrue(err.contains("no PEM object"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void aPemHoldingAWellFormedObjectThatIsNoKeyIsNamedByItsType(@TempDir File tempDir)
+		throws Exception
+	{
+		// EC PARAMETERS parses cleanly into a curve identifier: a well formed PEM object that is
+		// neither a key nor a certificate, which is the case the message exists for
+		byte[] secp256r1 = { 0x06, 0x08, 0x2A, (byte)0x86, 0x48, (byte)0xCE, 0x3D, 0x03, 0x01,
+				0x07 };
+		File pem = new File(tempDir, "params.pem");
+		Files.writeString(pem.toPath(), KeyFileWriter.toPem("EC PARAMETERS", secp256r1),
+			StandardCharsets.UTF_8);
+
+		assertEquals(2, run("convert", "--in", pem.getPath(), "--describe"));
+		assertTrue(err.contains("not a key or a certificate"),
+			"the message must say what it holds, but was: '" + err + "'");
+	}
+
+	@Test
+	void aPemWhoseBodyDoesNotMatchItsArmourIsNamedAsUnreadable(@TempDir File tempDir)
+		throws Exception
+	{
+		File pem = new File(tempDir, "broken.pem");
+		Files.writeString(pem.toPath(),
+			"-----BEGIN CERTIFICATE-----" + System.lineSeparator() + "!!!not base64!!!"
+				+ System.lineSeparator() + "-----END CERTIFICATE-----" + System.lineSeparator(),
+			StandardCharsets.UTF_8);
+
+		assertEquals(2, run("convert", "--in", pem.getPath(), "--describe"));
+		assertTrue(err.contains("could not read a PEM object"),
+			"the message must say the body could not be read, but was: '" + err + "'");
+	}
+
+	@Test
+	void theCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("convert", "--help"));
+		assertTrue(out.contains("--describe") && out.contains("--to"), "stdout was: '" + out + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
@@ -1,0 +1,209 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.astrapi69.mystic.crypt.pw.PassphraseCryptor;
+
+/**
+ * Unit tests for the {@code encrypt} and {@code decrypt} subcommands, driven through the real
+ * command line against real files.
+ */
+class EncryptDecryptCommandTest extends AbstractCliTest
+{
+
+	@Test
+	void aFileSurvivesTheRoundTripByteForByte(@TempDir File tempDir) throws IOException
+	{
+		File plain = new File(tempDir, "plain.txt");
+		File encrypted = new File(tempDir, "plain.enc");
+		File back = new File(tempDir, "back.txt");
+		byte[] original = "the contents of a file\nwith two lines\n"
+			.getBytes(StandardCharsets.UTF_8);
+		Files.write(plain.toPath(), original);
+
+		assertEquals(0, run("encrypt", "-i", plain.getPath(), "-o", encrypted.getPath(), "-p",
+			"a good passphrase"));
+		assertTrue(PassphraseCryptor.isEncrypted(Files.readAllBytes(encrypted.toPath())),
+			"the written file must carry the format marker");
+		assertFalse(new String(Files.readAllBytes(encrypted.toPath()), StandardCharsets.UTF_8)
+			.contains("with two lines"), "the plaintext must not survive in the output");
+
+		assertEquals(0, run("decrypt", "-i", encrypted.getPath(), "-o", back.getPath(), "-p",
+			"a good passphrase"));
+		assertArrayEquals(original, Files.readAllBytes(back.toPath()));
+	}
+
+	@Test
+	void textIsPrintedAsBase64AndComesBackAsTheSameText()
+	{
+		assertEquals(0, run("encrypt", "--text", "hello over the wire", "-p", "pass"));
+		String base64 = out.trim();
+		assertTrue(PassphraseCryptor.isEncrypted(Base64.getDecoder().decode(base64)),
+			"the printed text must be the base64 of an encrypted blob, but was: '" + base64 + "'");
+
+		assertEquals(0, run("decrypt", "--text", base64, "-p", "pass"));
+		assertEquals("hello over the wire", out.trim());
+	}
+
+	@Test
+	void theTextAndThePassphraseCanBothComeThroughStandardInput()
+	{
+		assertEquals(0, runWithStdin("from stdin\n", "encrypt", "--text-stdin", "-p", "pass"));
+		String base64 = out.trim();
+
+		assertEquals(0, runWithStdin("pass\n", "decrypt", "--text", base64, "--passphrase-stdin"));
+		assertEquals("from stdin", out.trim());
+	}
+
+	@Test
+	void aWrongPassphraseIsTheNegativeAnswerAndExitsWithOne(@TempDir File tempDir)
+		throws IOException
+	{
+		File plain = new File(tempDir, "plain.txt");
+		File encrypted = new File(tempDir, "plain.enc");
+		Files.writeString(plain.toPath(), "secret");
+		assertEquals(0,
+			run("encrypt", "-i", plain.getPath(), "-o", encrypted.getPath(), "-p", "right"));
+
+		int exitCode = run("decrypt", "-i", encrypted.getPath(), "-p", "wrong");
+
+		assertEquals(1, exitCode,
+			"a wrong passphrase is the negative answer, not a tool error, but exit code was "
+				+ exitCode + " and stderr was: '" + err + "'");
+		assertFalse(out.contains("secret"), "nothing of the plaintext may be printed");
+		assertFalse(err.isBlank(), "the failure must be explained on stderr");
+	}
+
+	@Test
+	void alteredCiphertextIsRejectedRatherThanDecryptedIntoRubbish(@TempDir File tempDir)
+		throws IOException
+	{
+		File plain = new File(tempDir, "plain.txt");
+		File encrypted = new File(tempDir, "plain.enc");
+		Files.writeString(plain.toPath(), "do not tamper");
+		assertEquals(0,
+			run("encrypt", "-i", plain.getPath(), "-o", encrypted.getPath(), "-p", "pass"));
+
+		byte[] tampered = Files.readAllBytes(encrypted.toPath());
+		tampered[tampered.length - 1] ^= 0x01;
+		Files.write(encrypted.toPath(), tampered);
+
+		assertEquals(1, run("decrypt", "-i", encrypted.getPath(), "-p", "pass"));
+	}
+
+	@Test
+	void aFileThatIsNotEncryptedAtAllIsAToolErrorNotANegativeAnswer(@TempDir File tempDir)
+		throws IOException
+	{
+		File plain = new File(tempDir, "not-encrypted.txt");
+		Files.writeString(plain.toPath(), "just a text file");
+
+		int exitCode = run("decrypt", "-i", plain.getPath(), "-p", "pass");
+
+		assertEquals(2, exitCode,
+			"an input of the wrong kind is an error, stderr was: '" + err + "'");
+		assertTrue(err.contains("marker"),
+			"the message must say what was expected, but was: '" + err + "'");
+	}
+
+	@Test
+	void bothStandardInputOptionsTogetherAreRefusedWithAnExplanation()
+	{
+		int exitCode = runWithStdin("something\n", "encrypt", "--text-stdin", "--passphrase-stdin");
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("--text-stdin") && err.contains("--passphrase-stdin"),
+			"the message must name both options, but was: '" + err + "'");
+	}
+
+	@Test
+	void encryptingTheSameFileTwiceProducesDifferentOutput(@TempDir File tempDir) throws IOException
+	{
+		File plain = new File(tempDir, "plain.txt");
+		File first = new File(tempDir, "first.enc");
+		File second = new File(tempDir, "second.enc");
+		Files.writeString(plain.toPath(), "same input");
+
+		assertEquals(0, run("encrypt", "-i", plain.getPath(), "-o", first.getPath(), "-p", "pass"));
+		assertEquals(0,
+			run("encrypt", "-i", plain.getPath(), "-o", second.getPath(), "-p", "pass"));
+
+		assertNotEquals(Base64.getEncoder().encodeToString(Files.readAllBytes(first.toPath())),
+			Base64.getEncoder().encodeToString(Files.readAllBytes(second.toPath())),
+			"a fresh salt and nonce per run must make the two outputs differ");
+	}
+
+	@Test
+	void aMissingPassphraseSaysWhichOptionsProvideIt()
+	{
+		assertEquals(2, run("encrypt", "--text", "no passphrase given"));
+		assertTrue(err.contains("--passphrase"),
+			"the message must name the option, but was: '" + err + "'");
+	}
+
+	@Test
+	void textToDecryptThatIsNotBase64SaysSoRatherThanFailingOnTheFormatCheck()
+	{
+		int exitCode = run("decrypt", "--text", "this is certainly not base64 ***", "-p", "pass");
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("base64"),
+			"the message must name what the text was expected to be, but was: '" + err + "'");
+	}
+
+	@Test
+	void decryptAlsoRefusesTwoReadersOfStandardInput()
+	{
+		int exitCode = runWithStdin("something\n", "decrypt", "--text-stdin", "--passphrase-stdin");
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("--text-stdin"),
+			"the message must name the options, but was: '" + err + "'");
+	}
+
+	@Test
+	void bothCommandsAnswerTheirOwnHelp()
+	{
+		assertEquals(0, run("encrypt", "--help"));
+		assertTrue(out.contains("--passphrase-stdin"));
+		assertEquals(0, run("decrypt", "--help"));
+		assertTrue(out.contains("--passphrase-stdin"));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommandTest.java
@@ -1,0 +1,289 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.key.KeyExchangeSupport;
+
+/**
+ * Unit tests for the {@code keyx} subcommands, driven through the real command line as three
+ * separate runs against real files, the way two people would use it.
+ */
+class KeyExchangeCommandTest extends AbstractCliTest
+{
+
+	private static final Pattern FINGERPRINT = Pattern
+		.compile("shared secret fingerprint: ([0-9a-f]{8})");
+
+	private static String fingerprintIn(String output)
+	{
+		Matcher matcher = FINGERPRINT.matcher(output);
+		assertTrue(matcher.find(), "no fingerprint was printed in: '" + output + "'");
+		return matcher.group(1);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024", "X25519",
+			"Hybrid X25519 + ML-KEM-768" })
+	void bothSidesArriveAtTheSameSecretInThreeSeparateRuns(String algorithm, @TempDir File tempDir)
+		throws IOException
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+
+		assertEquals(0, run("keyx", "new", "-a", algorithm, "-k", privateKey.getPath(), "-p",
+			publicKey.getPath()), "stderr was: '" + err + "'");
+		assertTrue(Files.readString(publicKey.toPath()).startsWith(KeyExchangeSupport.PREFIX),
+			"the public half must be an envelope of this tool");
+
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath()),
+			"stderr was: '" + err + "'");
+		String senderFingerprint = fingerprintIn(out);
+
+		assertEquals(0,
+			run("keyx", "receive", "-k", privateKey.getPath(), "-s", handshake.getPath()),
+			"stderr was: '" + err + "'");
+		String recipientFingerprint = fingerprintIn(out);
+
+		assertEquals(senderFingerprint, recipientFingerprint,
+			"both sides must derive the same secret for " + algorithm);
+		assertTrue(out.contains("algorithm: " + algorithm),
+			"the run must name the algorithm it used, but was: '" + out + "'");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ML-KEM-768", "X25519", "Hybrid X25519 + ML-KEM-768" })
+	void aMessageEncryptedWithTheSecretIsReadableOnTheOtherSide(String algorithm,
+		@TempDir File tempDir)
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+		File encrypted = new File(tempDir, "message.enc");
+
+		assertEquals(0, run("keyx", "new", "-a", algorithm, "-k", privateKey.getPath(), "-p",
+			publicKey.getPath()));
+		assertEquals(0,
+			run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath(), "-m",
+				"meet me at the usual place", "-e", encrypted.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertEquals(0, run("keyx", "receive", "-k", privateKey.getPath(), "-s",
+			handshake.getPath(), "-e", encrypted.getPath()), "stderr was: '" + err + "'");
+		assertTrue(out.contains("message: meet me at the usual place"),
+			"the message must come back readable, but the output was: '" + out + "'");
+	}
+
+	@Test
+	void theHandshakeAndThePublicKeyAreNotTheSecret(@TempDir File tempDir) throws IOException
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+
+		assertEquals(0, run("keyx", "new", "-k", privateKey.getPath(), "-p", publicKey.getPath()));
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath()));
+		String fingerprint = fingerprintIn(out);
+
+		assertFalse(Files.readString(publicKey.toPath()).contains(fingerprint),
+			"the public key must not carry the secret's fingerprint");
+		assertFalse(Files.readString(handshake.toPath()).contains(fingerprint),
+			"the handshake must not carry the secret's fingerprint");
+	}
+
+	@Test
+	void theStoredPrivateKeyIsRecognisedAsTheSecretHalf(@TempDir File tempDir) throws IOException
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		assertEquals(0, run("keyx", "new", "-k", privateKey.getPath()));
+
+		assertTrue(out.contains("hand out only the public one"),
+			"the run must say which file is the secret, but was: '" + out + "'");
+		assertTrue(Files.readString(privateKey.toPath()).contains("$PRV$"),
+			"the stored key must be marked as the private half");
+		assertTrue(out.contains(KeyExchangeSupport.PREFIX),
+			"without -p the public half is printed, but the output was: '" + out + "'");
+	}
+
+	/**
+	 * The defect this pins: a public key has fewer parts than a private one, so a length check
+	 * before the kind check reports "this is not a key of this tool" about a perfectly good public
+	 * key and sends the user looking in the wrong place.
+	 */
+	@Test
+	void handingThePublicHalfWhereThePrivateOneBelongsSaysExactlyThat(@TempDir File tempDir)
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+		assertEquals(0, run("keyx", "new", "-k", privateKey.getPath(), "-p", publicKey.getPath()));
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath()));
+
+		int exitCode = run("keyx", "receive", "-k", publicKey.getPath(), "-s", handshake.getPath());
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("public half"),
+			"the message must name what was handed in, but was: '" + err + "'");
+		assertFalse(err.contains("not a stored key of this tool"),
+			"a good public key must not be called unrecognisable, but was: '" + err + "'");
+	}
+
+	@Test
+	void aHandshakeOfAnotherAlgorithmIsRefusedByName(@TempDir File tempDir)
+	{
+		File mlKemKey = new File(tempDir, "mlkem.key");
+		File x25519Key = new File(tempDir, "x25519.key");
+		File x25519Public = new File(tempDir, "x25519.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+
+		assertEquals(0, run("keyx", "new", "-a", "ML-KEM-768", "-k", mlKemKey.getPath()));
+		assertEquals(0, run("keyx", "new", "-a", "X25519", "-k", x25519Key.getPath(), "-p",
+			x25519Public.getPath()));
+		assertEquals(0,
+			run("keyx", "send", "-r", x25519Public.getPath(), "-o", handshake.getPath()));
+
+		int exitCode = run("keyx", "receive", "-k", mlKemKey.getPath(), "-s", handshake.getPath());
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("this handshake is for X25519"),
+			"the message must name both sides, but was: '" + err + "'");
+	}
+
+	@Test
+	void theWrongPrivateKeyDoesNotProduceTheSendersSecret(@TempDir File tempDir)
+	{
+		File rightKey = new File(tempDir, "right.key");
+		File rightPublic = new File(tempDir, "right.pub");
+		File wrongKey = new File(tempDir, "wrong.key");
+		File handshake = new File(tempDir, "handshake.txt");
+		File encrypted = new File(tempDir, "message.enc");
+
+		assertEquals(0, run("keyx", "new", "-k", rightKey.getPath(), "-p", rightPublic.getPath()));
+		assertEquals(0, run("keyx", "new", "-k", wrongKey.getPath()));
+		assertEquals(0, run("keyx", "send", "-r", rightPublic.getPath(), "-o", handshake.getPath(),
+			"-m", "for the right recipient", "-e", encrypted.getPath()));
+		String senderFingerprint = fingerprintIn(out);
+
+		int exitCode = run("keyx", "receive", "-k", wrongKey.getPath(), "-s", handshake.getPath(),
+			"-e", encrypted.getPath());
+
+		// ML-KEM decapsulates to *some* secret with any well formed private key, so the check that
+		// matters is that it is not the sender's and the message stays unreadable
+		assertFalse(out.contains("for the right recipient"),
+			"the message must not be readable with the wrong key, but the output was: '" + out
+				+ "'");
+		if (exitCode == 0)
+		{
+			assertFalse(out.contains(senderFingerprint),
+				"a different key must not arrive at the sender's secret");
+		}
+	}
+
+	@Test
+	void aFileThatIsNotFromThisToolIsNamedAsSuch(@TempDir File tempDir) throws IOException
+	{
+		File foreign = new File(tempDir, "foreign.txt");
+		Files.writeString(foreign.toPath(), "just some text", StandardCharsets.UTF_8);
+
+		assertEquals(2, run("keyx", "send", "-r", foreign.getPath()));
+		assertTrue(err.contains("is not from this tool"), "stderr was: '" + err + "'");
+
+		assertEquals(2, run("keyx", "receive", "-k", foreign.getPath(), "-s", foreign.getPath()));
+		assertTrue(err.contains("not a stored key of this tool"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void anUnknownAlgorithmListsTheOnesThatExist(@TempDir File tempDir)
+	{
+		File key = new File(tempDir, "unused.key");
+
+		assertEquals(2, run("keyx", "new", "-a", "ML-KEM-2048", "-k", key.getPath()));
+		assertTrue(err.contains("is not one of") && err.contains("ML-KEM-768"),
+			"the message must list the algorithms, but was: '" + err + "'");
+	}
+
+	@Test
+	void anEmptyHandshakeFileSaysThereIsNothingToRead(@TempDir File tempDir) throws IOException
+	{
+		File key = new File(tempDir, "recipient.key");
+		File empty = new File(tempDir, "empty.txt");
+		assertEquals(0, run("keyx", "new", "-k", key.getPath()));
+		Files.writeString(empty.toPath(), "   ", StandardCharsets.UTF_8);
+
+		assertEquals(2, run("keyx", "receive", "-k", key.getPath(), "-s", empty.getPath()));
+		assertTrue(err.contains("nothing to read"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void everyKeyxCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("keyx", "--help"));
+		assertTrue(out.contains("new") && out.contains("send") && out.contains("receive"));
+		assertEquals(0, run("keyx", "new", "--help"));
+		assertTrue(out.contains("--algorithm"));
+		assertEquals(0, run("keyx", "send", "--help"));
+		assertTrue(out.contains("--recipient"));
+		assertEquals(0, run("keyx", "receive", "--help"));
+		assertTrue(out.contains("--handshake"));
+	}
+
+	@Test
+	void theBareKeyxCommandPrintsItsUsage()
+	{
+		assertEquals(0, run("keyx"));
+		assertTrue(out.contains("send"), "stdout was: '" + out + "'");
+	}
+
+	@Test
+	void theFingerprintIsShortEnoughToReadOutAndNotTheSecretItself(@TempDir File tempDir)
+		throws Exception
+	{
+		File key = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		assertEquals(0, run("keyx", "new", "-k", key.getPath(), "-p", publicKey.getPath()));
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath()));
+
+		String fingerprint = fingerprintIn(out);
+		assertEquals(8, fingerprint.length(), "eight hex characters can be read out loud");
+		assertNotNull(fingerprint);
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenDetailsCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenDetailsCommandTest.java
@@ -1,0 +1,201 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.security.interfaces.ECPrivateKey;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.key.KeyFileReader;
+import io.github.astrapi69.mystic.crypt.key.KeyFileWriter;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for what {@code keygen} gained: naming the curve, choosing the private key encoding,
+ * and saying what it actually made.
+ */
+class KeygenDetailsCommandTest extends AbstractCliTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "secp256r1, 256", "secp384r1, 384", "secp521r1, 521" })
+	void generatesAnEcKeyOnTheNamedCurveAndSaysWhichOne(String curve, int fieldSize,
+		@TempDir File tempDir) throws Exception
+	{
+		File privateKey = new File(tempDir, "ec.pem");
+		File publicKey = new File(tempDir, "ec-public.pem");
+
+		assertEquals(0,
+			run("keygen", "-a", "EC", "--curve", curve, "--print-details", "--out-private",
+				privateKey.getPath(), "--out-public", publicKey.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("curve: " + curve),
+			"the run must name the curve, but was: '" + out + "'");
+		assertTrue(out.contains("field size: " + fieldSize + " bits"),
+			"the run must name the field size, but was: '" + out + "'");
+
+		ECPrivateKey generated = (ECPrivateKey)KeyFileReader.readPrivateKey(privateKey, "EC");
+		assertEquals(fieldSize, generated.getParams().getCurve().getField().getFieldSize(),
+			"the key on disk must really be on that curve");
+	}
+
+	/**
+	 * The honest check that the PKCS#8 fix landed: what --format asks for is what the PEM label
+	 * says, and the key still reads back as the same key.
+	 */
+	@ParameterizedTest
+	@CsvSource({ "pkcs8, PRIVATE KEY", "pkcs1, RSA PRIVATE KEY" })
+	void theFormatAskedForIsTheFormatWritten(String format, String expectedLabel,
+		@TempDir File tempDir) throws Exception
+	{
+		File privateKey = new File(tempDir, "rsa.pem");
+
+		assertEquals(0, run("keygen", "-a", "RSA", "-s", "2048", "--format", format,
+			"--print-details", "--out-private", privateKey.getPath()), "stderr was: '" + err + "'");
+
+		assertTrue(
+			Files.readString(privateKey.toPath()).contains("-----BEGIN " + expectedLabel + "-----"),
+			"the file must carry the " + expectedLabel + " header");
+		assertTrue(out.contains("PEM label: " + expectedLabel),
+			"the details must name the label actually written, but was: '" + out + "'");
+		assertArrayEquals(KeyFileReader.readPrivateKey(privateKey, "RSA").getEncoded(),
+			KeyFileReader.readPrivateKey(privateKey, "RSA").getEncoded());
+	}
+
+	@Test
+	void theDefaultFormatIsPkcs8(@TempDir File tempDir) throws Exception
+	{
+		File privateKey = new File(tempDir, "rsa.pem");
+
+		assertEquals(0,
+			run("keygen", "-a", "RSA", "-s", "2048", "--out-private", privateKey.getPath()));
+
+		assertTrue(Files.readString(privateKey.toPath())
+			.contains("-----BEGIN " + KeyFileWriter.PKCS8_LABEL + "-----"));
+	}
+
+	@Test
+	void printDetailsNamesTheSizeOfAnRsaKey(@TempDir File tempDir) throws Exception
+	{
+		assertEquals(0,
+			run("keygen", "-a", "RSA", "-s", "3072", "--print-details", "--out-private",
+				new File(tempDir, "k.pem").getPath(), "--out-public",
+				new File(tempDir, "p.pem").getPath()));
+
+		assertTrue(out.contains("algorithm: RSA") && out.contains("size: 3072 bits"),
+			"stdout was: '" + out + "'");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "X25519", "ML-KEM-768", "ML-DSA-65" })
+	void aFixedParameterAlgorithmIsNamedAsSuch(String algorithm, @TempDir File tempDir)
+	{
+		assertEquals(0,
+			run("keygen", "-a", algorithm, "--print-details", "--out-private",
+				new File(tempDir, "k.pem").getPath(), "--out-public",
+				new File(tempDir, "p.pem").getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("fixed parameter set"),
+			"an algorithm with no size or curve must say so, but was: '" + out + "'");
+	}
+
+	@Test
+	void anUnknownCurveNamesSomeThatExist(@TempDir File tempDir)
+	{
+		assertEquals(2, run("keygen", "-a", "EC", "--curve", "secp999r9", "--out-private",
+			new File(tempDir, "k.pem").getPath()));
+
+		assertTrue(err.contains("unknown curve") && err.contains("secp256r1"),
+			"the message must offer a curve that works, but was: '" + err + "'");
+	}
+
+	@Test
+	void anUnknownAlgorithmIsAnErrorNotACrash(@TempDir File tempDir)
+	{
+		assertEquals(2,
+			run("keygen", "-a", "NOPE", "--out-private", new File(tempDir, "k.pem").getPath()));
+
+		assertTrue(err.contains("unknown key algorithm"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void anEcKeyAskedForPkcs1KeepsThePkcs8LabelAndSaysSo(@TempDir File tempDir) throws Exception
+	{
+		File privateKey = new File(tempDir, "ec.pem");
+
+		assertEquals(0,
+			run("keygen", "-a", "EC", "--curve", "secp256r1", "--format", "pkcs1",
+				"--print-details", "--out-private", privateKey.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("PEM label: " + KeyFileWriter.PKCS8_LABEL),
+			"only RSA has a traditional label of its own, but the details said: '" + out + "'");
+	}
+
+	/**
+	 * An EC key generated without naming a curve still has a field size, but no name to report, so
+	 * the details say so rather than printing an empty curve.
+	 */
+	@Test
+	void anEcKeyGeneratedWithoutACurveIsReportedAsUnnamed(@TempDir File tempDir)
+	{
+		assertEquals(0,
+			run("keygen", "-a", "EC", "--print-details", "--out-private",
+				new File(tempDir, "k.pem").getPath(), "--out-public",
+				new File(tempDir, "p.pem").getPath()),
+			"stderr was: '" + err + "'");
+
+		assertTrue(out.contains("curve: unnamed") && out.contains("field size:"),
+			"stdout was: '" + out + "'");
+	}
+
+	@Test
+	void theCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("keygen", "--help"));
+		assertTrue(
+			out.contains("--curve") && out.contains("--format") && out.contains("--print-details"),
+			"stdout was: '" + out + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the operated obfuscation rules {@code obfuscate} and {@code disentangle} gained: a
+ * rule that carries an operation and the positions it applies at, next to the plain substitution.
+ */
+class OperatedObfuscationCommandTest extends AbstractCliTest
+{
+
+	private String obfuscate(String text, String... rules)
+	{
+		String[] args = new String[3 + 2 * rules.length];
+		args[0] = "obfuscate";
+		args[1] = "--text";
+		args[2] = text;
+		for (int i = 0; i < rules.length; i++)
+		{
+			args[3 + 2 * i] = "--rule";
+			args[4 + 2 * i] = rules[i];
+		}
+		assertEquals(0, run(args), "obfuscating failed, stderr was: '" + err + "'");
+		return out.strip();
+	}
+
+	private String disentangle(String text, String... rules)
+	{
+		String[] args = new String[3 + 2 * rules.length];
+		args[0] = "disentangle";
+		args[1] = "--text";
+		args[2] = text;
+		for (int i = 0; i < rules.length; i++)
+		{
+			args[3 + 2 * i] = "--rule";
+			args[4 + 2 * i] = rules[i];
+		}
+		assertEquals(0, run(args), "disentangling failed, stderr was: '" + err + "'");
+		return out.strip();
+	}
+
+	/**
+	 * At a named position the operated character is written, everywhere else the plain replacement.
+	 * The round trip has to give back exactly what went in.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "aba", "banana", "aaa", "abcabc", "nothing to replace", "" })
+	void anOperatedRuleSurvivesTheRoundTrip(String text)
+	{
+		String[] rules = { "a=x:UPPERCASE@0,3", "b=y:LOWERCASE@1", "c=z" };
+
+		String obfuscated = obfuscate(text, rules);
+
+		assertEquals(text, disentangle(obfuscated, rules),
+			"'" + text + "' became '" + obfuscated + "' and must come back unchanged");
+	}
+
+	@Test
+	void theOperatedCharacterStandsAtTheNamedPositionAndTheReplacementElsewhere()
+	{
+		assertEquals("Ayx", obfuscate("aba", "a=x:UPPERCASE@0", "b=y"),
+			"position 0 carries the uppercase A, position 2 the plain replacement x");
+	}
+
+	/**
+	 * NONE is not "no rule": at a named position it writes the character unchanged, which is what
+	 * operating with NONE produces, while everywhere else the plain replacement still applies.
+	 */
+	@ParameterizedTest
+	@CsvSource({ "UPPERCASE, aa, Ax", "LOWERCASE, AA, aX", "NONE, aa, ax" })
+	void eachOperationWritesItsOwnCharacterAtThePosition(String operation, String input,
+		String expected)
+	{
+		assertEquals(expected,
+			obfuscate(input, "a=x:" + operation + "@0", "A=X:" + operation + "@0"),
+			operation + " on '" + input + "'");
+	}
+
+	@Test
+	void aPlainRuleStandingNextToAnOperatedOneStillSubstitutesEverywhere()
+	{
+		assertEquals("Ayz", obfuscate("abc", "a=x:UPPERCASE@0", "b=y", "c=z"));
+		assertEquals("abc", disentangle("Ayz", "a=x:UPPERCASE@0", "b=y", "c=z"));
+	}
+
+	@Test
+	void theplainFormIsUnchangedByTheOperatedOneExisting()
+	{
+		assertEquals("xyc", obfuscate("abc", "a=x", "b=y"));
+		assertEquals("abc", disentangle("xyc", "a=x", "b=y"));
+	}
+
+	@Test
+	void anOperatedRuleDiffersFromThePlainOneItWouldOtherwiseBe()
+	{
+		assertNotEquals(obfuscate("aba", "a=x", "b=y"), obfuscate("aba", "a=x:UPPERCASE@0", "b=y"),
+			"the operation must make a difference at the named position");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "a=x:NOPE", "a=x:UPPERCASE@notanumber", "a=x:UPPERCASE@-1",
+			"a=xy:UPPERCASE@0", "a=xy" })
+	void aMalformedRuleIsRefusedWithTheReason(String rule)
+	{
+		int exitCode = run("obfuscate", "--text", "abc", "--rule", rule);
+
+		assertEquals(2, exitCode, "'" + rule + "' must be refused, stderr was: '" + err + "'");
+		assertTrue(err.contains("error"), "the failure must be explained for '" + rule + "'");
+	}
+
+	@Test
+	void anUnknownOperationListsTheOnesThatExist()
+	{
+		assertEquals(2, run("obfuscate", "--text", "abc", "--rule", "a=x:ROT13"));
+
+		assertTrue(err.contains("UPPERCASE") && err.contains("NEGATE"),
+			"the message must list the operations, but was: '" + err + "'");
+	}
+
+	@Test
+	void bothCommandsExplainTheOperatedShapeInTheirHelp()
+	{
+		assertEquals(0, run("obfuscate", "--help"));
+		assertTrue(out.contains("UPPERCASE"),
+			"the help must show the operated shape, but was: '" + out + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
@@ -1,0 +1,274 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.github.astrapi69.mystic.crypt.secret.SecretShare;
+
+/**
+ * Unit tests for the {@code share split} and {@code share combine} subcommands, driven through the
+ * real command line.
+ */
+class ShareCommandTest extends AbstractCliTest
+{
+
+	private static final String SECRET = "a secret long enough to be split";
+
+	private List<String> splitLines(int threshold, int shares)
+	{
+		assertEquals(0, run("share", "split", "--secret", SECRET, "-t", String.valueOf(threshold),
+			"-n", String.valueOf(shares)));
+		return out.lines().filter(line -> !line.isBlank()).toList();
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "2,2", "2,3", "3,5", "5,5" })
+	void anyThresholdManySharesReconstructTheSecret(int threshold, int shares)
+	{
+		List<String> lines = splitLines(threshold, shares);
+		assertEquals(shares, lines.size(), "split must print one line per share");
+
+		String[] args = new String[1 + 2 * threshold];
+		args[0] = "combine";
+		for (int i = 0; i < threshold; i++)
+		{
+			args[1 + 2 * i] = "--share";
+			args[2 + 2 * i] = lines.get(i);
+		}
+		String[] full = new String[args.length + 1];
+		full[0] = "share";
+		System.arraycopy(args, 0, full, 1, args.length);
+
+		assertEquals(0, run(full), "stderr was: '" + err + "'");
+		assertEquals(SECRET, out.trim());
+	}
+
+	@Test
+	void fewerSharesThanTheThresholdSayeSoInsteadOfRebuildingNonsense()
+	{
+		List<String> lines = splitLines(3, 5);
+
+		int exitCode = run("share", "combine", "--share", lines.get(0), "--share", lines.get(1));
+
+		assertEquals(1, exitCode, "stderr was: '" + err + "'");
+		assertTrue(err.contains("needs 3 shares"),
+			"the message must say how many are needed, but was: '" + err + "'");
+		assertEquals("", out.trim(), "no secret, right or wrong, may be printed");
+	}
+
+	@Test
+	void sharesOfTwoDifferentSplitsAreRefusedRatherThanMixed()
+	{
+		List<String> firstSplit = splitLines(2, 3);
+		List<String> secondSplit = splitLines(2, 3);
+		assertNotEquals(SecretShare.decode(firstSplit.get(0)).getSplitId(),
+			SecretShare.decode(secondSplit.get(0)).getSplitId(),
+			"two splits must not share an identifier");
+
+		int exitCode = run("share", "combine", "--share", firstSplit.get(0), "--share",
+			secondSplit.get(1));
+
+		assertEquals(1, exitCode);
+		assertTrue(err.contains("different splits"),
+			"the message must name the problem, but was: '" + err + "'");
+	}
+
+	@Test
+	void theSameShareTwiceDoesNotCountTwice()
+	{
+		List<String> lines = splitLines(2, 3);
+
+		int exitCode = run("share", "combine", "--share", lines.get(0), "--share", lines.get(0));
+
+		assertEquals(1, exitCode);
+		assertTrue(err.contains("more than once"),
+			"the message must name the problem, but was: '" + err + "'");
+	}
+
+	@Test
+	void aShareAlteredWhileBeingCopiedIsCaughtByItsOwnChecksum()
+	{
+		List<String> lines = splitLines(2, 3);
+		String share = lines.get(0);
+		// Change a character in the MIDDLE of the value field, as a typo while copying would.
+		// Not the last one: in unpadded base64 only some bits of the final character are
+		// significant, so 'A' and 'B' there can decode to identical bytes and the checksum, which
+		// covers the decoded value, would legitimately still match. That is the same trap that
+		// once made Argon2SupportTest flaky.
+		int valueStart = share
+			.indexOf(':',
+				share.indexOf(':',
+					share.indexOf(':', share.indexOf(':', share.indexOf(':') + 1) + 1) + 1) + 1)
+			+ 1;
+		int lastColon = share.lastIndexOf(':');
+		int middle = valueStart + (lastColon - valueStart) / 2;
+		char[] characters = share.toCharArray();
+		characters[middle] = characters[middle] == 'A' ? 'B' : 'A';
+		String mistyped = new String(characters);
+
+		int exitCode = run("share", "combine", "--share", mistyped, "--share", lines.get(1));
+
+		assertEquals(2, exitCode, "stderr was: '" + err + "'");
+		assertTrue(err.contains("checksum"),
+			"the message must point at the share itself, but was: '" + err + "'");
+	}
+
+	@Test
+	void aLineThatIsNotAShareAtAllIsNamedAsSuch()
+	{
+		int exitCode = run("share", "combine", "--share", "just some text");
+
+		assertEquals(2, exitCode);
+		assertTrue(err.contains("not a mystic-crypt share"),
+			"the message must say what a share looks like, but was: '" + err + "'");
+	}
+
+	@Test
+	void sharesRoundTripThroughFiles(@TempDir File tempDir) throws IOException
+	{
+		File secretFile = new File(tempDir, "secret.bin");
+		File sharesFile = new File(tempDir, "shares.txt");
+		File recovered = new File(tempDir, "recovered.bin");
+		byte[] secret = "file contents to be shared out".getBytes(StandardCharsets.UTF_8);
+		Files.write(secretFile.toPath(), secret);
+
+		assertEquals(0, run("share", "split", "--file", secretFile.getPath(), "-t", "2", "-n", "3",
+			"-o", sharesFile.getPath()));
+		assertTrue(out.contains("any 2 of them"),
+			"the confirmation must state the threshold, but was: '" + out + "'");
+
+		// keep only two of the three lines, the situation combine exists for
+		List<String> all = Files.readAllLines(sharesFile.toPath());
+		Files.write(sharesFile.toPath(), List.of(all.get(0), all.get(2)));
+
+		assertEquals(0,
+			run("share", "combine", "--file", sharesFile.getPath(), "-o", recovered.getPath()),
+			"stderr was: '" + err + "'");
+		assertArrayEquals(secret, Files.readAllBytes(recovered.toPath()));
+	}
+
+	@Test
+	void theSecretCanComeThroughStandardInput()
+	{
+		assertEquals(0, runWithStdin("secret from standard input\n", "share", "split",
+			"--secret-stdin", "-t", "2", "-n", "2"));
+		List<String> lines = out.lines().filter(line -> !line.isBlank()).toList();
+
+		assertEquals(0, run("share", "combine", "--share", lines.get(0), "--share", lines.get(1)));
+		assertEquals("secret from standard input", out.trim());
+	}
+
+	@Test
+	void aThresholdOfOneIsRefusedBecauseItIsNotASplit()
+	{
+		assertEquals(2, run("share", "split", "--secret", SECRET, "-t", "1", "-n", "3"));
+		assertTrue(err.contains("at least 2"),
+			"the message must say what is wrong, but was: '" + err + "'");
+	}
+
+	@Test
+	void moreSharesThanTheSecretHasBytesIsRefusedWithTheLibraryReason()
+	{
+		assertEquals(2, run("share", "split", "--secret", "tiny", "-t", "2", "-n", "5"));
+		assertTrue(err.contains("secret length"),
+			"the message must explain the limit, but was: '" + err + "'");
+	}
+
+	@Test
+	void fewerSharesThanTheThresholdCannotEvenBeSplit()
+	{
+		assertEquals(2, run("share", "split", "--secret", SECRET, "-t", "4", "-n", "2"));
+		assertTrue(err.contains("at least the threshold"),
+			"the message must explain the relation, but was: '" + err + "'");
+	}
+
+	@Test
+	void missingInputIsNamedOnBothSides()
+	{
+		assertEquals(2, run("share", "split", "-t", "2", "-n", "3"));
+		assertTrue(err.contains("--secret"), "stderr was: '" + err + "'");
+
+		assertEquals(2, run("share", "combine"));
+		assertTrue(err.contains("--share"), "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void blankLinesInASharesFileAreIgnoredRatherThanParsed(@TempDir File tempDir) throws IOException
+	{
+		File sharesFile = new File(tempDir, "shares.txt");
+		List<String> lines = splitLines(2, 3);
+		Files.write(sharesFile.toPath(), List.of(lines.get(0), "", "   ", lines.get(1)));
+
+		assertEquals(0, run("share", "combine", "--file", sharesFile.getPath()),
+			"stderr was: '" + err + "'");
+		assertEquals(SECRET, out.trim());
+	}
+
+	@Test
+	void anOutputPathThatCannotBeWrittenIsReportedAsAnError(@TempDir File tempDir)
+	{
+		List<String> lines = splitLines(2, 2);
+
+		// a directory is not a file that can be written to, which is the plainest way to reach the
+		// write failure without depending on file permissions
+		int exitCode = run("share", "combine", "--share", lines.get(0), "--share", lines.get(1),
+			"-o", tempDir.getPath());
+
+		assertEquals(2, exitCode, "stderr was: '" + err + "'");
+	}
+
+	@Test
+	void everyShareCommandAnswersItsOwnHelp()
+	{
+		assertEquals(0, run("share", "--help"));
+		assertTrue(out.contains("split") && out.contains("combine"));
+		assertEquals(0, run("share", "split", "--help"));
+		assertTrue(out.contains("--threshold"));
+		assertEquals(0, run("share", "combine", "--help"));
+		assertTrue(out.contains("--share"));
+	}
+
+	@Test
+	void theBareShareCommandPrintsItsUsage()
+	{
+		assertEquals(0, run("share"));
+		assertTrue(out.contains("split"), "stdout was: '" + out + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignCommandTest.java
@@ -163,7 +163,7 @@ class SignCommandTest extends AbstractCliTest
 
 	/** Algorithms that exist but cannot sign - and unknown names - are rejected clearly. */
 	@ParameterizedTest
-	@ValueSource(strings = { "RSA", "EC", "X25519", "ML-KEM-768" })
+	@ValueSource(strings = { "X25519", "X448", "ML-KEM-768" })
 	void nonSignatureAlgorithmsAreRejected(String algorithm, @TempDir File tempDir) throws Exception
 	{
 		File dataFile = new File(tempDir, "data.txt");

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupportTest.java
@@ -76,10 +76,13 @@ class SignatureSupportTest
 		assertEquals(expected, SignatureSupport.keyFactoryAlgorithm(input));
 	}
 
-	/** Algorithms that exist but cannot sign are rejected with a clear message. */
+	/**
+	 * Algorithms that exist but cannot sign are rejected with a clear message. RSA, EC and DSA used
+	 * to be on this list and no longer are: they sign, through Bouncy Castle. What is left here are
+	 * the key-exchange algorithms, which have no signature operation at all.
+	 */
 	@ParameterizedTest
-	@ValueSource(strings = { "RSA", "EC", "DSA", "X25519", "X448", "ML-KEM-512", "ML-KEM-768",
-			"ML-KEM-1024" })
+	@ValueSource(strings = { "X25519", "X448", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024" })
 	void nonSignatureAlgorithmsAreRejected(String name)
 	{
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
@@ -87,6 +90,25 @@ class SignatureSupportTest
 		assertTrue(exception.getMessage().contains("is not a supported signature algorithm"),
 			"the message must say why '" + name + "' is rejected, but was: '"
 				+ exception.getMessage() + "'");
+	}
+
+	/**
+	 * A JCA-style name of a family this tool has no signer for is not a classical algorithm, so it
+	 * falls through to the post-quantum parser and is rejected there rather than being attempted.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "SHA256withFOO", "nothing at all", "with" })
+	void aWithNameOfAnUnknownFamilyIsNotClassical(String algorithm)
+	{
+		assertFalse(SignatureSupport.isClassical(algorithm));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "RSA", "ec", "ECDSA", "DSA", "SHA512withRSA", "SHA256withECDSA" })
+	void theClassicalFamiliesAreRecognisedByEitherName(String algorithm)
+	{
+		assertTrue(SignatureSupport.isClassical(algorithm),
+			algorithm + " must be recognised as a classical signature algorithm");
 	}
 
 	@Test

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/VerifyCommandTest.java
@@ -25,48 +25,106 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Unit tests for the {@code verify} subcommand: exit code 0 = matches, 1 = does not match.
+ * Unit tests for the {@code verify} subcommand: exit code 0 = matches, 1 = does not match, 2 = the
+ * hash belongs to no algorithm this tool knows.
+ * <p>
+ * {@code verify} takes no {@code --algorithm}: every encoding says what produced it, and reading it
+ * from the hash removes the way of getting it wrong.
  */
 class VerifyCommandTest extends AbstractCliTest
 {
 
 	private String hash(String algorithm, String password)
 	{
-		run("hash", "--algorithm", algorithm, "--password", password);
+		assertEquals(0, run("hash", "--algorithm", algorithm, "--password", password),
+			"hashing with " + algorithm + " failed, stderr was: '" + err + "'");
 		return out.strip();
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "argon2id", "pbkdf2" })
-	void correctPasswordVerifies(String algorithm)
+	@ValueSource(strings = { "argon2id", "pbkdf2", "bcrypt", "scrypt" })
+	void aCorrectPasswordVerifiesWithoutBeingToldTheAlgorithm(String algorithm)
 	{
 		String hash = hash(algorithm, "the-secret");
-		assertEquals(0,
-			run("verify", "--algorithm", algorithm, "--hash", hash, "--password", "the-secret"));
-		assertTrue(out.contains("matches"));
+
+		assertEquals(0, run("verify", "--hash", hash, "--password", "the-secret"),
+			"stderr was: '" + err + "'");
+		assertTrue(out.contains("matches"), "stdout was: '" + out + "'");
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "argon2id", "pbkdf2" })
-	void wrongPasswordDoesNotVerify(String algorithm)
+	@ValueSource(strings = { "argon2id", "pbkdf2", "bcrypt", "scrypt" })
+	void aWrongPasswordDoesNotVerify(String algorithm)
 	{
 		String hash = hash(algorithm, "the-secret");
-		assertEquals(1,
-			run("verify", "--algorithm", algorithm, "--hash", hash, "--password", "wrong"));
-		assertTrue(out.contains("does not match"));
+
+		assertEquals(1, run("verify", "--hash", hash, "--password", "wrong"));
+		assertTrue(out.contains("does not match"), "stdout was: '" + out + "'");
 	}
 
-	@org.junit.jupiter.api.Test
+	/**
+	 * The encoding each algorithm writes, which is what makes the detection possible. The bcrypt
+	 * revision here is {@code 2y}, which is what this library's hasher actually produces; hashes
+	 * written as {@code 2a} and {@code 2b} are the same construction and are recognised too.
+	 */
+	@ParameterizedTest
+	@CsvSource({ "argon2id, $argon2id$, ARGON2ID", "pbkdf2, $pbkdf2-sha256$, PBKDF2",
+			"bcrypt, $2y$, BCRYPT", "scrypt, $scrypt$, SCRYPT" })
+	void eachAlgorithmWritesItsOwnPrefixAndIsNamedBackOnVerifying(String algorithm, String prefix,
+		String reportedFormat)
+	{
+		String hash = hash(algorithm, "the-secret");
+		assertTrue(hash.startsWith(prefix),
+			algorithm + " must encode as " + prefix + ", but was: '" + hash + "'");
+
+		assertEquals(0, run("verify", "--hash", hash, "--password", "the-secret"));
+		assertTrue(out.contains(reportedFormat),
+			"the answer must name the algorithm it detected, but was: '" + out + "'");
+	}
+
+	@Test
+	void aHashOfNoKnownAlgorithmIsAnErrorNotAMismatch()
+	{
+		int exitCode = run("verify", "--hash", "not-a-hash-of-anything", "--password", "whatever");
+
+		assertEquals(2, exitCode,
+			"an unreadable hash is not the negative answer, stderr was: '" + err + "'");
+		assertTrue(err.contains("$argon2id$") && err.contains("$2a$"),
+			"the message must list the encodings it knows, but was: '" + err + "'");
+	}
+
+	@Test
+	void theAlgorithmOptionIsGoneSinceTheHashCarriesIt()
+	{
+		String hash = hash("pbkdf2", "the-secret");
+
+		assertNotEquals(0,
+			run("verify", "--algorithm", "pbkdf2", "--hash", hash, "--password", "the-secret"),
+			"--algorithm must no longer be accepted on verify");
+	}
+
+	@Test
 	void readsPasswordFromStdin()
 	{
 		String hash = hash("pbkdf2", "piped");
-		assertEquals(0, runWithStdin("piped\n", "verify", "--algorithm", "pbkdf2", "--hash", hash,
-			"--password-stdin"));
+
+		assertEquals(0, runWithStdin("piped\n", "verify", "--hash", hash, "--password-stdin"));
+	}
+
+	@Test
+	void twoHashesOfTheSamePasswordDifferBecauseOfTheSalt()
+	{
+		assertNotEquals(hash("scrypt", "same"), hash("scrypt", "same"),
+			"a fresh salt per hash must make two hashes of the same password differ");
+		assertNotEquals(hash("bcrypt", "same"), hash("bcrypt", "same"));
 	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
@@ -1,0 +1,196 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for the input handling of {@link KeyExchangeSupport}: the paths a person reaches by
+ * handing in the wrong file, which are exactly the ones that have to say what is wrong.
+ */
+class KeyExchangeSupportTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	@Test
+	void everyOfferedAlgorithmCanSetUpAPartyAndBeReadBackFromItsStoredForm() throws Exception
+	{
+		for (String algorithm : KeyExchangeSupport.algorithms())
+		{
+			KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(algorithm);
+
+			KeyExchangeSupport.Party restored = KeyExchangeSupport
+				.partyFrom(KeyExchangeSupport.privateKeyOf(party));
+
+			assertEquals(algorithm, restored.algorithm());
+			assertArrayEquals(party.first().getPublic().getEncoded(),
+				restored.first().getPublic().getEncoded(),
+				"the restored party must hold the same key as the stored one, for " + algorithm);
+			assertEquals(algorithm,
+				KeyExchangeSupport.algorithmOf(KeyExchangeSupport.publicKeyOf(party)));
+		}
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { "not from here", "MCKX1", "NOPE$PRV$X25519$AAAA$BBBB" })
+	void aStoredKeyThatIsNotOneIsNamedAsSuch(String text)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.partyFrom(text));
+
+		assertEquals("this is not a stored key of this tool", rejected.getMessage());
+	}
+
+	@Test
+	void aStoredPrivateKeyMissingItsHalvesIsCalledIncomplete()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.partyFrom("MCKX1$PRV$X25519$AAAA"));
+
+		assertEquals("this stored key is incomplete", rejected.getMessage());
+	}
+
+	@Test
+	void aStoredHybridKeyWithOnlyOneHalfSaysWhichHalfIsMissing()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport
+				.partyFrom("MCKX1$PRV$" + KeyExchangeSupport.HYBRID + "$AAAA$BBBB$CCCC"));
+
+		assertEquals("a stored hybrid key carries two halves and this one carries one",
+			rejected.getMessage());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { "nope", "MCKX1$PUB", "NOPE$PUB$X25519" })
+	void anEnvelopeWhoseAlgorithmCannotBeReadIsNamedAsNotFromThisTool(String envelope)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.algorithmOf(envelope));
+
+		assertTrue(rejected.getMessage().contains("is not from this tool"),
+			"the message was: '" + rejected.getMessage() + "'");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { "   " })
+	void nothingToReadIsSaidPlainly(String envelope)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.encapsulate(envelope));
+
+		assertEquals("there is nothing to read", rejected.getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "MCKX1$PUB$X25519", "NOPE$PUB$X25519$AAAA" })
+	void anEnvelopeTooShortOrWithAForeignPrefixIsNamedAsNotFromThisTool(String envelope)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.encapsulate(envelope));
+
+		assertTrue(rejected.getMessage().contains("is not from this tool"),
+			"the message was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aHandshakeWhereAPublicKeyBelongsIsNamedAsAHandshake()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.encapsulate("MCKX1$HS$X25519$AAAA"));
+
+		assertEquals("this is a handshake, and a public key was expected", rejected.getMessage());
+	}
+
+	@Test
+	void aPublicKeyWhereAHandshakeBelongsIsNamedAsAPublicKey() throws Exception
+	{
+		KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(KeyExchangeSupport.X25519);
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.decapsulate(party, "MCKX1$PUB$X25519$AAAA"));
+
+		assertEquals("this is a public key, and a handshake was expected", rejected.getMessage());
+	}
+
+	@Test
+	void aHybridEnvelopeCarryingOnlyOneHalfIsNamedByItsKind()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport
+				.encapsulate("MCKX1$PUB$" + KeyExchangeSupport.HYBRID + "$AAAA"));
+
+		assertEquals("a hybrid pub carries two halves and this one carries one",
+			rejected.getMessage());
+	}
+
+	@Test
+	void anUnknownAlgorithmListsTheOnesThatExist()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.newParty("ML-KEM-2048"));
+
+		assertTrue(
+			rejected.getMessage().contains("is not one of")
+				&& rejected.getMessage().contains(KeyExchangeSupport.ML_KEM_768),
+			"the message must list the algorithms, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aMessageEncryptedWithTheSharedSecretComesBackThroughIt() throws Exception
+	{
+		KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(KeyExchangeSupport.ML_KEM_768);
+		KeyExchangeSupport.Handshake handshake = KeyExchangeSupport
+			.encapsulate(KeyExchangeSupport.publicKeyOf(party));
+		byte[] message = "over the wire".getBytes(StandardCharsets.UTF_8);
+
+		String encrypted = KeyExchangeSupport.encryptMessage(handshake.sharedSecret(), message);
+
+		assertArrayEquals(message,
+			KeyExchangeSupport.decryptMessage(handshake.sharedSecret(), encrypted));
+		assertEquals(8, KeyExchangeSupport.fingerprintOf(handshake.sharedSecret()).length());
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyFileReaderTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyFileReaderTest.java
@@ -1,0 +1,282 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for {@link KeyFileReader}: the shapes a key file arrives in, and what it says about
+ * the ones it cannot read.
+ */
+class KeyFileReaderTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	private static KeyPair rsaKeyPair() throws Exception
+	{
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA",
+			BouncyCastleProvider.PROVIDER_NAME);
+		generator.initialize(2048);
+		return generator.generateKeyPair();
+	}
+
+	private static File armoured(File tempDir, String name, String label, byte[] encoded)
+		throws Exception
+	{
+		File file = new File(tempDir, name);
+		String base64 = Base64
+			.getMimeEncoder(64, System.lineSeparator().getBytes(StandardCharsets.US_ASCII))
+			.encodeToString(encoded);
+		Files.writeString(file.toPath(),
+			"-----BEGIN " + label + "-----" + System.lineSeparator() + base64
+				+ System.lineSeparator() + "-----END " + label + "-----" + System.lineSeparator(),
+			StandardCharsets.UTF_8);
+		return file;
+	}
+
+	@Test
+	void readsAPkcs8PrivateKeyPem(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		File pem = armoured(tempDir, "pkcs8.pem", "PRIVATE KEY", keyPair.getPrivate().getEncoded());
+
+		assertTrue(KeyFileReader.isPem(pem));
+		assertArrayEquals(keyPair.getPrivate().getEncoded(),
+			KeyFileReader.readPrivateKey(pem, "RSA").getEncoded());
+	}
+
+	@Test
+	void readsAPublicKeyPem(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		File pem = armoured(tempDir, "public.pem", "PUBLIC KEY", keyPair.getPublic().getEncoded());
+
+		assertArrayEquals(keyPair.getPublic().getEncoded(),
+			KeyFileReader.readPublicKey(pem, "RSA").getEncoded());
+	}
+
+	@Test
+	void readsBothHalvesFromDer(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		File privateDer = new File(tempDir, "private.der");
+		File publicDer = new File(tempDir, "public.der");
+		Files.write(privateDer.toPath(), keyPair.getPrivate().getEncoded());
+		Files.write(publicDer.toPath(), keyPair.getPublic().getEncoded());
+
+		assertFalse(KeyFileReader.isPem(privateDer), "a DER file carries no armour");
+		assertArrayEquals(keyPair.getPrivate().getEncoded(),
+			KeyFileReader.readPrivateKey(privateDer, "RSA").getEncoded());
+		assertArrayEquals(keyPair.getPublic().getEncoded(),
+			KeyFileReader.readPublicKey(publicDer, "RSA").getEncoded());
+	}
+
+	/**
+	 * A traditional PKCS#1 PEM holds the whole key pair, so it answers both "what is the private
+	 * key" and "what is the public half".
+	 */
+	@Test
+	void aKeyPairPemAnswersForBothHalves(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		byte[] pkcs1 = org.bouncycastle.asn1.pkcs.PrivateKeyInfo
+			.getInstance(keyPair.getPrivate().getEncoded()).parsePrivateKey().toASN1Primitive()
+			.getEncoded();
+		File pem = armoured(tempDir, "pkcs1.pem", "RSA PRIVATE KEY", pkcs1);
+
+		assertArrayEquals(keyPair.getPrivate().getEncoded(),
+			KeyFileReader.readPrivateKey(pem, "RSA").getEncoded());
+		assertArrayEquals(keyPair.getPublic().getEncoded(),
+			KeyFileReader.readPublicKey(pem, "RSA").getEncoded());
+	}
+
+	@Test
+	void aPublicKeyWhereAPrivateOneBelongsIsNamedByWhatItHolds(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		File pem = armoured(tempDir, "public.pem", "PUBLIC KEY", keyPair.getPublic().getEncoded());
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(pem, "RSA"));
+
+		assertTrue(rejected.getMessage().contains("not a private key"),
+			"the message must say what the file holds instead, but was: '" + rejected.getMessage()
+				+ "'");
+	}
+
+	@Test
+	void aPrivateKeyWhereAPublicOneBelongsIsNamedByWhatItHolds(@TempDir File tempDir)
+		throws Exception
+	{
+		KeyPair keyPair = rsaKeyPair();
+		File pem = armoured(tempDir, "pkcs8.pem", "PRIVATE KEY", keyPair.getPrivate().getEncoded());
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPublicKey(pem, "RSA"));
+
+		assertTrue(rejected.getMessage().contains("not a public key"),
+			"the message was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aPemWithNoObjectInItIsNamedAsSuch(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "empty.pem");
+		Files.writeString(pem.toPath(), "-----BEGIN NOTHING-----" + System.lineSeparator(),
+			StandardCharsets.UTF_8);
+
+		IllegalArgumentException asPrivate = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(pem, "RSA"));
+		IllegalArgumentException asPublic = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPublicKey(pem, "RSA"));
+
+		assertTrue(asPrivate.getMessage().contains("PEM object"),
+			"the message was: '" + asPrivate.getMessage() + "'");
+		assertTrue(asPublic.getMessage().contains("PEM object"),
+			"the message was: '" + asPublic.getMessage() + "'");
+	}
+
+	@Test
+	void aPemHoldingSomethingElseEntirelyIsNamedByItsType(@TempDir File tempDir) throws Exception
+	{
+		// a certificate signing request is a well formed PEM object that is not a key at all
+		File pem = armoured(tempDir, "other.pem", "CERTIFICATE REQUEST",
+			new byte[] { 0x30, 0x03, 0x02, 0x01, 0x00 });
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(pem, "RSA"));
+
+		assertTrue(rejected.getMessage().contains("PEM object"),
+			"a body that does not match its armour is still 'this file is not that key', but the "
+				+ "message was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void bytesThatAreNeitherPemNorDerAreNamedWithTheAlgorithmThatWasExpected(@TempDir File tempDir)
+		throws Exception
+	{
+		File rubbish = new File(tempDir, "rubbish.bin");
+		Files.write(rubbish.toPath(), new byte[] { 1, 2, 3, 4, 5 });
+
+		IllegalArgumentException asPrivate = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(rubbish, "RSA"));
+		IllegalArgumentException asPublic = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPublicKey(rubbish, "RSA"));
+
+		assertTrue(asPrivate.getMessage().contains("RSA private key"),
+			"the message was: '" + asPrivate.getMessage() + "'");
+		assertTrue(asPublic.getMessage().contains("RSA public key"),
+			"the message was: '" + asPublic.getMessage() + "'");
+	}
+
+	@Test
+	void anEmptyFileIsNotMistakenForPem(@TempDir File tempDir) throws Exception
+	{
+		File empty = new File(tempDir, "empty.bin");
+		Files.write(empty.toPath(), new byte[0]);
+
+		assertFalse(KeyFileReader.isPem(empty));
+		assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(empty, "RSA"));
+	}
+
+	/**
+	 * A key of an algorithm no provider knows parses fine - the ASN.1 is well formed - and fails
+	 * only when the converter tries to build a key out of it. Bouncy Castle answers "no such
+	 * algorithm: 1.2.3.4.5.6.7", which has to reach the caller as a statement about this file.
+	 */
+	@Test
+	void aKeyOfAnAlgorithmNoProviderKnowsIsReportedAgainstTheFile(@TempDir File tempDir)
+		throws Exception
+	{
+		AlgorithmIdentifier unknown = new AlgorithmIdentifier(
+			new ASN1ObjectIdentifier("1.2.3.4.5.6.7"));
+		File privatePem = armoured(tempDir, "unknown-private.pem", "PRIVATE KEY",
+			new PrivateKeyInfo(unknown, new DEROctetString(new byte[] { 1, 2, 3 })).getEncoded());
+		File publicPem = armoured(tempDir, "unknown-public.pem", "PUBLIC KEY",
+			new SubjectPublicKeyInfo(unknown, new byte[] { 1, 2, 3 }).getEncoded());
+
+		IllegalArgumentException asPrivate = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(privatePem, "RSA"));
+		IllegalArgumentException asPublic = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPublicKey(publicPem, "RSA"));
+
+		assertTrue(asPrivate.getMessage().contains("unknown-private.pem"),
+			"the message must name the file, but was: '" + asPrivate.getMessage() + "'");
+		assertTrue(asPublic.getMessage().contains("unknown-public.pem"),
+			"the message must name the file, but was: '" + asPublic.getMessage() + "'");
+	}
+
+	/**
+	 * A stray BEGIN marker inside ordinary text is enough to look like PEM but parses to nothing,
+	 * and that has to read as "no PEM object" rather than as a null slipping through.
+	 */
+	@Test
+	void textThatOnlyLooksLikePemHoldsNoPemObject(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "looks-like.pem");
+		Files.writeString(pem.toPath(), "text -----BEGIN something odd" + System.lineSeparator()
+			+ "more text" + System.lineSeparator(), StandardCharsets.UTF_8);
+
+		assertTrue(KeyFileReader.isPem(pem));
+		IllegalArgumentException asPrivate = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPrivateKey(pem, "RSA"));
+		IllegalArgumentException asPublic = assertThrows(IllegalArgumentException.class,
+			() -> KeyFileReader.readPublicKey(pem, "RSA"));
+
+		assertTrue(asPrivate.getMessage().contains("no PEM object"),
+			"the message was: '" + asPrivate.getMessage() + "'");
+		assertTrue(asPublic.getMessage().contains("no PEM object"),
+			"the message was: '" + asPublic.getMessage() + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptorTest.java
@@ -1,0 +1,205 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for {@link PassphraseCryptor}, the passphrase-based authenticated encryption behind
+ * the {@code encrypt} and {@code decrypt} commands.
+ */
+class PassphraseCryptorTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	private static char[] passphrase(String value)
+	{
+		return value.toCharArray();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "a", "the quick brown fox", "unicode: Ärger, Straße, 漢字" })
+	void whatWasEncryptedComesBackByteForByte(String plainText) throws Exception
+	{
+		byte[] plain = plainText.getBytes(StandardCharsets.UTF_8);
+
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("correct horse"), plain);
+		byte[] decrypted = PassphraseCryptor.decrypt(passphrase("correct horse"), encrypted);
+
+		assertArrayEquals(plain, decrypted);
+	}
+
+	@Test
+	void aWrongPassphraseFailsLoudlyInsteadOfReturningRubbish() throws Exception
+	{
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("right one"),
+			"secret".getBytes(StandardCharsets.UTF_8));
+
+		Exception rejected = assertThrows(Exception.class,
+			() -> PassphraseCryptor.decrypt(passphrase("wrong one"), encrypted));
+
+		assertFalse(rejected.getMessage() == null || rejected.getMessage().isBlank(),
+			"the failure must name a reason, but the message was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void alteringOneByteOfTheCiphertextIsDetected() throws Exception
+	{
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("pass"),
+			"tamper with me".getBytes(StandardCharsets.UTF_8));
+		// flip a bit in the middle, past the header and inside the ciphertext
+		byte[] tampered = encrypted.clone();
+		int middle = PassphraseCryptor.HEADER_LENGTH
+			+ (tampered.length - PassphraseCryptor.HEADER_LENGTH) / 2;
+		tampered[middle] ^= 0x01;
+
+		assertThrows(Exception.class,
+			() -> PassphraseCryptor.decrypt(passphrase("pass"), tampered));
+	}
+
+	@Test
+	void theOutputStartsWithTheFormatMarkerAndItsVersion()
+	{
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("pass"),
+			"marked".getBytes(StandardCharsets.UTF_8));
+
+		byte[] marker = Arrays.copyOf(encrypted, PassphraseCryptor.MAGIC.length);
+		assertArrayEquals(PassphraseCryptor.MAGIC, marker,
+			"the output must be recognisable by its leading marker");
+		assertEquals(PassphraseCryptor.FORMAT_VERSION, encrypted[PassphraseCryptor.MAGIC.length],
+			"the byte after the marker must be the format version, so the format can be changed "
+				+ "later without guessing");
+		assertTrue(PassphraseCryptor.isEncrypted(encrypted),
+			"a freshly encrypted blob must be recognised as one");
+	}
+
+	@Test
+	void encryptingTheSameInputTwiceYieldsDifferentOutput()
+	{
+		byte[] plain = "same input".getBytes(StandardCharsets.UTF_8);
+
+		byte[] first = PassphraseCryptor.encrypt(passphrase("pass"), plain);
+		byte[] second = PassphraseCryptor.encrypt(passphrase("pass"), plain);
+
+		assertFalse(Arrays.equals(first, second),
+			"a fresh salt and nonce per call must make two encryptions of the same input differ");
+	}
+
+	@Test
+	void inputThatIsNotOfThisFormatIsRejectedByName()
+	{
+		byte[] foreign = "this is a plain text file, not an encrypted one"
+			.getBytes(StandardCharsets.UTF_8);
+		assertFalse(PassphraseCryptor.isEncrypted(foreign));
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> PassphraseCryptor.decrypt(passphrase("pass"), foreign));
+		assertTrue(rejected.getMessage().contains("mystic-crypt"),
+			"the message must say what the input was expected to be, but was: '"
+				+ rejected.getMessage() + "'");
+	}
+
+	@Test
+	void anInputTooShortToHoldAHeaderIsRejectedRatherThanIndexed()
+	{
+		byte[] tooShort = { 'M', 'C', 'R' };
+		assertFalse(PassphraseCryptor.isEncrypted(tooShort));
+		assertThrows(IllegalArgumentException.class,
+			() -> PassphraseCryptor.decrypt(passphrase("pass"), tooShort));
+	}
+
+	@Test
+	void theIterationCountIsAtLeastTheOwaspFloorAndTravelsWithTheOutput()
+	{
+		assertTrue(PassphraseCryptor.DEFAULT_ITERATIONS >= 600_000,
+			"PBKDF2-HMAC-SHA256 below 600000 iterations is under the OWASP guidance");
+
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("pass"),
+			"iterations".getBytes(StandardCharsets.UTF_8));
+
+		assertEquals(PassphraseCryptor.DEFAULT_ITERATIONS,
+			PassphraseCryptor.iterationsOf(encrypted),
+			"the iteration count must be readable from the output, so a later default change can "
+				+ "still decrypt what an older default produced");
+	}
+
+	@Test
+	void nothingAndTheRightMarkerWithAForeignVersionAreBothRefused()
+	{
+		assertFalse(PassphraseCryptor.isEncrypted(null), "no input is not encrypted input");
+
+		byte[] futureVersion = PassphraseCryptor.encrypt(passphrase("pass"),
+			"from a later format".getBytes(StandardCharsets.UTF_8));
+		futureVersion[PassphraseCryptor.MAGIC.length] = PassphraseCryptor.FORMAT_VERSION + 1;
+
+		assertFalse(PassphraseCryptor.isEncrypted(futureVersion),
+			"a version this build does not know must not be treated as readable");
+		assertThrows(IllegalArgumentException.class,
+			() -> PassphraseCryptor.decrypt(passphrase("pass"), futureVersion));
+	}
+
+	@Test
+	void anInputThatCannotBeSealedIsReportedAsSuchAndStillClearsThePassphrase()
+	{
+		char[] toEncrypt = passphrase("wipe me too");
+
+		IllegalStateException failed = assertThrows(IllegalStateException.class,
+			() -> PassphraseCryptor.encrypt(toEncrypt, null));
+
+		assertTrue(failed.getMessage().contains("could not encrypt"),
+			"the message must say what failed, but was: '" + failed.getMessage() + "'");
+		assertArrayEquals(new char[toEncrypt.length], toEncrypt,
+			"the passphrase must be cleared on the failure path as well");
+	}
+
+	@Test
+	void thePassphraseArrayIsClearedSoItCannotLingerInMemory()
+	{
+		char[] toEncrypt = passphrase("wipe me");
+		PassphraseCryptor.encrypt(toEncrypt, "x".getBytes(StandardCharsets.UTF_8));
+
+		assertArrayEquals(new char[toEncrypt.length], toEncrypt,
+			"encrypt must zero the passphrase it was given, as the rest of this package does");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupportTest.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.pw;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for {@link ScryptSupport}, the PHC-like encoding that lets a scrypt hash be verified
+ * from the stored string alone.
+ */
+class ScryptSupportTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	@Test
+	void aPasswordVerifiesAgainstItsOwnHashAndNothingElse()
+	{
+		String encoded = ScryptSupport.hash("the-secret".toCharArray());
+
+		assertTrue(encoded.startsWith(ScryptSupport.PREFIX));
+		assertTrue(ScryptSupport.verify("the-secret".toCharArray(), encoded));
+		assertFalse(ScryptSupport.verify("not-the-secret".toCharArray(), encoded));
+	}
+
+	@Test
+	void theParametersTravelWithTheHashSoTheyNeedNotBeStoredElsewhere()
+	{
+		String encoded = ScryptSupport.hash("the-secret".toCharArray());
+
+		assertTrue(encoded.contains("ln=" + ScryptSupport.DEFAULT_LOG_N),
+			"the cost must be readable from the hash, but was: '" + encoded + "'");
+		assertTrue(encoded.contains("r=" + ScryptSupport.DEFAULT_R));
+		assertTrue(encoded.contains("p=" + ScryptSupport.DEFAULT_P));
+		assertEquals(5, encoded.split("\\$").length,
+			"the encoding is $scrypt$params$salt$hash, but was: '" + encoded + "'");
+	}
+
+	@Test
+	void aFreshSaltPerCallMakesTwoHashesOfTheSamePasswordDiffer()
+	{
+		assertNotEquals(ScryptSupport.hash("same".toCharArray()),
+			ScryptSupport.hash("same".toCharArray()));
+	}
+
+	/**
+	 * Every one of these is malformed in a different way, and each must come back as "does not
+	 * match" rather than as an exception out of the hasher.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "", "not a hash at all", "$scrypt$",
+			"$argon2id$v=19$m=1,t=1,p=1$AA$BB", "$scrypt$ln=15,r=8$AA$BB",
+			"$scrypt$ln=15,r=8,p=1,x=2$AA$BB", "$scrypt$lnr8p1$AA$BB", "$scrypt$ln=0,r=8,p=1$AA$BB",
+			"$scrypt$ln=31,r=8,p=1$AA$BB", "$scrypt$ln=15,r=0,p=1$AA$BB",
+			"$scrypt$ln=15,r=8,p=0$AA$BB", "$scrypt$ln=notanumber,r=8,p=1$AA$BB",
+			"$scrypt$ln=15,r=8,p=1$not base64$BB", "$bogus$ln=15,r=8,p=1$AA$BB" })
+	void aMalformedHashAnswersFalseRatherThanThrowing(String encoded)
+	{
+		assertFalse(ScryptSupport.verify("whatever".toCharArray(), encoded),
+			"a malformed hash must answer false, but '" + encoded + "' did not");
+	}
+
+	@Test
+	void theZeroCostBoundIsRefusedBecauseItWouldOverflowIntoANegativeN()
+	{
+		// 1 << 31 is negative, which the hasher would reject with an exception rather than a
+		// "does not match"; the upper bound on ln is what keeps that out of the hasher
+		assertFalse(ScryptSupport.verify("whatever".toCharArray(), "$scrypt$ln=31,r=8,p=1$AA$BB"));
+		assertFalse(ScryptSupport.verify("whatever".toCharArray(), "$scrypt$ln=99,r=8,p=1$AA$BB"));
+	}
+
+	@Test
+	void thePasswordArrayIsClearedOnBothPaths()
+	{
+		char[] toHash = "wipe me".toCharArray();
+		String encoded = ScryptSupport.hash(toHash);
+		assertArrayEquals(new char[toHash.length], toHash,
+			"hash must zero the password it was given");
+
+		char[] toVerify = "wipe me".toCharArray();
+		ScryptSupport.verify(toVerify, encoded);
+		assertArrayEquals(new char[toVerify.length], toVerify,
+			"verify must zero the password it was given");
+	}
+
+	@Test
+	void anEncodingOfNoKnownAlgorithmIsNamedWithTheOnesThatAre()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> PasswordHashFormat.of(null));
+
+		assertTrue(rejected.getMessage().contains("$scrypt$"),
+			"the message must list the encodings, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void nullIsRefusedOutright()
+	{
+		assertThrows(NullPointerException.class, () -> ScryptSupport.hash(null));
+		assertThrows(NullPointerException.class,
+			() -> ScryptSupport.verify(null, "$scrypt$ln=15,r=8,p=1$AA$BB"));
+		assertThrows(NullPointerException.class,
+			() -> ScryptSupport.verify("x".toCharArray(), null));
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/secret/SecretShareTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/secret/SecretShareTest.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.secret;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for {@link SecretShare}, the text format one share is written in.
+ */
+class SecretShareTest
+{
+
+	private static final byte[] VALUE = { 0x01, 0x02, 0x03, 0x04, (byte)0xff };
+
+	@Test
+	void aShareSurvivesTheRoundTripThroughItsTextForm()
+	{
+		SecretShare share = new SecretShare("00112233445566aa", 3, 5, 2, VALUE);
+
+		SecretShare parsed = SecretShare.decode(share.encode());
+
+		assertEquals("00112233445566aa", parsed.getSplitId());
+		assertEquals(3, parsed.getThreshold());
+		assertEquals(5, parsed.getTotal(), "the share must carry how many shares the split made");
+		assertEquals(2, parsed.getIndex());
+		assertArrayEquals(VALUE, parsed.getValue());
+	}
+
+	@Test
+	void theEncodedLineStartsWithTheFormatPrefix()
+	{
+		assertTrue(
+			new SecretShare("abcd", 2, 3, 1, VALUE).encode().startsWith(SecretShare.PREFIX + ":"),
+			"a share line must be recognisable by its prefix");
+	}
+
+	/**
+	 * Every one of these is a line that could arrive from a person copying a share by hand, and
+	 * each must be named rather than silently accepted.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "", "just some text", "mcs1:only:four:fields",
+			"mcs1:a:2:3:1:AAAA:dead:beef", "nope:a:2:3:1:AAAA:deadbeef" })
+	@NullSource
+	void aLineThatIsNotAShareIsRejectedWithAnExampleOfOneThatIs(String line)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SecretShare.decode(line));
+
+		assertTrue(rejected.getMessage().contains(SecretShare.PREFIX),
+			"the message must show what a share line looks like, but was: '" + rejected.getMessage()
+				+ "'");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "mcs1:a:two:3:1:AAAA:deadbeef, threshold", "mcs1:a:2:all:1:AAAA:deadbeef, total",
+			"mcs1:a:2:3:first:AAAA:deadbeef, index" })
+	void aNumericFieldThatIsNotANumberIsNamedByItsRole(String line, String expectedFieldName)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SecretShare.decode(line));
+
+		assertTrue(rejected.getMessage().contains(expectedFieldName),
+			"the message must name the field, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aValueThatIsNotBase64IsNamedAsSuch()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SecretShare.decode("mcs1:a:2:3:1:not base64 at all:deadbeef"));
+
+		assertTrue(rejected.getMessage().contains("base64url"),
+			"the message must say what was expected, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aChecksumThatDoesNotMatchNamesTheShareAndTheSplit()
+	{
+		String tamperedChecksum = new SecretShare("beefsplit", 2, 3, 7, VALUE).encode()
+			.replaceAll(":[0-9a-f]{8}$", ":00000000");
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SecretShare.decode(tamperedChecksum));
+
+		assertTrue(
+			rejected.getMessage().contains("7") && rejected.getMessage().contains("beefsplit"),
+			"the message must identify which share of which split, but was: '"
+				+ rejected.getMessage() + "'");
+	}
+
+	@Test
+	void anUnavailableDigestAlgorithmIsReportedRatherThanSwallowed()
+	{
+		assertThrows(IllegalStateException.class,
+			() -> SecretShare.checksumOf("mcs1:a:2:3:1:AAAA", "NoSuchDigest-512"));
+	}
+
+	@Test
+	void combineRefusesNothingToCombine()
+	{
+		assertThrows(IllegalArgumentException.class, () -> SecretSharing.combine(null));
+		assertThrows(IllegalArgumentException.class, () -> SecretSharing.combine(List.of()));
+	}
+
+	@Test
+	void aSingleShareOfAThreeShareSplitIsReportedInTheSingular()
+	{
+		List<SecretShare> shares = SecretSharing.split(
+			"a secret with enough bytes".getBytes(java.nio.charset.StandardCharsets.UTF_8), 2, 3);
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SecretSharing.combine(List.of(shares.get(0))));
+
+		assertTrue(rejected.getMessage().contains("1 was given"),
+			"one share is 'was given', not 'were given', but the message was: '"
+				+ rejected.getMessage() + "'");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactoryTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactoryTest.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Unit tests for the parts of {@link SelfSignedCertificateFactory} that a caller can get wrong
+ * before a certificate is ever built.
+ */
+class SelfSignedCertificateFactoryTest
+{
+
+	@BeforeAll
+	static void registerBouncyCastle()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	private static KeyPair keyPair(String algorithm) throws Exception
+	{
+		KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm);
+		generator.initialize(2048);
+		return generator.generateKeyPair();
+	}
+
+	/**
+	 * Both spellings of a PSS signature satisfy RFC 4055: the ...andMGF1 names and a name that says
+	 * PSS outright.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "SHA256withRSAandMGF1", "SHA512withRSAandMGF1", "RSASSA-PSS",
+			"SHA256WITHRSASSA-PSS" })
+	void aPssSignatureIsAcceptedForAnRsassaPssKey(String signatureAlgorithm) throws Exception
+	{
+		KeyPair keyPair = keyPair("RSASSA-PSS");
+
+		SelfSignedCertificateFactory.requireSignatureFitsTheKey(keyPair, signatureAlgorithm);
+	}
+
+	@Test
+	void aPlainRsaSignatureIsRefusedForAnRsassaPssKey() throws Exception
+	{
+		KeyPair keyPair = keyPair("RSASSA-PSS");
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SelfSignedCertificateFactory.requireSignatureFitsTheKey(keyPair,
+				"SHA256withRSA"));
+
+		assertTrue(rejected.getMessage().contains("RFC 4055"),
+			"the message must cite the requirement, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void aPlainRsaKeyIsNotHeldToThePssRequirement() throws Exception
+	{
+		SelfSignedCertificateFactory.requireSignatureFitsTheKey(keyPair("RSA"), "SHA256withRSA");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { "example.org", ":example.org", "dns:" })
+	void aSubjectAlternativeNameWithoutBothHalvesIsRefusedWithAnExample(String text)
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SelfSignedCertificateFactory.SubjectAlternativeName.parse(text));
+
+		assertTrue(rejected.getMessage().contains("dns:example.org"),
+			"the message must show what one looks like, but was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void anUnknownKeyUsageIsNamedWithTheOnesThatExist()
+	{
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> SelfSignedCertificateFactory.keyUsageBits(java.util.List.of("signEverything")));
+
+		assertTrue(rejected.getMessage().contains("is not a key usage"),
+			"the message was: '" + rejected.getMessage() + "'");
+	}
+
+	@Test
+	void contentCommitmentIsTheOtherNameForNonRepudiation()
+	{
+		assertEquals(SelfSignedCertificateFactory.keyUsageBits(java.util.List.of("nonRepudiation")),
+			SelfSignedCertificateFactory.keyUsageBits(java.util.List.of("contentCommitment")),
+			"the two names must select the same bit");
+	}
+}


### PR DESCRIPTION
The UI treats `--cli` as a backlink into this library's picocli root command, and its plugins may only carry commands for what the library does not cover. Three plugins carried their own because of that, and several commands covered less than the tool window next to them. This closes all ten gaps.

Measured on this branch, rebased onto develop so it builds against crypt-data 12.0.0 (`dependencyInsight` confirms the resolved version): **1184 tests, 0 failures, 100.00% branch coverage**, with only the two documented lines of `MysticCryptCli.main` uncovered. Every command and subcommand answers `--help`.

## What each commit does

| Gap | Command | What it adds |
|---|---|---|
| 1 | `encrypt` / `decrypt` | file and text encryption with a passphrase, which the CLI could not do at all |
| 2 | `share split` / `share combine` | Shamir secret sharing, which nothing exposed |
| 3 | `keyx new/send/receive` | the key exchange as two people use it, each holding only their own half |
| 4 | `hash` / `verify` | bcrypt and scrypt, and the algorithm read from the hash |
| 5 | `checksum --hmac` | the keyed answer next to the plain digest |
| 6 | `sign` / `verify-signature` | RSA, ECDSA, DSA, and DER as well as PEM |
| 7 | `convert` | replaces `der2pem`, detects the file and converts both ways |
| 8 | `cert` | basic constraints, key usage, subject alternative names |
| 9 | `keygen` | `--curve`, `--format`, `--print-details` |
| 10 | `obfuscate` / `disentangle` | rules that carry an operation |

## The parts worth reading before merging

**One breaking change.** `verify` no longer accepts `--algorithm`: every encoding says what produced it, and naming it again was only a way to get it wrong - the wrong name turned "this is a bcrypt hash" into "the password does not match". Its test was updated in the same commit rather than left passing.

**Two library defects are worked around, not fixed at their source.**

- `PrivateKeyWriter.write(..., KeyFormat.PKCS_8)` in crypt-data does not write PKCS#8. It routes through `PrivateKeyExtensions.toPemFormat`, which calls `toPKCS1Format` for *every* key type and strips the wrapper, so PKCS#1 lands in the file under an RSA PRIVATE KEY header. crypt-data 12.0.0 shipped today, so a fix there is not consumable without another release; `KeyFileWriter` in this repository writes correctly instead and a test pins both headers.
- `ObfuscatorExtensions.disentangle` does not reverse an operated rule set: for `a=x:UPPERCASE@0` and `b=y` it turns `Ayx` into `ayx` rather than `aba`, and `disentangleImproved` throws a `NullPointerException` on the same input. A one-way obfuscation is a trap, so the reversal is done in the command's own support class and the library methods are left untouched and reported.

**Two premises of the task were already true** and were verified rather than acted on: `SimpleObfuscatorExtensions.disentangle` is no longer broken (checked through the real CLI, and `docs/TESTING.md:29` records the earlier fix), and `disentangle` already called `disentangleBiMap` rather than that method.

**Bouncy Castle throughout for the classical families.** An EC key on a named curve is rejected by SunEC when it signs, and verification with it returns `false` rather than throwing - a valid signature reads as invalid with nothing saying why. Signing, verifying and decoding all name the provider, which is why `KeyFileReader` exists next to crypt-data's readers: those call `KeyFactory.getInstance(algorithm)` without a provider, and for `EC` the JDK's own wins.

**RFC 4055 is enforced.** An RSASSA-PSS key signed with `SHA256withRSA` is refused with the requirement named, rather than producing a certificate some verifiers quietly reject.

## Tests

Every command has a real round trip through the command line against real files - encrypt/decrypt, split/combine, sign/verify, new/send/receive, convert both ways - plus the negative cases: wrong passphrase, too few shares, shares of two splits, altered ciphertext, wrong key, foreign files. Known-answer vectors where they exist (RFC 4231 case 1 for the keyed checksum, the four digest vectors kept from before). Algorithm lists are parameterized rather than copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)