### PR TITLE
test(key): drive every post quantum parameter set, not one or two each

### DIFF
--- a/docs/COVERAGE_EXCEPTIONS.md
+++ b/docs/COVERAGE_EXCEPTIONS.md
@@ -17,10 +17,10 @@ check found.
 
 Nothing. Every line, branch and mutant. 78 mutants generated, 78 killed.
 
-## `crypt-data` - 0 lines / 0 branches uncovered; 0 surviving mutants of 779
+## `crypt-data` - 0 lines / 0 branches uncovered; 0 surviving mutants of 820
 
 Every line and branch is covered; no JaCoCo exclusions were added to get there. Nothing survives
-either: 779 mutants generated, 779 killed.
+either: 820 mutants generated, 820 killed.
 
 The three mutants that used to survive here were cleared in PR #8, and two of them only because
 the reasoning that had retired them was re-read rather than re-quoted:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,8 +89,8 @@ code the tests do run, how much would they notice being broken?".
 | Repo | Measured on | Tests | Line | Branch | Mutation score (killed / generated) | Test strength |
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
-| `crypt-data` | `2374c66` (PR #8) | 1019 | 100.00% | 100.00% | 100.0% (779 / 779) | 100.0% |
-| `mystic-crypt` | `01b143b4` (PR #96) | 1234 | 99.94% | 100.00% | 99.6% (1498 / 1504) | 99.6% |
+| `crypt-data` | `991aa47` (develop, after PR #30) | 1294 | 100.00% | 100.00% | 100.0% (820 / 820) | 100.0% |
+| `mystic-crypt` | `04ea8a59` (PR #102) | 1249 | 99.94% | 100.00% | 99.6% (1498 / 1504) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.

--- a/src/test/java/io/github/astrapi69/mystic/crypt/key/PqcVariantParityTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/key/PqcVariantParityTest.java
@@ -1,0 +1,208 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.key;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.util.Arrays;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.github.astrapi69.crypt.api.algorithm.key.KeyPairGeneratorAlgorithm;
+import io.github.astrapi69.mystic.crypt.provider.SecurityProviderSupport;
+
+/**
+ * Parity tests across the post quantum parameter sets: every variant a signer accepts has to sign
+ * something its own verifier accepts and nothing else does, and every variant of the key
+ * encapsulation has to arrive at the same secret on both sides.
+ * <p>
+ * The pair tests next to this one drive one or two variants each - ML-DSA at 44 and 65, SLH-DSA at
+ * the two 128S sets, ML-KEM at 768. A parameter set is chosen by a caller though, so a variant that
+ * was wired to the wrong parameters would pass every one of them.
+ * <p>
+ * The signature length is asserted against the value FIPS 204 and FIPS 205 give for that parameter
+ * set, which is what makes these tests worth more than "nothing was thrown": a variant wired to
+ * another one's parameters signs perfectly well, only at the wrong size.
+ */
+class PqcVariantParityTest
+{
+
+	private static final byte[] PAYLOAD = "the message under test".getBytes();
+
+	@BeforeAll
+	static void setUp()
+	{
+		SecurityProviderSupport.ensureBouncyCastle();
+	}
+
+	/**
+	 * Every ML-DSA parameter set signs, verifies, refuses a tampered signature and a foreign key,
+	 * and produces a signature of the length FIPS 204 gives for it.
+	 *
+	 * @param algorithm
+	 *            the parameter set under test
+	 * @param expectedSignatureLength
+	 *            the signature length FIPS 204 gives for that parameter set
+	 * @throws Exception
+	 *             if key generation, signing or verifying fails
+	 */
+	@ParameterizedTest
+	@CsvSource({ "ML_DSA_44, 2420", "ML_DSA_65, 3309", "ML_DSA_87, 4627" })
+	void everyMlDsaParameterSetSignsAndVerifiesAtItsOwnLength(
+		final KeyPairGeneratorAlgorithm algorithm, final int expectedSignatureLength)
+		throws Exception
+	{
+		KeyPair keyPair = MlDsaSigner.newKeyPair(algorithm);
+		KeyPair foreignKeyPair = MlDsaSigner.newKeyPair(algorithm);
+
+		byte[] signature = new MlDsaSigner(keyPair.getPrivate(), algorithm).sign(PAYLOAD);
+
+		assertEquals(expectedSignatureLength, signature.length,
+			algorithm + " must sign at the length FIPS 204 gives for it");
+		assertTrue(new MlDsaVerifier(keyPair.getPublic(), algorithm).verify(PAYLOAD, signature),
+			algorithm + " must verify what it signed");
+		assertFalse(
+			new MlDsaVerifier(foreignKeyPair.getPublic(), algorithm).verify(PAYLOAD, signature),
+			algorithm + " must not verify a signature made with another key");
+		assertFalse(
+			new MlDsaVerifier(keyPair.getPublic(), algorithm).verify(PAYLOAD, tampered(signature)),
+			algorithm + " must not verify a tampered signature");
+	}
+
+	/**
+	 * The same for SLH-DSA. The four slow parameter sets are left out, see
+	 * {@link #slhDsaParameterSetsNotCovered()}.
+	 *
+	 * @param algorithm
+	 *            the parameter set under test
+	 * @param expectedSignatureLength
+	 *            the signature length FIPS 205 gives for that parameter set
+	 * @throws Exception
+	 *             if key generation, signing or verifying fails
+	 */
+	@ParameterizedTest
+	@CsvSource({ "SLH_DSA_SHA2_128S, 7856", "SLH_DSA_SHAKE_128S, 7856", "SLH_DSA_SHA2_128F, 17088",
+			"SLH_DSA_SHAKE_128F, 17088", "SLH_DSA_SHA2_192F, 35664", "SLH_DSA_SHAKE_192F, 35664",
+			"SLH_DSA_SHA2_256F, 49856", "SLH_DSA_SHAKE_256F, 49856" })
+	void everySlhDsaParameterSetSignsAndVerifiesAtItsOwnLength(
+		final KeyPairGeneratorAlgorithm algorithm, final int expectedSignatureLength)
+		throws Exception
+	{
+		KeyPair keyPair = SlhDsaSigner.newKeyPair(algorithm);
+
+		byte[] signature = new SlhDsaSigner(keyPair.getPrivate(), algorithm).sign(PAYLOAD);
+
+		assertEquals(expectedSignatureLength, signature.length,
+			algorithm + " must sign at the length FIPS 205 gives for it");
+		assertTrue(new SlhDsaVerifier(keyPair.getPublic(), algorithm).verify(PAYLOAD, signature),
+			algorithm + " must verify what it signed");
+		assertFalse(
+			new SlhDsaVerifier(keyPair.getPublic(), algorithm).verify(PAYLOAD, tampered(signature)),
+			algorithm + " must not verify a tampered signature");
+	}
+
+	/**
+	 * The four SLH-DSA parameter sets this class does not drive, named rather than silently absent.
+	 * <p>
+	 * SLH_DSA_SHA2_192S, SLH_DSA_SHA2_256S, SLH_DSA_SHAKE_192S and SLH_DSA_SHAKE_256S take between
+	 * 1.5 and 1.8 seconds each to sign once, measured on this machine, against 43 to 146
+	 * milliseconds for the F sets of the same sizes - the S sets buy a smaller signature with
+	 * signing time. Adding the four would put about 6.5 seconds on a suite that runs in 38, for
+	 * parameter sets that share their code path with the 128S sets driven above. They were
+	 * exercised once by hand and verified at 16224 and 29792 bytes.
+	 * <p>
+	 * This test asserts that the list of what is left out is exactly those four, so a new parameter
+	 * set cannot slip past unnoticed.
+	 */
+	@org.junit.jupiter.api.Test
+	void slhDsaParameterSetsNotCovered()
+	{
+		java.util.Set<String> driven = java.util.Set.of("SLH_DSA_SHA2_128S", "SLH_DSA_SHAKE_128S",
+			"SLH_DSA_SHA2_128F", "SLH_DSA_SHAKE_128F", "SLH_DSA_SHA2_192F", "SLH_DSA_SHAKE_192F",
+			"SLH_DSA_SHA2_256F", "SLH_DSA_SHAKE_256F");
+		java.util.List<String> notDriven = Arrays.stream(KeyPairGeneratorAlgorithm.values())
+			.map(Enum::name).filter(name -> name.startsWith("SLH_DSA"))
+			.filter(name -> !driven.contains(name)).sorted().toList();
+
+		assertEquals(
+			java.util.List.of("SLH_DSA_SHA2_192S", "SLH_DSA_SHA2_256S", "SLH_DSA_SHAKE_192S",
+				"SLH_DSA_SHAKE_256S"),
+			notDriven,
+			"exactly the four slow parameter sets are left out; a new one must be added above "
+				+ "rather than quietly join this list");
+	}
+
+	/**
+	 * Every ML-KEM parameter set arrives at the same secret on both sides, and a foreign key does
+	 * not arrive at it. ML-KEM answers a wrong key with a different secret rather than an error,
+	 * which is what implicit rejection means, so the assertion is on the secrets and not on a
+	 * throw.
+	 *
+	 * @param algorithm
+	 *            the parameter set under test
+	 * @throws Exception
+	 *             if key generation, encapsulating or decapsulating fails
+	 */
+	@ParameterizedTest
+	@EnumSource(value = KeyPairGeneratorAlgorithm.class, names = { "ML_KEM_512", "ML_KEM_768",
+			"ML_KEM_1024" })
+	void everyMlKemParameterSetArrivesAtTheSameSecret(final KeyPairGeneratorAlgorithm algorithm)
+		throws Exception
+	{
+		KeyPair keyPair = MlKemKeyExchange.newKeyPair(algorithm);
+		KeyPair foreignKeyPair = MlKemKeyExchange.newKeyPair(algorithm);
+
+		MlKemKeyExchange.Encapsulation encapsulation = MlKemKeyExchange
+			.encapsulate(keyPair.getPublic(), algorithm);
+		SecretKey opened = MlKemKeyExchange.decapsulate(keyPair.getPrivate(),
+			encapsulation.getCiphertext(), algorithm);
+
+		assertArrayEquals(encapsulation.getSharedSecret().getEncoded(), opened.getEncoded(),
+			algorithm + " must arrive at the same secret on both sides");
+
+		SecretKey openedWithAForeignKey = MlKemKeyExchange.decapsulate(foreignKeyPair.getPrivate(),
+			encapsulation.getCiphertext(), algorithm);
+		assertFalse(
+			Arrays.equals(encapsulation.getSharedSecret().getEncoded(),
+				openedWithAForeignKey.getEncoded()),
+			algorithm + " must not arrive at the secret with a key it was not meant for");
+	}
+
+	private static byte[] tampered(final byte[] signature)
+	{
+		byte[] changed = signature.clone();
+		changed[changed.length / 2] ^= 0x01;
+		return changed;
+	}
+}


### PR DESCRIPTION
The parity survey that found #23, #24, #25 and #28 in `crypt-data`, pointed at this repository.

**It found no defect here.** The writer/reader, signer/verifier and key-exchange pairs hold across every algorithm and parameter set: seven key algorithms round-trip through `KeyFileWriter`/`KeyFileReader` in DER and PEM, all three ML-KEM sets arrive at the same secret on both sides, all fifteen ML-DSA and SLH-DSA sets sign and verify and refuse tampering. That is a checked result, not an absence of looking.

What it found is a gap in what is *asserted* about them.

## The gap

The pair tests drive one or two parameter sets each:

| test | drives | of |
|---|---|---|
| `MlDsaSignerVerifierTest` | 44, 65 | 3 |
| `SlhDsaSignerVerifierTest` | SHA2_128S, SHAKE_128S | 12 |
| `MlKemKeyExchangeTest` | 768 | 3 |

The parameter set is chosen by the caller, so a variant wired to another one's parameters would pass every one of those tests. It would sign and verify perfectly well - at the wrong size.

## So the size is what is asserted

Against the value FIPS 204 and FIPS 205 give for each set:

```
ML_DSA_44   2420    SLH_DSA_*_128S   7856    SLH_DSA_*_192F  35664
ML_DSA_65   3309    SLH_DSA_*_128F  17088    SLH_DSA_*_256F  49856
ML_DSA_87   4627
```

Alongside it: a tampered signature is refused, and for ML-DSA a signature made with another key is refused too - which none of the post-quantum pair tests checked. ML-KEM is checked on both sides and against a foreign key, which answers with a *different secret* rather than an error (implicit rejection), so the assertion is on the secrets and not on a throw.

## Four parameter sets are left out, and the class says so

Measured on this machine, signing once:

```
SLH_DSA_SHA2_192S   1826 ms      SLH_DSA_SHA2_192F     73 ms
SLH_DSA_SHA2_256S   1512 ms      SLH_DSA_SHA2_256F    146 ms
SLH_DSA_SHAKE_192S  1760 ms      SLH_DSA_SHAKE_192F    72 ms
SLH_DSA_SHAKE_256S  1465 ms      SLH_DSA_SHAKE_256F   144 ms
```

The S sets buy a smaller signature with signing time. All four would put about 6.5 seconds on a suite that runs in 38, for sets that share their code path with the 128S sets that *are* driven. They were exercised once by hand and came out at 16224 and 29792 bytes as specified.

A test asserts that the list of what is left out is **exactly those four**, so a parameter set added later cannot quietly join it.

## Found on the way: issue #101

A file named `-` appeared in the repository root during `./gradlew pitest`. It does not appear in a normal test run - a mutant had removed `SignCommand`'s guard against `--signature -`. Chasing it turned up that `SignCommand` is the only command that guards its output path:

```
encrypt --out -           exit=0   file '-' created, 110 bytes
keygen --out-private -    exit=0   file '-' created, 1704 bytes
```

1704 bytes at `--out-private` is a private key, on disk, where the user meant a pipe. Filed as #101, not fixed here.

## Docs

`docs/TESTING.md` carries the canonical numbers, so its table is updated in the same change - and the `crypt-data` row with it, which today's five fixes there had made stale. Both re-measured rather than remembered:

| Repo | Measured on | Tests | Line | Branch | Mutation |
|---|---|---|---|---|---|
| `crypt-data` | `991aa47` | 1294 | 100.00% | 100.00% | 820 / 820 |
| `mystic-crypt` | `04ea8a59` | 1249 | 99.94% | 100.00% | 1498 / 1504 |

`docs/COVERAGE_EXCEPTIONS.md` said `crypt-data` had 779 mutants; it has 820 now, still none surviving.

## Measured on 04ea8a59

- 1249 tests, 0 failures (was 1234)
- 99.94% line, 100.00% branch - the two uncovered lines are the documented `MysticCryptCli.main` pair
- pitest 1498 / 1504, unchanged, as it should be for tests that add no production code
