### PR TITLE
chore: open 12.1-SNAPSHOT for the next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Change log
 ----------------------
 
+Version 12.1-SNAPSHOT
+-------------
+
+(nothing released yet)
+
+
 Version 12.0.0
 -------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ######################
 # project properties #
 ######################
-projectVersion=12.0.0
+projectVersion=12.1-SNAPSHOT
 groupPackage=io.github.astrapi69
 projectSourceCompatibility=25
 projectInceptionYear=2015


### PR DESCRIPTION
12.0.0 is on Maven Central: `repo1` serves the POM (HTTP 200) and `maven-metadata.xml` names it as both `<latest>` and `<release>`. So `develop` moves on to `12.1-SNAPSHOT`, with a fresh changelog section above the released one.

The version is not only bookkeeping here. `gradle.yml` publishes a snapshot on every push to `develop`, and it only does that for a `-SNAPSHOT` version - while `develop` sat at `12.0.0` it published nothing at all and said so in the log. This restores that.

`./gradlew clean build` green: 1234 tests, 0 failures.

## Where the family stands

| Repo | Released | develop |
|---|---|---|
| `crypt-api` | 10.1 | 10.2-SNAPSHOT, only build hygiene since |
| `crypt-data` | 12.0.0 | 12.1-SNAPSHOT |
| `mystic-crypt` | **12.0.0** | 12.1-SNAPSHOT after this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)