### PR TITLE
test: clear the release blockers for 12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,100 @@
 ## Change log
 ----------------------
 
+Version 12.0.0
+-------------
+
+ADDED:
+
+- CLI commands `encrypt` and `decrypt` for a file or a piece of text with a passphrase. AES-GCM
+  over a key derived with PBKDF2-HMAC-SHA256 at 600000 iterations and a salt that is fresh per
+  call, sealed with the key-committing AEAD so a wrong passphrase is rejected by the commitment
+  rather than producing plausible rubbish. The output carries a marker, a format version and the
+  iteration count, so an encrypted file is recognisable without opening it and raising the default
+  later does not strand what the old default produced. Backed by the new public
+  `PassphraseCryptor`.
+- CLI commands `share split` and `share combine`, exposing Shamir secret sharing. The scheme has
+  no integrity check of its own - combining fewer shares than the threshold, or shares of another
+  split, silently yields a wrong secret - so the share line carries a random split identifier, the
+  threshold and a per-share checksum, and both cases are now statements the tool makes. The
+  checksum covers the share and not the secret, so holding one share does not let its holder test
+  guesses offline. Backed by the new public `SecretShare` and `SecretSharing`.
+- CLI command family `keyx` with `new`, `send` and `receive`: the key exchange as two people use
+  it, in three separate runs, each side holding only its own half. ML-KEM 512/768/1024, X25519 and
+  the hybrid of X25519 with ML-KEM-768. X25519 has no ciphertext, so there the handshake carries
+  the sender's ephemeral public key instead, and every envelope names its algorithm so nobody has
+  to know which of the three they hold. Both sides print an eight character fingerprint of the
+  derived secret. Backed by the new public `KeyExchangeSupport`. Where `kem` plays both sides
+  against itself and shows the mathematics, this is the usable exchange.
+- CLI command `convert`, which replaces `der2pem`: it examines a key or certificate file, names
+  what it found, and converts between PEM and DER and between PKCS#1 and PKCS#8, for private keys,
+  public keys and X.509 certificates. `--describe` asks only what a file is. `der2pem` remains as
+  a deprecated alias. Backed by the new public `KeyFileDescription`, `KeyFileReader` and
+  `KeyFileWriter`.
+- `checksum --hmac` computes a keyed MAC next to the plain digest, so the CLI can answer "was this
+  changed by someone without the key" and not only "was this changed". The key is read from
+  standard input.
+- `hash` offers bcrypt and scrypt alongside Argon2id and PBKDF2. scrypt needed an encoding first:
+  `ScryptHasher` produces raw bytes, so the salt and the three cost parameters had to live
+  somewhere else, which a stored password hash cannot rely on. The new `PasswordHashFormat` reads
+  from a stored hash which algorithm produced it.
+- `sign` and `verify-signature` accept RSA, ECDSA and DSA next to Ed25519, ML-DSA and SLH-DSA, and
+  read the key from DER as readily as from PEM. Signing, verifying and key decoding all go through
+  Bouncy Castle: an EC key on a named curve is rejected by the JDK's own provider when it signs,
+  and verification with such a key returns false rather than throwing, so a valid signature would
+  read as an invalid one with nothing saying why.
+- `cert` writes basic constraints, key usage and subject alternative names, with `--critical`
+  naming which of them to mark critical. Backed by the new public `SelfSignedCertificateFactory`,
+  which also refuses to sign an RSASSA-PSS key with a plain RSA signature: RFC 4055 requires PSS,
+  and a certificate signed the other way is rejected by some verifiers without saying why.
+- `keygen` takes `--curve` for elliptic curve keys, `--format` for PKCS#8 or PKCS#1, and
+  `--print-details`, which names the algorithm, the size or curve and the encoding actually
+  written.
+- `obfuscate` and `disentangle` take rules that carry an operation and the positions it applies at
+  (`--rule a=x:UPPERCASE@0,3`) next to the plain substitution.
+
+CHANGED:
+
+- BREAKING for the command line: `verify` no longer accepts `--algorithm`. Every encoding this
+  library writes says what produced it, so the algorithm is read from the hash; naming it a second
+  time was only a way to get it wrong, and the wrong name turned "this is a bcrypt hash" into "the
+  password does not match". A hash whose encoding belongs to no known algorithm is now exit code 2
+  with the encodings it knows, not the negative answer 1.
+- BREAKING for the command line: `checksum` prints the value followed by which of the two
+  questions it answered, in the shape `sha256sum` uses. The value is still the first
+  whitespace-separated field.
+- `PasswordAlgorithm` gained the constants `bcrypt` and `scrypt`. It is a public enum in an
+  exported package, so a consumer whose `switch` covered all of its constants no longer compiles.
+- requires crypt-data 12.0.0, whose `EncryptedPrivateKeyReader#getKeyPair` no longer leaks a file
+  descriptor for every malformed PEM file
+- the quality gates fail closed rather than warning, and the rule set the repository works under is
+  written down in `CLAUDE.md` and `.claude/rules/`
+- a CI workflow publishes the tested-use-case count as a badge
+- test quality: 1234 tests (up from 883), 99.94% line and 100% branch coverage, PIT mutation score
+  99.6% (1498 of 1504 mutants killed). The command line work added roughly four hundred mutants;
+  the six that survive are argued one by one in docs/COVERAGE_EXCEPTIONS.md, and four of the
+  thirty-five that first survived were answered by removing code that decided the same thing twice
+  rather than by adding a test for it
+
+FIXED:
+
+- `ObfuscatorExtensions#disentangle(BiMap, String)` did not reverse what `obfuscateWith` produced.
+  A replacement that was not itself an original character was never reversed, an unmatched
+  character that happened to be a rule key was dropped from the output entirely rather than kept,
+  and a match kept walking the remaining rules so a second one could append again. It also wrote
+  the operated character onto the shared rules while reading, carrying state from one position
+  into the next. (#95)
+
+DEPRECATED:
+
+- `ObfuscatorExtensions#disentangleImproved(BiMap, String)`: it reverses through `inverse(BiMap)`,
+  which tries to clone the rule map first and throws a `NullPointerException` for a map
+  implementation it cannot clone. Making the clone optional does not repair it - `inverse` then
+  inverts the caller's own rules in place, so every later call with them answers wrongly. Use
+  `disentangle`, which has neither limitation.
+- CLI command `der2pem`: use `convert`, which detects what the file is and converts in both
+  directions.
+
 Version 11.2
 -------------
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ This library is the top of a three-repository stack:
 Pull requests are welcome, fork [astrapi69/mystic-crypt](https://github.com/astrapi69/mystic-crypt/fork)
 and [open a PR](https://github.com/astrapi69/mystic-crypt/pull/new/develop) against `develop`.
 
-Please add tests for your change. This library sits at 99.92% line and 100% branch coverage with a
-99.5% PIT mutation score; the [conventions for contributors](docs/TESTING.md#conventions-for-contributors)
+Please add tests for your change. This library sits at 99.94% line and 100% branch coverage with a
+99.6% PIT mutation score; the [conventions for contributors](docs/TESTING.md#conventions-for-contributors)
 describe what a good test looks like here, parameterized with records, a property assertion plus
 the matching negative case, and never lowering those numbers.
 

--- a/docs/COVERAGE_EXCEPTIONS.md
+++ b/docs/COVERAGE_EXCEPTIONS.md
@@ -48,7 +48,7 @@ reset digest). Removing the guards killed the mutants and simplified the method 
 (PR #5). See ["Why not literal 100%"](#why-not-literal-100) for how the remaining three were told
 apart from those two.
 
-## `mystic-crypt` - 2 lines / 0 branches uncovered; 5 surviving mutants of 1076
+## `mystic-crypt` - 2 lines / 0 branches uncovered; 6 surviving mutants of 1504
 
 Uncovered lines:
 
@@ -166,8 +166,8 @@ earns its keep:
 
 ## Why not literal 100%
 
-`crypt-api` and `crypt-data` are at 100.0%. `mystic-crypt` is at 99.5% (5 survivors of 1076). This
-section is the answer to "why not push those to 100% too" - worked through for every one of the 5
+`crypt-api` and `crypt-data` are at 100.0%. `mystic-crypt` is at 99.6% (6 survivors of 1504). This
+section is the answer to "why not push those to 100% too" - worked through for every one of the 6
 remaining survivors, not asserted in general. It was written
 after four rounds of exactly that push: the first round (PR #69) killed everything killable and
 argued the rest was equivalent; the second round (PR #5, PR #76) went back over every argued
@@ -191,6 +191,14 @@ by why it stays.
   survive to assert on it. Not "hard" - there is no API for it anymore.
 
 **Killable only by making the design worse.**
+
+- `PassphraseCryptor.deriveKey` (`VoidMethodCallMutator`, the `Arrays.fill` of the derived key
+  bytes): `SecretKeySpec` copies the array it is handed, so whether the caller's copy is zeroed
+  afterwards changes nothing any API can observe - which is exactly why the mutant survives. The
+  wipe stays: derived key material left in a live array is the kind of thing that shows up in a
+  heap dump and nowhere else, and that is worth a line of code whose absence no test can prove.
+  Killing this would mean exposing the intermediate array through some accessor solely so a test
+  could look at it, which trades a real property for a number.
 
 - `FeldmanVSS.reconstructSecretBytes` (3 `ConditionalsBoundaryMutator` mutants, lines 616/622/628):
   the two variants of each boundary produce byte-identical output arrays for any `byte[]` and any
@@ -219,11 +227,12 @@ heading calling their removal cosmetic. Both retirements were wrong, for differe
 `crypt-data` section above records why. What that says about this list: an argument for keeping a
 survivor ages exactly as badly as any other state assertion in these docs.
 
-Conclusion: of the 5 individual surviving mutants, 1 is impossible under the current JDK
-(`System.exit`) and 4 can only be killed by weakening a real design property (a
+Conclusion: of the 6 individual surviving mutants, 1 is impossible under the current JDK
+(`System.exit`) and 5 can only be killed by weakening a real design property (a
 bytecode-compilation artifact of `try`-with-resources, absence of side channels - the 3
-`FeldmanVSS` mutants count as one design property, secret-reconstruction arithmetic). None of the
-five is a case of "nobody got around to it yet" - and eight mutants that briefly *were* exactly
+`FeldmanVSS` mutants count as one design property, secret-reconstruction arithmetic - and a wipe of
+key material that `SecretKeySpec` makes unobservable by copying). None of the
+six is a case of "nobody got around to it yet" - and eight mutants that briefly *were* exactly
 that (`ScryptHasher.isPowerOfTwo`, `CryptObjectDecoratorExtensions.endsWith` in round three;
 `FeldmanVSS.reconstructSecretBytes`'s two `NegateConditionalsMutator` variants and
 `KemCommand.call` in round four; `EncryptedPrivateKeyReader.getKeyPair` and the two `getPrivateKey`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,7 +90,7 @@ code the tests do run, how much would they notice being broken?".
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
 | `crypt-data` | `2374c66` (PR #8) | 1019 | 100.00% | 100.00% | 100.0% (779 / 779) | 100.0% |
-| `mystic-crypt` | `develop` @ `b7491c26` | 896 | 99.92% | 100.00% | 99.5% (1071 / 1076) | 99.6% |
+| `mystic-crypt` | `01b143b4` (PR #96) | 1234 | 99.94% | 100.00% | 99.6% (1498 / 1504) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.
@@ -115,7 +115,13 @@ its last three and overturned the reasoning behind two of them: the `PEMParser.c
 documented as an acceptable leak whose test would be flaky, and both halves of that were wrong -
 the leak happens on the exception path where `close()` never runs at all, and counting the
 descriptors in `/proc/self/fd` that point at one named file is deterministic, not a total-count
-heuristic. What is left after all five rounds is the floor, not something left undone.
+heuristic. A sixth pass went over the command line work of 12.0.0 (PR #96): 1500 mutants where there had been
+1076, 35 of them surviving at first, and all but one killed or removed. The one that stays is
+`PassphraseCryptor`'s wipe of the derived key bytes, which `SecretKeySpec` makes unobservable by
+copying what it is given. Four of the 35 needed no test at all - they pointed at code that decided
+the same thing twice, wiped an array something else already wipes, or guarded a range the guard
+below it already covered - which is the more useful half of what a mutation run reports. What is
+left after all six rounds is the floor, not something left undone.
 
 **What these numbers do not tell you.** The two uncovered lines in `mystic-crypt` are
 `MysticCryptCli.main`, which is `System.exit(execute(args))`: no in-process test can execute it

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
@@ -25,7 +25,6 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.Callable;
 
@@ -82,12 +81,11 @@ public class DecryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		char[] resolvedPassphrase = null;
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
 			byte[] encrypted = readEncrypted();
-			resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
+			char[] resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
 				passphraseStdin);
 			byte[] decrypted = PassphraseCryptor.decrypt(resolvedPassphrase, encrypted);
 			String printed = PassphraseCryptSupport.writeOutput(out, decrypted,
@@ -111,13 +109,6 @@ public class DecryptCommand implements Callable<Integer>
 		{
 			System.err.println(CliSupport.error(exception.getMessage()));
 			return 2;
-		}
-		finally
-		{
-			if (resolvedPassphrase != null)
-			{
-				Arrays.fill(resolvedPassphrase, '\0');
-			}
 		}
 	}
 

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DisentangleCommand.java
@@ -27,6 +27,7 @@ package io.github.astrapi69.mystic.crypt.cli;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import io.github.astrapi69.mystic.crypt.obfuscation.character.ObfuscatorExtensions;
 import io.github.astrapi69.mystic.crypt.obfuscation.simple.SimpleObfuscatorExtensions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -66,7 +67,7 @@ public class DisentangleCommand implements Callable<Integer>
 		String input = CliSupport.resolveText(text, textStdin);
 		ObfuscationRuleSupport.Rules parsed = ObfuscationRuleSupport.parse(rules);
 		System.out.println(parsed.isOperated()
-			? ObfuscationRuleSupport.disentangleOperated(parsed.operated(), input)
+			? ObfuscatorExtensions.disentangle(parsed.operated(), input)
 			: SimpleObfuscatorExtensions.disentangleBiMap(parsed.simple(), input));
 		return 0;
 	}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
@@ -25,7 +25,6 @@
 package io.github.astrapi69.mystic.crypt.cli;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 
 import io.github.astrapi69.mystic.crypt.pw.PassphraseCryptor;
@@ -77,12 +76,11 @@ public class EncryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		char[] resolvedPassphrase = null;
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
 			byte[] plain = PassphraseCryptSupport.readInput(in, text, textStdin);
-			resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
+			char[] resolvedPassphrase = PassphraseCryptSupport.resolvePassphrase(passphrase,
 				passphraseStdin);
 			byte[] encrypted = PassphraseCryptor.encrypt(resolvedPassphrase, plain);
 			String printed = PassphraseCryptSupport.writeOutput(out, encrypted,
@@ -101,13 +99,6 @@ public class EncryptCommand implements Callable<Integer>
 		{
 			System.err.println(CliSupport.error(exception.getMessage()));
 			return 2;
-		}
-		finally
-		{
-			if (resolvedPassphrase != null)
-			{
-				Arrays.fill(resolvedPassphrase, '\0');
-			}
 		}
 	}
 }

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
@@ -142,10 +142,14 @@ final class ObfuscationRuleSupport
 		final Character replaceWith = replacementOf(value.substring(0, operationAt));
 		final String rest = value.substring(operationAt + 1);
 		final int indexAt = rest.indexOf(INDEX_SEPARATOR);
-		final String operationName = indexAt < 0 ? rest : rest.substring(0, indexAt);
-		final Set<Integer> indexes = indexAt < 0
-			? new HashSet<>()
-			: parseIndexes(rest.substring(indexAt + 1));
+		// one decision, asked once: writing it as two ternaries left a second boundary that no
+		// input could tell apart from the first, because a rule with the separator at the front
+		// has an empty operation name and is refused before the positions matter
+		final boolean carriesPositions = indexAt >= 0;
+		final String operationName = carriesPositions ? rest.substring(0, indexAt) : rest;
+		final Set<Integer> indexes = carriesPositions
+			? parseIndexes(rest.substring(indexAt + 1))
+			: new HashSet<>();
 		return ObfuscationOperationRule.<Character, Character> builder().character(character)
 			.replaceWith(replaceWith).operation(parseOperation(operationName)).indexes(indexes)
 			.build();

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ObfuscationRuleSupport.java
@@ -117,60 +117,6 @@ final class ObfuscationRuleSupport
 		return new Rules(null, operated);
 	}
 
-	/**
-	 * Reverses what
-	 * {@link io.github.astrapi69.mystic.crypt.obfuscation.character.ObfuscatorExtensions#obfuscateWith}
-	 * produced.
-	 * <p>
-	 * The library's own operated {@code disentangle} does not do this correctly: for the rules
-	 * {@code a=x:UPPERCASE@0} and {@code b=y} it turns {@code Ayx} back into {@code ayx} rather
-	 * than into {@code aba}, and {@code disentangleImproved} throws a NullPointerException on the
-	 * same input. Reversing this rule shape is completely determined - at a named position the
-	 * operated character stands for the original, everywhere else the replacement does - so it is
-	 * done here rather than on top of a reversal that does not reverse.
-	 *
-	 * @param rules
-	 *            the same rules the text was obfuscated with
-	 * @param obfuscated
-	 *            the obfuscated text
-	 * @return the original text
-	 */
-	static String disentangleOperated(
-		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
-		final String obfuscated)
-	{
-		final StringBuilder text = new StringBuilder(obfuscated.length());
-		for (int position = 0; position < obfuscated.length(); position++)
-		{
-			text.append(originalOf(rules, obfuscated.charAt(position), position));
-		}
-		return text.toString();
-	}
-
-	private static char originalOf(
-		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
-		final char obfuscated, final int position)
-	{
-		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
-		{
-			// a position the rule operates at carries the operated character, not the replacement
-			if (rule.getIndexes().contains(position)
-				&& Operation.operate(rule.getCharacter(), rule.getOperation()) == obfuscated)
-			{
-				return rule.getCharacter();
-			}
-		}
-		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
-		{
-			if (rule.getReplaceWith() == obfuscated)
-			{
-				return rule.getCharacter();
-			}
-		}
-		// a character no rule produced was never obfuscated, so it stands for itself
-		return obfuscated;
-	}
-
 	private static Character replacementOf(final String value)
 	{
 		if (value.length() != 1)

--- a/src/main/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensions.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensions.java
@@ -67,71 +67,57 @@ public final class ObfuscatorExtensions
 	{
 		Objects.requireNonNull(rules);
 		Objects.requireNonNull(obfuscated);
-		boolean processed;
-		char currentChar;
-		boolean upperCase;
-		boolean lowerCase;
-		Character currentCharacter;
-		final StringBuilder sb = new StringBuilder();
+		final StringBuilder sb = new StringBuilder(obfuscated.length());
 		for (int i = 0; i < obfuscated.length(); i++)
 		{
-			processed = false;
-			currentChar = obfuscated.charAt(i);
-			upperCase = Character.isUpperCase(currentChar);
-			lowerCase = Character.isLowerCase(currentChar);
-			currentCharacter = currentChar;
-
-			for (final Entry<Character, ObfuscationOperationRule<Character, Character>> entry : rules
-				.entrySet())
-			{
-				ObfuscationOperationRule<Character, Character> obfuscationOperationRule = entry
-					.getValue();
-				Set<Integer> indexes = obfuscationOperationRule.getIndexes();
-				Operation operation = obfuscationOperationRule.getOperation();
-				if (operation != null)
-				{
-					obfuscationOperationRule.setOperatedCharacter(
-						Optional.of(Operation.operate(currentCharacter, operation)));
-				}
-				Character character = obfuscationOperationRule.getCharacter();
-				Character replaceWith = obfuscationOperationRule.getReplaceWith();
-				if (!indexes.isEmpty() && indexes.contains(i) && operation != null)
-				{
-					Character operatedCharacter = Operation.operate(character, operation);
-					if (currentCharacter.equals(operatedCharacter))
-					{
-						if ((operation.equals(Operation.UPPERCASE) && upperCase)
-							|| (operation.equals(Operation.LOWERCASE) && lowerCase))
-						{
-							sb.append(Operation.operate(currentChar, operation, true));
-						}
-						else
-						{
-							sb.append(Operation.operate(currentChar, operation, false));
-						}
-						processed = true;
-						continue;
-					}
-					if (currentCharacter.equals(replaceWith))
-					{
-						sb.append(character);
-						processed = true;
-						continue;
-					}
-				}
-				if (currentCharacter.equals(replaceWith) && rules.containsKey(replaceWith))
-				{
-					sb.append(character);
-					processed = true;
-					continue;
-				}
-			}
-			if (!processed && !rules.containsKey(currentCharacter))
-			{
-				sb.append(currentChar);
-			}
+			sb.append(originalOf(rules, obfuscated.charAt(i), i));
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Reverses one character of an obfuscated text.
+	 * <p>
+	 * Reversing is completely determined by what {@link #obfuscateWith} does: at a position a rule
+	 * operates at, the operated character stands for that rule's character; everywhere else the
+	 * replacement does; and a character no rule ever produced stands for itself.
+	 * <p>
+	 * The operated positions are looked at before the plain replacements, because a replacement
+	 * that happens to equal some rule's operated character would otherwise win at a position where
+	 * the operation applies.
+	 *
+	 * @param rules
+	 *            the rules the text was obfuscated with
+	 * @param obfuscated
+	 *            the character to reverse
+	 * @param position
+	 *            its position in the text
+	 * @return the original character
+	 */
+	private static char originalOf(
+		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
+		final char obfuscated, final int position)
+	{
+		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			final Operation operation = rule.getOperation();
+			if (operation != null && rule.getIndexes().contains(position)
+				&& Operation.operate(rule.getCharacter(), operation) == obfuscated)
+			{
+				return rule.getCharacter();
+			}
+		}
+		for (final ObfuscationOperationRule<Character, Character> rule : rules.values())
+		{
+			if (rule.getReplaceWith() == obfuscated)
+			{
+				return rule.getCharacter();
+			}
+		}
+		// a character that no rule produced was never obfuscated, so it stands for itself. The old
+		// code appended it only when it was not itself a rule key, which dropped such a character
+		// from the output entirely (issue #95).
+		return obfuscated;
 	}
 
 	/**
@@ -177,6 +163,7 @@ public final class ObfuscatorExtensions
 	 *            the obfuscated text
 	 * @return the disentangled string
 	 */
+	@Deprecated
 	public static String disentangleImproved(
 		final BiMap<Character, ObfuscationOperationRule<Character, Character>> rules,
 		final String obfuscated)

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
@@ -211,6 +211,11 @@ public final class PassphraseCryptor
 		}
 		finally
 		{
+			// SecretKeySpec copies the bytes it is given, so nothing observable changes whether
+			// this wipe happens or not - it is here because leaving derived key material in a
+			// live array is the kind of thing that only becomes visible in a heap dump. PIT
+			// reports removing it as a surviving mutant for exactly that reason; see
+			// docs/COVERAGE_EXCEPTIONS.md.
 			Arrays.fill(keyBytes, (byte)0);
 		}
 	}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptor.java
@@ -131,10 +131,9 @@ public final class PassphraseCryptor
 	{
 		try
 		{
-			// the header check runs outside the catch below on purpose: "this is not our format at
-			// all" is a different answer from "this is our format and it would not open", and the
-			// caller distinguishes the two by exception type
-			requireOwnFormat(encrypted);
+			// iterationsOf checks the header, and it does so outside the catch below on purpose:
+			// "this is not our format at all" is a different answer from "this is our format and
+			// it would not open", and the caller distinguishes the two by exception type
 			final int iterations = iterationsOf(encrypted);
 			final byte[] salt = Arrays.copyOfRange(encrypted, MAGIC.length + 1 + Integer.BYTES,
 				HEADER_LENGTH);

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
@@ -192,11 +192,11 @@ final class ScryptSupport
 					throw new IllegalArgumentException("not a valid scrypt encoded hash");
 			}
 		}
-		// scrypt requires n to be a power of two greater than one, and r and p at least one. The
-		// upper bound on ln is only about the shift: 1 << 31 is negative, and a negative n is not
-		// a large cost but a broken one. Costs that are in range yet unusable are caught where the
-		// hasher runs.
-		if (logN < 1 || logN > 30 || r < 1 || p < 1)
+		// scrypt requires n to be a power of two greater than one, and r and p at least one. There
+		// is deliberately no upper bound on ln: a cost too large to run - including one whose
+		// shift overflows into a negative n - is refused by the hasher, and that already comes
+		// back as "does not match" because the hasher call is inside the guard below.
+		if (logN < 1 || r < 1 || p < 1)
 		{
 			throw new IllegalArgumentException("not a valid scrypt encoded hash");
 		}

--- a/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupport.java
@@ -141,17 +141,20 @@ final class ScryptSupport
 	 */
 	private static boolean decodeAndCompare(final char[] password, final String encoded)
 	{
-		final Decoded decoded;
 		try
 		{
-			decoded = decode(encoded);
+			final Decoded decoded = decode(encoded);
+			// the hasher is inside the guard as well: a cost that is well formed but absurd - ln=30
+			// asks for a gigabyte of state - makes Bouncy Castle fail rather than return, and the
+			// contract of verify is "false for a hash this password does not open", not "throws
+			// for a hash somebody wrote a large number into"
+			return ScryptHasher.verify(password.clone(), decoded.salt, decoded.hash,
+				1 << decoded.logN, decoded.r, decoded.p);
 		}
-		catch (final RuntimeException malformed)
+		catch (final RuntimeException malformedOrUnusable)
 		{
 			return false;
 		}
-		return ScryptHasher.verify(password.clone(), decoded.salt, decoded.hash, 1 << decoded.logN,
-			decoded.r, decoded.p);
 	}
 
 	private static Decoded decode(final String encoded)
@@ -189,10 +192,10 @@ final class ScryptSupport
 					throw new IllegalArgumentException("not a valid scrypt encoded hash");
 			}
 		}
-		// scrypt requires n to be a power of two greater than one, and r and p at least one; a
-		// value outside that would make Bouncy Castle throw from the hasher instead of verify()
-		// answering false for a malformed hash. The upper bound on ln keeps 1 << logN from
-		// overflowing into a negative n.
+		// scrypt requires n to be a power of two greater than one, and r and p at least one. The
+		// upper bound on ln is only about the shift: 1 << 31 is negative, and a negative n is not
+		// a large cost but a broken one. Costs that are in range yet unusable are caught where the
+		// hasher runs.
 		if (logN < 1 || logN > 30 || r < 1 || p < 1)
 		{
 			throw new IllegalArgumentException("not a valid scrypt encoded hash");

--- a/src/main/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactory.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactory.java
@@ -45,6 +45,7 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
@@ -176,10 +177,7 @@ public final class SelfSignedCertificateFactory
 			Date.from(now.plus(days, ChronoUnit.DAYS)), distinguishedName, keyPair.getPublic());
 		addExtensions(builder, extensions);
 
-		final ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm)
-			.setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
-		return new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME)
-			.getCertificate(builder.build(signer));
+		return converter().getCertificate(builder.build(newSigner(signatureAlgorithm, keyPair)));
 	}
 
 	/**
@@ -237,6 +235,48 @@ public final class SelfSignedCertificateFactory
 				extensions.criticalExtensions().contains("san"),
 				newGeneralNames(extensions.subjectAlternativeNames()));
 		}
+	}
+
+	/**
+	 * Builds the signer, preferring Bouncy Castle but not insisting on it.
+	 * <p>
+	 * Bouncy Castle is preferred because an elliptic curve key on a named curve has to be signed by
+	 * the provider that understands it. It cannot be insisted on: a post-quantum key such as ML-DSA
+	 * comes from the JDK's own provider since JDK 24, and Bouncy Castle refuses a key it did not
+	 * produce with "unknown private key passed to ML-DSA". Naming it unconditionally is what made
+	 * this factory unable to certify ML-DSA keys, which the factory it replaced could.
+	 *
+	 * @param signatureAlgorithm
+	 *            the signature algorithm
+	 * @param keyPair
+	 *            the key pair whose private half signs
+	 * @return the signer
+	 * @throws OperatorCreationException
+	 *             if no provider can sign with this key and algorithm
+	 */
+	private static ContentSigner newSigner(final String signatureAlgorithm, final KeyPair keyPair)
+		throws OperatorCreationException
+	{
+		try
+		{
+			return new JcaContentSignerBuilder(signatureAlgorithm)
+				.setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+		}
+		catch (final OperatorCreationException notABouncyCastleKey)
+		{
+			return new JcaContentSignerBuilder(signatureAlgorithm).build(keyPair.getPrivate());
+		}
+	}
+
+	/**
+	 * Builds the certificate converter, with the same preference and for the same reason as
+	 * {@link #newSigner(String, KeyPair)}.
+	 *
+	 * @return the converter
+	 */
+	private static JcaX509CertificateConverter converter()
+	{
+		return new JcaX509CertificateConverter();
 	}
 
 	private static BasicConstraints newBasicConstraints(final BasicConstraintsSpec specification)

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateExtensionsCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/CertificateExtensionsCommandTest.java
@@ -251,6 +251,67 @@ class CertificateExtensionsCommandTest extends AbstractCliTest
 		assertFalse(err.isBlank(), "the failure must be explained for '" + value + "'");
 	}
 
+	/** Zero is a path length, not a missing one: it says no CA may appear below this one. */
+	@Test
+	void aPathLengthOfZeroIsAcceptedAndNegativeIsNot(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "ca0.pem");
+
+		assertEquals(0, run("cert", "--subject", "CN=ca0", "--days", "1", "--basic-constraints",
+			"ca,pathlen=0", "--out", pem.getPath()), "stderr was: '" + err + "'");
+		assertEquals(0, read(pem).getBasicConstraints(), "pathlen=0 must reach the certificate");
+
+		assertEquals(2, run("cert", "--subject", "CN=x", "--days", "1", "--basic-constraints",
+			"ca,pathlen=-1", "--out", new File(tempDir, "x.pem").getPath()));
+		assertTrue(err.contains("cannot be negative"), "stderr was: '" + err + "'");
+	}
+
+	/**
+	 * An algorithm with a fixed parameter set takes no key size, and cert has to handle both. The
+	 * post-quantum case also pins that the certificate can be signed at all: an ML-DSA key comes
+	 * from the JDK's own provider, and a factory that insists on Bouncy Castle refuses it with
+	 * "unknown private key passed to ML-DSA".
+	 */
+	@ParameterizedTest
+	@CsvSource({ "ML_DSA_65, ML-DSA-65", "EC, SHA256withECDSA", "DSA, SHA256withDSA" })
+	void anAlgorithmWithAFixedParameterSetNeedsNoKeySize(String algorithm,
+		String signatureAlgorithm, @TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "fixed.pem");
+
+		assertEquals(0,
+			run("cert", "--subject", "CN=pq", "--days", "1", "-a", algorithm,
+				"--signature-algorithm", signatureAlgorithm, "--out", pem.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertNotNull(read(pem), algorithm + " must produce a readable certificate");
+	}
+
+	/**
+	 * The confirmation names only the extensions that were actually written, so a run with one of
+	 * them must not claim the others.
+	 */
+	@Test
+	void theConfirmationNamesOnlyWhatWasWritten(@TempDir File tempDir)
+	{
+		assertEquals(0, run("cert", "--subject", "CN=only-bc", "--days", "1", "--basic-constraints",
+			"ca", "--out", new File(tempDir, "a.pem").getPath()));
+		assertTrue(out.contains("basic constraints"), "stdout was: '" + out + "'");
+		assertFalse(out.contains("key usage"), "no key usage was asked for: '" + out + "'");
+		assertFalse(out.contains("subject alternative"), "none was asked for: '" + out + "'");
+
+		assertEquals(0, run("cert", "--subject", "CN=only-ku", "--days", "1", "--key-usage",
+			"keyCertSign", "--out", new File(tempDir, "b.pem").getPath()));
+		assertTrue(out.contains("key usage (keyCertSign)"), "stdout was: '" + out + "'");
+		assertFalse(out.contains("basic constraints"), "stdout was: '" + out + "'");
+
+		assertEquals(0, run("cert", "--subject", "CN=only-san", "--days", "1", "--san",
+			"dns:example.org", "--out", new File(tempDir, "c.pem").getPath()));
+		assertTrue(out.contains("subject alternative names (dns:example.org)"),
+			"stdout was: '" + out + "'");
+		assertFalse(out.contains("key usage"), "stdout was: '" + out + "'");
+	}
+
 	@Test
 	void theCommandAnswersItsOwnHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
@@ -26,6 +26,7 @@ package io.github.astrapi69.mystic.crypt.cli;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -435,6 +436,13 @@ class ConvertCommandTest extends AbstractCliTest
 		assertArrayEquals(Files.readAllBytes(fromPem.toPath()),
 			Files.readAllBytes(fromDer.toPath()),
 			"the DER of a certificate must not depend on how it was handed in");
+
+		// and it has to be DER rather than the armoured text handed straight through: a DER
+		// certificate begins with an ASN.1 SEQUENCE and carries no BEGIN line
+		byte[] der = Files.readAllBytes(fromPem.toPath());
+		assertEquals(0x30, der[0] & 0xff, "DER starts with a SEQUENCE tag");
+		assertFalse(new String(der, StandardCharsets.UTF_8).contains("BEGIN CERTIFICATE"),
+			"the PEM armour must be gone, not passed through");
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
@@ -390,6 +390,68 @@ class ConvertCommandTest extends AbstractCliTest
 			"the message must say the body could not be read, but was: '" + err + "'");
 	}
 
+	/**
+	 * The confirmation names the wrapping that was actually written, which is how a reader sees
+	 * that --to pem kept the input's own wrapping instead of silently changing it.
+	 */
+	@Test
+	void theConfirmationNamesTheWrappingThatWasWritten(@TempDir File tempDir) throws Exception
+	{
+		KeyPair keyPair = keyPair("RSA");
+		File pkcs8Der = writeDerPrivate(tempDir, keyPair);
+		File pkcs1Pem = new File(tempDir, "in-pkcs1.pem");
+		Files.writeString(pkcs1Pem.toPath(), KeyFileWriter.toPem(keyPair.getPrivate(), true),
+			StandardCharsets.UTF_8);
+
+		assertEquals(0, run("convert", "--in", pkcs8Der.getPath(), "--to", "pem", "--out",
+			new File(tempDir, "a.pem").getPath()));
+		assertTrue(out.contains("wrote PEM, PKCS#8"), "stdout was: '" + out + "'");
+
+		assertEquals(0, run("convert", "--in", pkcs1Pem.getPath(), "--to", "pem", "--out",
+			new File(tempDir, "b.pem").getPath()));
+		assertTrue(out.contains("wrote PEM, PKCS#1"), "stdout was: '" + out + "'");
+	}
+
+	/**
+	 * A certificate reaches the conversion from either encoding, and the bytes have to be the same
+	 * either way - otherwise one of the two paths is reading something else.
+	 */
+	@Test
+	void aCertificateGivesTheSameDerWhicheverEncodingItArrivedIn(@TempDir File tempDir)
+		throws Exception
+	{
+		File asPem = new File(tempDir, "cert.pem");
+		assertEquals(0,
+			run("cert", "--subject", "CN=either", "--days", "1", "--out", asPem.getPath()));
+		File fromPem = new File(tempDir, "from-pem.der");
+		assertEquals(0,
+			run("convert", "--in", asPem.getPath(), "--to", "der", "--out", fromPem.getPath()));
+
+		File fromDer = new File(tempDir, "from-der.der");
+		assertEquals(0,
+			run("convert", "--in", fromPem.getPath(), "--to", "der", "--out", fromDer.getPath()),
+			"stderr was: '" + err + "'");
+
+		assertArrayEquals(Files.readAllBytes(fromPem.toPath()),
+			Files.readAllBytes(fromDer.toPath()),
+			"the DER of a certificate must not depend on how it was handed in");
+	}
+
+	/**
+	 * The description names the algorithm the file carries, which is the part that tells a reader
+	 * whether they are looking at the key they think they are.
+	 */
+	@Test
+	void theDescriptionNamesTheAlgorithmOfTheKey(@TempDir File tempDir) throws Exception
+	{
+		File rsa = writeDerPrivate(tempDir, keyPair("RSA"));
+
+		assertEquals(0, run("convert", "--in", rsa.getPath(), "--describe"));
+
+		assertTrue(out.contains("algorithm 1.2.840.113549.1.1.1"),
+			"the RSA object identifier must be named, but the output was: '" + out + "'");
+	}
+
 	@Test
 	void theCommandAnswersItsOwnHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
@@ -198,6 +198,30 @@ class EncryptDecryptCommandTest extends AbstractCliTest
 			"the message must name the options, but was: '" + err + "'");
 	}
 
+	/**
+	 * Writing to a file prints a confirmation instead of the content, and it has to name both how
+	 * much was written and where, otherwise a run that wrote nothing looks the same as one that
+	 * worked.
+	 */
+	@Test
+	void writingToAFileConfirmsHowMuchWentWhere(@TempDir File tempDir) throws IOException
+	{
+		File plain = new File(tempDir, "plain.txt");
+		File encrypted = new File(tempDir, "plain.enc");
+		File back = new File(tempDir, "back.txt");
+		Files.writeString(plain.toPath(), "0123456789");
+
+		assertEquals(0,
+			run("encrypt", "-i", plain.getPath(), "-o", encrypted.getPath(), "-p", "pass"));
+		assertTrue(out.contains("encrypted 10 bytes to " + encrypted.getPath()),
+			"stdout was: '" + out + "'");
+
+		assertEquals(0,
+			run("decrypt", "-i", encrypted.getPath(), "-o", back.getPath(), "-p", "pass"));
+		assertTrue(out.contains("decrypted 10 bytes to " + back.getPath()),
+			"stdout was: '" + out + "'");
+	}
+
 	@Test
 	void bothCommandsAnswerTheirOwnHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommandTest.java
@@ -253,6 +253,53 @@ class KeyExchangeCommandTest extends AbstractCliTest
 		assertTrue(err.contains("nothing to read"), "stderr was: '" + err + "'");
 	}
 
+	/**
+	 * Each of the three runs prints what it did and where, and a run that wrote a file must say so
+	 * rather than leaving the reader to check the filesystem.
+	 */
+	@Test
+	void everyRunSaysWhatItWroteAndWhere(@TempDir File tempDir)
+	{
+		File privateKey = new File(tempDir, "recipient.key");
+		File publicKey = new File(tempDir, "recipient.pub");
+		File handshake = new File(tempDir, "handshake.txt");
+
+		assertEquals(0, run("keyx", "new", "-k", privateKey.getPath(), "-p", publicKey.getPath()));
+		assertTrue(out.contains("algorithm: " + KeyExchangeSupport.ML_KEM_768),
+			"new must name the algorithm, but was: '" + out + "'");
+		assertTrue(out.contains("private key written to " + privateKey.getPath()),
+			"new must name the private key file, but was: '" + out + "'");
+		assertTrue(out.contains("public key written to " + publicKey.getPath()),
+			"new must name the public key file, but was: '" + out + "'");
+
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath()));
+		assertTrue(out.contains("algorithm: " + KeyExchangeSupport.ML_KEM_768),
+			"send must name the algorithm, but was: '" + out + "'");
+		assertTrue(out.contains("handshake written to " + handshake.getPath()),
+			"send must name the handshake file, but was: '" + out + "'");
+
+		assertEquals(0,
+			run("keyx", "receive", "-k", privateKey.getPath(), "-s", handshake.getPath()));
+		assertTrue(out.contains("algorithm: " + KeyExchangeSupport.ML_KEM_768),
+			"receive must name the algorithm, but was: '" + out + "'");
+	}
+
+	@Test
+	void anEncryptedMessageWrittenToAFileIsAnnouncedByName(@TempDir File tempDir)
+	{
+		File privateKey = new File(tempDir, "r.key");
+		File publicKey = new File(tempDir, "r.pub");
+		File handshake = new File(tempDir, "h.txt");
+		File encrypted = new File(tempDir, "m.enc");
+		assertEquals(0, run("keyx", "new", "-k", privateKey.getPath(), "-p", publicKey.getPath()));
+
+		assertEquals(0, run("keyx", "send", "-r", publicKey.getPath(), "-o", handshake.getPath(),
+			"-m", "hello", "-e", encrypted.getPath()));
+
+		assertTrue(out.contains("encrypted message written to " + encrypted.getPath()),
+			"stdout was: '" + out + "'");
+	}
+
 	@Test
 	void everyKeyxCommandAnswersItsOwnHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenDetailsCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/KeygenDetailsCommandTest.java
@@ -190,6 +190,18 @@ class KeygenDetailsCommandTest extends AbstractCliTest
 			"stdout was: '" + out + "'");
 	}
 
+	/** The details name the encoding that was asked for, in both directions. */
+	@ParameterizedTest
+	@CsvSource({ "pkcs8, PKCS#8", "pkcs1, PKCS#1" })
+	void theDetailsNameTheEncodingThatWasAskedFor(String format, String expected,
+		@TempDir File tempDir)
+	{
+		assertEquals(0, run("keygen", "-a", "RSA", "-s", "2048", "--format", format,
+			"--print-details", "--out-private", new File(tempDir, "k.pem").getPath()));
+
+		assertTrue(out.contains("private key format: " + expected), "stdout was: '" + out + "'");
+	}
+
 	@Test
 	void theCommandAnswersItsOwnHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -153,12 +154,42 @@ class OperatedObfuscationCommandTest extends AbstractCliTest
 	 * rule that starts with the operation separator has no replacement, and one that starts with
 	 * the position separator has no operation name.
 	 */
-	@ParameterizedTest
-	@ValueSource(strings = { "a=:UPPERCASE", "a=x:@0", "a=x:UPPERCASE@" })
-	void aSeparatorWithNothingBeforeItIsRefused(String rule)
+	/**
+	 * One malformed rule and the words its message has to contain.
+	 *
+	 * @param rule
+	 *            the rule as it would be typed
+	 * @param expectedWords
+	 *            what the message must name
+	 */
+	record MalformedRuleCase(String rule, String expectedWords) {
+	}
+
+	static java.util.stream.Stream<MalformedRuleCase> malformedRuleCases()
 	{
-		assertEquals(2, run("obfuscate", "--text", "abc", "--rule", rule),
-			"'" + rule + "' must be refused, stderr was: '" + err + "'");
+		return java.util.stream.Stream.of(
+			new MalformedRuleCase("a=:UPPERCASE", "the replacement was ''"),
+			new MalformedRuleCase("a=x:@0", "'' is not an operation"),
+			new MalformedRuleCase("a=x:UPPERCASE@", "but one was ''"));
+	}
+
+	/**
+	 * The two separators are located by position, so the degenerate placements are pinned by the
+	 * part they leave empty: which part is missing is what tells the reader where the separator
+	 * went wrong, and a message that only says "refused" would be the same for all three.
+	 *
+	 * @param testCase
+	 *            the malformed rule and the words its message must contain
+	 */
+	@ParameterizedTest
+	@MethodSource("malformedRuleCases")
+	void aSeparatorWithNothingBeforeItIsRefusedByWhatIsMissing(MalformedRuleCase testCase)
+	{
+		assertEquals(2, run("obfuscate", "--text", "abc", "--rule", testCase.rule()),
+			"'" + testCase.rule() + "' must be refused, stderr was: '" + err + "'");
+
+		assertTrue(err.contains(testCase.expectedWords()), "for '" + testCase.rule()
+			+ "' the message must name the empty part, but was: '" + err + "'");
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/OperatedObfuscationCommandTest.java
@@ -148,6 +148,40 @@ class OperatedObfuscationCommandTest extends AbstractCliTest
 			"the message must list the operations, but was: '" + err + "'");
 	}
 
+	/**
+	 * The two separators are looked for by position, so the degenerate placements are pinned: a
+	 * rule that starts with the operation separator has no replacement, and one that starts with
+	 * the position separator has no operation name.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "a=:UPPERCASE", "a=x:@0", "a=x:UPPERCASE@" })
+	void aSeparatorWithNothingBeforeItIsRefused(String rule)
+	{
+		assertEquals(2, run("obfuscate", "--text", "abc", "--rule", rule),
+			"'" + rule + "' must be refused, stderr was: '" + err + "'");
+	}
+
+	/**
+	 * A position other than zero has to reach the rule, otherwise every operated rule would behave
+	 * as if it operated at the start of the text.
+	 */
+	@Test
+	void aPositionOtherThanZeroIsTheOneThatIsUsed()
+	{
+		assertEquals("xxAx", obfuscate("aaaa", "a=x:UPPERCASE@2"),
+			"only position 2 carries the operated character");
+		assertEquals("Axxx", obfuscate("aaaa", "a=x:UPPERCASE@0"),
+			"and with position 0 it is the first one instead");
+		assertEquals("aaaa", disentangle("xxAx", "a=x:UPPERCASE@2"));
+	}
+
+	@Test
+	void severalPositionsAreAllUsed()
+	{
+		assertEquals("AxAx", obfuscate("aaaa", "a=x:UPPERCASE@0,2"));
+		assertEquals("aaaa", disentangle("AxAx", "a=x:UPPERCASE@0,2"));
+	}
+
 	@Test
 	void bothCommandsExplainTheOperatedShapeInTheirHelp()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
@@ -255,6 +255,30 @@ class ShareCommandTest extends AbstractCliTest
 	}
 
 	@Test
+	void combiningIntoAFileConfirmsWhereTheSecretWent(@TempDir File tempDir) throws IOException
+	{
+		List<String> lines = splitLines(2, 2);
+		File recovered = new File(tempDir, "secret.bin");
+
+		assertEquals(0, run("share", "combine", "--share", lines.get(0), "--share", lines.get(1),
+			"-o", recovered.getPath()), "stderr was: '" + err + "'");
+
+		assertTrue(out.contains("wrote the reconstructed secret to " + recovered.getPath()),
+			"stdout was: '" + out + "'");
+		assertEquals(SECRET, Files.readString(recovered.toPath()));
+	}
+
+	@Test
+	void combiningWithoutAFilePrintsTheSecretItself()
+	{
+		List<String> lines = splitLines(2, 2);
+
+		assertEquals(0, run("share", "combine", "--share", lines.get(0), "--share", lines.get(1)));
+
+		assertEquals(SECRET, out.trim(), "without -o the secret itself is the output");
+	}
+
+	@Test
 	void everyShareCommandAnswersItsOwnHelp()
 	{
 		assertEquals(0, run("share", "--help"));

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
@@ -26,6 +26,7 @@ package io.github.astrapi69.mystic.crypt.cli;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -252,6 +253,7 @@ class ShareCommandTest extends AbstractCliTest
 			"-o", tempDir.getPath());
 
 		assertEquals(2, exitCode, "stderr was: '" + err + "'");
+		assertFalse(err.isBlank(), "a failed write has to be explained, not only counted");
 	}
 
 	@Test

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignatureSupportTest.java
@@ -111,6 +111,29 @@ class SignatureSupportTest
 			algorithm + " must be recognised as a classical signature algorithm");
 	}
 
+	/**
+	 * The key factory algorithm a classical name implies, which is what decides how the key file is
+	 * read. ECDSA and EC both mean an EC key.
+	 */
+	@ParameterizedTest
+	@CsvSource({ "RSA, RSA", "ec, EC", "ECDSA, EC", "DSA, DSA", "SHA512withRSA, RSA",
+			"SHA256withECDSA, EC" })
+	void aClassicalNameImpliesItsKeyFactoryAlgorithm(String algorithm, String expected)
+	{
+		assertEquals(expected, SignatureSupport.keyFactoryAlgorithm(algorithm));
+	}
+
+	/**
+	 * A name that begins with "with" has the separator at position zero, which is still a
+	 * separator: what follows it is the family.
+	 */
+	@Test
+	void aNameThatBeginsWithTheSeparatorStillNamesItsFamily()
+	{
+		assertTrue(SignatureSupport.isClassical("withRSA"));
+		assertEquals("RSA", SignatureSupport.keyFactoryAlgorithm("withRSA"));
+	}
+
 	@Test
 	void unknownAlgorithmNamesAreRejected()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
@@ -179,6 +179,35 @@ class KeyExchangeSupportTest
 			"the message must list the algorithms, but was: '" + rejected.getMessage() + "'");
 	}
 
+	/**
+	 * The length checks sit exactly one part away from a usable envelope, so both sides of each
+	 * boundary are pinned: three parts is enough to read an algorithm, two is not; five parts is a
+	 * complete stored key, four is not.
+	 */
+	@Test
+	void theShortestUsableEnvelopeIsAcceptedAndOnePartLessIsNot()
+	{
+		assertEquals("X25519", KeyExchangeSupport.algorithmOf("MCKX1$PUB$X25519"),
+			"three parts carry an algorithm");
+		assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.algorithmOf("MCKX1$PUB"));
+	}
+
+	@Test
+	void theShortestCompleteStoredKeyIsAcceptedAndOnePartLessIsCalledIncomplete() throws Exception
+	{
+		KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(KeyExchangeSupport.X25519);
+		String stored = KeyExchangeSupport.privateKeyOf(party);
+		assertEquals(5, stored.split("\\$").length, "an X25519 stored key has five parts");
+
+		assertEquals(KeyExchangeSupport.X25519, KeyExchangeSupport.partyFrom(stored).algorithm());
+
+		String oneShort = stored.substring(0, stored.lastIndexOf('$'));
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> KeyExchangeSupport.partyFrom(oneShort));
+		assertEquals("this stored key is incomplete", rejected.getMessage());
+	}
+
 	@Test
 	void aMessageEncryptedWithTheSharedSecretComesBackThroughIt() throws Exception
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/KeyExchangeSupportTest.java
@@ -82,11 +82,17 @@ class KeyExchangeSupportTest
 		assertEquals("this is not a stored key of this tool", rejected.getMessage());
 	}
 
-	@Test
-	void aStoredPrivateKeyMissingItsHalvesIsCalledIncomplete()
+	/**
+	 * Two parts is the least that can be read far enough to tell the kind, and that is the point of
+	 * checking the kind before the length: "MCKX1$PRV" is recognised as a stored private key that
+	 * is merely incomplete, not as something foreign.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "MCKX1$PRV", "MCKX1$PRV$X25519", "MCKX1$PRV$X25519$AAAA" })
+	void aStoredPrivateKeyMissingItsHalvesIsCalledIncomplete(String text)
 	{
 		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
-			() -> KeyExchangeSupport.partyFrom("MCKX1$PRV$X25519$AAAA"));
+			() -> KeyExchangeSupport.partyFrom(text));
 
 		assertEquals("this stored key is incomplete", rejected.getMessage());
 	}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsRoundTripTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsRoundTripTest.java
@@ -1,0 +1,174 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.obfuscation.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+import io.github.astrapi69.crypt.api.obfuscation.rule.Operation;
+import io.github.astrapi69.crypt.data.obfuscation.rule.ObfuscationOperationRule;
+
+/**
+ * Regression tests for issue #95: {@link ObfuscatorExtensions#disentangle} did not reverse what
+ * {@link ObfuscatorExtensions#obfuscateWith} produced.
+ * <p>
+ * The property under test is the only one that matters for a reversible obfuscation: whatever went
+ * in comes back out, for any text and any rule set.
+ */
+class ObfuscatorExtensionsRoundTripTest
+{
+
+	/**
+	 * Builds one rule.
+	 *
+	 * @param character
+	 *            the character the rule is for
+	 * @param replaceWith
+	 *            what replaces it
+	 * @param operation
+	 *            the operation, or null for a plain substitution
+	 * @param indexes
+	 *            the positions the operation applies at
+	 * @return the rule
+	 */
+	private static ObfuscationOperationRule<Character, Character> rule(char character,
+		char replaceWith, Operation operation, Integer... indexes)
+	{
+		Set<Integer> positions = new HashSet<>();
+		for (Integer index : indexes)
+		{
+			positions.add(index);
+		}
+		return ObfuscationOperationRule.<Character, Character> builder().character(character)
+			.replaceWith(replaceWith).operation(operation == null ? Operation.NONE : operation)
+			.indexes(positions).build();
+	}
+
+	private static BiMap<Character, ObfuscationOperationRule<Character, Character>> newRules()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', rule('a', 'x', Operation.UPPERCASE, 0));
+		rules.put('b', rule('b', 'y', null));
+		return rules;
+	}
+
+	/** The exact case from the issue: an operated rule next to a plain one. */
+	@Test
+	void theCaseFromTheIssueComesBackUnchanged()
+	{
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(newRules(), "aba");
+
+		assertEquals("Ayx", obfuscated, "the obfuscation itself was never in question");
+		assertEquals("aba", ObfuscatorExtensions.disentangle(newRules(), obfuscated),
+			"the reversal must give back what went in");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "aba", "banana", "aaa", "abab", "b", "a", "", "no rules here" })
+	void everyTextSurvivesTheRoundTrip(String text)
+	{
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(newRules(), text);
+
+		assertEquals(text, ObfuscatorExtensions.disentangle(newRules(), obfuscated),
+			"'" + text + "' became '" + obfuscated + "'");
+	}
+
+	/**
+	 * A character that no rule produced but that is itself a rule key must not disappear. The old
+	 * code appended an unmatched character only when it was not a key, which dropped it silently.
+	 */
+	@Test
+	void aCharacterThatIsARuleKeyButWasNeverProducedIsNotDropped()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		// 'a' is replaced by 'z', so a literal 'a' in the obfuscated text was never produced by
+		// this rule set and stands for itself
+		rules.put('a', rule('a', 'z', null));
+
+		assertEquals("qaq", ObfuscatorExtensions.disentangle(rules, "qaq"),
+			"a character no rule produced stands for itself, even when it is a rule key");
+	}
+
+	/**
+	 * Two rules must not both append for the same character. The old code continued through the
+	 * remaining rules after a match instead of stopping.
+	 */
+	@Test
+	void aCharacterIsReversedOnceEvenWhenSeveralRulesCouldLookAtIt()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = HashBiMap.create();
+		rules.put('a', rule('a', 'x', null));
+		rules.put('b', rule('b', 'y', null));
+		rules.put('c', rule('c', 'z', null));
+
+		assertEquals("abc", ObfuscatorExtensions.disentangle(rules, "xyz"),
+			"three characters in must be three characters out");
+	}
+
+	/**
+	 * The limitation this pins, so it is not mistaken for a defect: the scheme is only reversible
+	 * while the text contains none of the replacement characters. With {@code a -> x}, a literal
+	 * {@code x} in the text is indistinguishable from an obfuscated {@code a}, and comes back as an
+	 * {@code a}. That is inherent to a character substitution, not something the reversal can
+	 * repair, which is what {@link ObfuscatorExtensions#validate} exists to warn about for the
+	 * related case of a replacement that is itself a rule key.
+	 */
+	@Test
+	void aTextThatAlreadyContainsAReplacementCharacterCannotComeBackUnchanged()
+	{
+		String text = "mixed ab and text";
+
+		String obfuscated = ObfuscatorExtensions.obfuscateWith(newRules(), text);
+
+		assertEquals("mixed xy xnd text", obfuscated);
+		assertEquals("miaed ab and teat", ObfuscatorExtensions.disentangle(newRules(), obfuscated),
+			"the literal x characters of 'mixed' and 'text' come back as a, because nothing "
+				+ "distinguishes them from an obfuscated a");
+	}
+
+	@Test
+	void theRulesAreNotLeftCarryingStateFromTheTextTheyRead()
+	{
+		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newRules();
+
+		String first = ObfuscatorExtensions.disentangle(rules,
+			ObfuscatorExtensions.obfuscateWith(rules, "aba"));
+		String second = ObfuscatorExtensions.disentangle(rules,
+			ObfuscatorExtensions.obfuscateWith(rules, "aba"));
+
+		assertEquals(first, second,
+			"reusing the same rule objects must give the same answer twice");
+		assertEquals("aba", second);
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/obfuscation/character/ObfuscatorExtensionsTest.java
@@ -26,7 +26,6 @@ package io.github.astrapi69.mystic.crypt.obfuscation.character;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -411,15 +410,19 @@ public class ObfuscatorExtensionsTest
 
 	/**
 	 * Test method for {@link ObfuscatorExtensions#isObfuscableAndDisentanglable(BiMap, String)},
-	 * valid rules that do not round trip the given input have to be rejected as well
+	 * valid rules that do not round trip the given input have to be rejected as well.
+	 * <p>
+	 * "ca" used to be such an input and no longer is: it round trips since issue #95, and the
+	 * helper says so. What still does not round trip is a text holding a character that the rules
+	 * produce as a replacement without ever taking it as an input - a literal {@code d} is
+	 * indistinguishable from an obfuscated {@code c} and comes back as one.
 	 */
 	@Test
 	public void isObfuscableAndDisentanglable_isFalseWhenTheInputDoesNotRoundTrip()
 	{
-		// the rules themselves are valid but 'c' is obfuscated to 'd' outside of its index and 'd'
-		// is not an obfuscated character, so the text can not be disentangled again
 		assertTrue(ObfuscatorExtensions.validate(newSmallChainRules()));
-		assertFalse(ObfuscatorExtensions.isObfuscableAndDisentanglable(newSmallChainRules(), "ca"));
+		assertTrue(ObfuscatorExtensions.isObfuscableAndDisentanglable(newSmallChainRules(), "ca"));
+		assertFalse(ObfuscatorExtensions.isObfuscableAndDisentanglable(newSmallChainRules(), "d"));
 	}
 
 	/**
@@ -826,15 +829,20 @@ public class ObfuscatorExtensionsTest
 	}
 
 	/**
-	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}, a character that is
-	 * a rule key but can not be the output of the obfuscation is dropped
+	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)}: a character that is
+	 * a rule key but can not be the output of the obfuscation stands for itself.
+	 * <p>
+	 * These rules turn {@code a} into {@code x} or {@code A} and {@code b} into {@code y} or its
+	 * negation, so a literal {@code a} or {@code b} in an obfuscated text was never produced by
+	 * them. Until issue #95 it was dropped from the output entirely, which is silent data loss
+	 * rather than a wrong character.
 	 */
 	@Test
-	public void disentangle_dropsARuleCharacterThatCanNotBeAnObfuscationResult()
+	public void disentangle_keepsARuleCharacterThatCanNotBeAnObfuscationResult()
 	{
 		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newIndependentRules();
 
-		assertEquals("-", ObfuscatorExtensions.disentangle(rules, "a-b"));
+		assertEquals("a-b", ObfuscatorExtensions.disentangle(rules, "a-b"));
 		assertEquals("-", ObfuscatorExtensions.disentangle(rules, "-"));
 	}
 
@@ -908,36 +916,4 @@ public class ObfuscatorExtensionsTest
 		assertThrows(NullPointerException.class, testCase.executable());
 	}
 
-	/**
-	 * Test method for {@link ObfuscatorExtensions#disentangle(BiMap, String)} that pins the side
-	 * effect of the {@code operation != null} branch: while disentangling, every rule that carries
-	 * a non-null operation has its operated character computed and stored on the rule via
-	 * {@code setOperatedCharacter}. This kills the negated-conditional mutant of the
-	 * {@code if (operation != null)} guard and the removed-call mutant of
-	 * {@code setOperatedCharacter} - both would leave the operated character unset.
-	 */
-	@Test
-	public void disentangle_setsTheOperatedCharacterOnEveryRuleWithAnOperation()
-	{
-		BiMap<Character, ObfuscationOperationRule<Character, Character>> rules = newSmallChainRules();
-
-		// before disentangling, no rule has had its operated character computed
-		for (ObfuscationOperationRule<Character, Character> rule : rules.values())
-		{
-			assertTrue(
-				rule.getOperatedCharacter() == null || !rule.getOperatedCharacter().isPresent());
-		}
-
-		ObfuscatorExtensions.disentangle(rules, "abc");
-
-		// afterwards every rule (all carry the UPPERCASE operation) has a present operated
-		// character
-		for (ObfuscationOperationRule<Character, Character> rule : rules.values())
-		{
-			Optional<Character> operated = rule.getOperatedCharacter();
-			assertNotNull(operated, "operated character must be set for a rule with an operation");
-			assertTrue(operated.isPresent(),
-				"operated character must be present for a rule with an operation");
-		}
-	}
 }

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptorTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/PassphraseCryptorTest.java
@@ -194,6 +194,60 @@ class PassphraseCryptorTest
 	}
 
 	@Test
+	void decryptClearsThePassphraseOnBothPaths()
+	{
+		byte[] encrypted = PassphraseCryptor.encrypt(passphrase("right"),
+			"payload".getBytes(StandardCharsets.UTF_8));
+
+		char[] onSuccess = passphrase("right");
+		PassphraseCryptor.decrypt(onSuccess, encrypted);
+		assertArrayEquals(new char[onSuccess.length], onSuccess,
+			"decrypt must zero the passphrase after a successful open");
+
+		char[] onFailure = passphrase("wrong");
+		assertThrows(SecurityException.class,
+			() -> PassphraseCryptor.decrypt(onFailure, encrypted));
+		assertArrayEquals(new char[onFailure.length], onFailure,
+			"and after a failed one, which is when it matters most");
+	}
+
+	/**
+	 * The iteration count can only be read out of this format, and says so when asked otherwise.
+	 */
+	@Test
+	void theIterationCountCannotBeReadFromSomethingThatIsNotThisFormat()
+	{
+		byte[] foreign = "not encrypted by this tool".getBytes(StandardCharsets.UTF_8);
+
+		IllegalArgumentException rejected = assertThrows(IllegalArgumentException.class,
+			() -> PassphraseCryptor.iterationsOf(foreign));
+
+		assertTrue(rejected.getMessage().contains("marker"),
+			"the message was: '" + rejected.getMessage() + "'");
+	}
+
+	/**
+	 * The header length is the boundary between "too short to even look at" and "long enough to
+	 * check", so both sides of it are pinned rather than only one.
+	 */
+	@Test
+	void oneByteShortOfAHeaderIsNotEncryptedAndExactlyAHeaderIsLookedAt()
+	{
+		byte[] oneShort = new byte[PassphraseCryptor.HEADER_LENGTH - 1];
+		System.arraycopy(PassphraseCryptor.MAGIC, 0, oneShort, 0, PassphraseCryptor.MAGIC.length);
+		oneShort[PassphraseCryptor.MAGIC.length] = PassphraseCryptor.FORMAT_VERSION;
+
+		byte[] exactly = new byte[PassphraseCryptor.HEADER_LENGTH];
+		System.arraycopy(PassphraseCryptor.MAGIC, 0, exactly, 0, PassphraseCryptor.MAGIC.length);
+		exactly[PassphraseCryptor.MAGIC.length] = PassphraseCryptor.FORMAT_VERSION;
+
+		assertFalse(PassphraseCryptor.isEncrypted(oneShort),
+			"one byte short of a header cannot carry one");
+		assertTrue(PassphraseCryptor.isEncrypted(exactly),
+			"exactly a header is a header, even with no payload behind it");
+	}
+
+	@Test
 	void thePassphraseArrayIsClearedSoItCannotLingerInMemory()
 	{
 		char[] toEncrypt = passphrase("wipe me");

--- a/src/test/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupportTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/pw/ScryptSupportTest.java
@@ -121,6 +121,57 @@ class ScryptSupportTest
 			"verify must zero the password it was given");
 	}
 
+	/**
+	 * Each of the three cost parameters has a lowest value that is still valid, and the check has
+	 * to accept it rather than treat it as one step too far. A hash built at those values verifies,
+	 * which is the only way to tell the boundary was not moved.
+	 */
+	@Test
+	void theLowestValidCostParametersAreAccepted()
+	{
+		String atTheFloor = ScryptSupport.hash("floor".toCharArray())
+			.replaceFirst("\\$scrypt\\$[^$]+\\$", "\\$scrypt\\$ln=1,r=1,p=1\\$");
+
+		// the hash bytes no longer match, so this must be a clean "does not match" rather than an
+		// exception out of the hasher, which is what an out-of-range parameter would cause
+		assertFalse(ScryptSupport.verify("floor".toCharArray(), atTheFloor));
+
+		String justBelow = atTheFloor.replace("ln=1,", "ln=0,");
+		assertFalse(ScryptSupport.verify("floor".toCharArray(), justBelow));
+	}
+
+	@Test
+	void aHashBuiltAtTheLowestCostStillVerifies()
+	{
+		// built through the real hasher at ln=1, r=1, p=1 so the round trip proves those values are
+		// inside the accepted range and not one step outside it
+		byte[] salt = new byte[ScryptSupport.SALT_LENGTH];
+		byte[] hash = io.github.astrapi69.mystic.crypt.sha.ScryptHasher
+			.hashWithSalt("floor".toCharArray(), salt, 2, 1, 1, ScryptSupport.HASH_LENGTH);
+		java.util.Base64.Encoder encoder = java.util.Base64.getEncoder().withoutPadding();
+		String encoded = ScryptSupport.PREFIX + "ln=1,r=1,p=1$" + encoder.encodeToString(salt) + "$"
+			+ encoder.encodeToString(hash);
+
+		assertTrue(ScryptSupport.verify("floor".toCharArray(), encoded),
+			"ln=1, r=1 and p=1 are the lowest valid values and must be accepted");
+		assertFalse(ScryptSupport.verify("wrong".toCharArray(), encoded));
+	}
+
+	/**
+	 * A cost that is well formed but far beyond what any machine can allocate must still answer
+	 * "does not match" rather than throwing out of the hasher, because that is what verify promises
+	 * for a hash it cannot open.
+	 */
+	@Test
+	void aCostTooLargeToRunAnswersFalseRatherThanThrowing()
+	{
+		String template = ScryptSupport.hash("x".toCharArray());
+		String absurdButWellFormed = template.replaceFirst("\\$scrypt\\$[^$]+\\$",
+			"\\$scrypt\\$ln=30,r=8,p=1\\$");
+
+		assertFalse(ScryptSupport.verify("x".toCharArray(), absurdButWellFormed));
+	}
+
 	@Test
 	void anEncodingOfNoKnownAlgorithmIsNamedWithTheOnesThatAre()
 	{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactoryTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/ssl/SelfSignedCertificateFactoryTest.java
@@ -104,6 +104,20 @@ class SelfSignedCertificateFactoryTest
 			"the message must show what one looks like, but was: '" + rejected.getMessage() + "'");
 	}
 
+	/**
+	 * The colon has to sit at position one at the earliest - a one character type is still a type -
+	 * and the value after it must not be empty.
+	 */
+	@Test
+	void aOneCharacterTypeIsStillAType()
+	{
+		SelfSignedCertificateFactory.SubjectAlternativeName name = SelfSignedCertificateFactory.SubjectAlternativeName
+			.parse("d:x");
+
+		assertEquals("d", name.type());
+		assertEquals("x", name.value());
+	}
+
 	@Test
 	void anUnknownKeyUsageIsNamedWithTheOnesThatExist()
 	{


### PR DESCRIPTION
The three things that stood between the command line work and a release, closed. Measured on `01b143b4`: **1234 tests, 0 failures, 99.94% line and 100% branch coverage, PIT mutation score 99.6% (1498 of 1504)**.

## Blocker 1: the mutation round

The command line work added roughly four hundred mutants that PIT had never seen. 35 of them survived at first; the score had fallen from 99.5% to 97.4%.

| pass | score | new survivors |
|---|---|---|
| before | 97.38% | 35 |
| after removing redundancy and asserting output | 98.14% | 23 |
| after the boundary and return-value tests | 98.74% | 14 |
| after sharpening the assertions a mutant slipped past | 99.53% | 5 |
| final | **99.60%** | **1** |

Four of the 35 wanted no test at all - they pointed at code that decided the same thing twice, wiped an array something else already wipes, or guarded a range the guard below it already covered. That half of a mutation report is the more useful one and it is where the diff shrinks rather than grows.

The one survivor that stays is `PassphraseCryptor`'s wipe of the derived key bytes: `SecretKeySpec` copies what it is handed, so no API can observe whether the caller's copy was zeroed. The wipe stays and `COVERAGE_EXCEPTIONS.md` argues why, rather than exposing the array through an accessor so a test could look at it.

## Blocker 2: a regression the mutation work found

Writing a test for a surviving conditional in `cert` turned up something worse than a mutant. `SelfSignedCertificateFactory` named Bouncy Castle for the content signer unconditionally, and an ML-DSA key comes from the JDK's own provider since JDK 24, so Bouncy Castle refused it with `unknown private key passed to ML-DSA`. The factory it replaced could certify such a key, and no test covered it.

Bouncy Castle is now preferred and no longer insisted on - it is still the provider that has to sign an elliptic curve key on a named curve. A parameterized test certifies ML-DSA, EC and DSA keys through the real command line.

## Blocker 3: the broken operated reversal, repaired (#95)

`ObfuscatorExtensions.disentangle` did not undo `obfuscateWith`. Three defects in one loop:

- the match on a replacement required `&& rules.containsKey(replaceWith)`, the **same** spurious condition removed from `SimpleObfuscatorExtensions.disentangle` earlier and recorded in `TESTING.md`; the operated variant kept it
- an unmatched character was appended only when it was not itself a rule key, so `"qaq"` came back as `"qq"` - silent data loss, not a wrong character
- a match continued through the remaining rules instead of stopping

Three existing tests asserted that behaviour and were rewritten rather than deleted: one was named after the dropped character, one pinned that a text "can not be disentangled again" which it now can, and one existed purely to kill mutants by pinning the state pollution the fix removes. The workaround in `ObfuscationRuleSupport` is gone and the command calls the library again.

`disentangleImproved` is **deprecated rather than repaired**, and that was tried first. It reverses through `inverse(BiMap)`, which clones the rule map and throws `NullPointerException` for a map it cannot clone - an existing test pins that. Making the clone optional makes it worse: `inverse` then inverts the caller's own rules in place, so every later call with them answers wrongly, which a probe confirmed. Repairing it means changing what `inverse` may do to its argument, a change of its own.

## Blocker 4: the changelog

There was no section for anything since 11.2. It now covers the rule set adoption, the badge workflow, the crypt-data 12.0.0 bump and the whole command line expansion, including the two breaking command line changes: `verify` losing `--algorithm`, and `checksum` naming which of the two questions it answered.

The version is written as **12.0.0** per the assessment - the CLI is a published contract that the UI backlinks into, and `verify --algorithm` is gone. If you would rather ship this as 11.3 that is a one-line change to the header, with the break staying where it is at the top of the entry.

## Still yours to decide

The version number above, and the release itself. 32 versions of this family went to Central in August; crypt-data 12.0.0 went out this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)