### PR TITLE
fix(cli): refuse a dash where a path to write to is wanted (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@
 Version 12.1-SNAPSHOT
 -------------
 
-(nothing released yet)
+FIXED:
+
+- Every command that writes to a file refused nothing when handed '-' as the path: a file literally
+  called '-' appeared in the working directory, the command reported success, and the bytes the
+  caller expected in a pipe were on disk instead. For 'keygen --out-private' those bytes are a
+  private key. The input side reads standard input from '-', which is where the expectation comes
+  from, and standard output is already reachable on the output side by leaving the option out - so
+  '-' is refused now rather than given a second meaning. 'sign --signature' had guarded itself from
+  the start; that guard moved to CliSupport and is used by all twelve output options. (#101)
+
+CHANGED:
+
+- The message 'sign --signature -' answers with is the shared one now. It names the option and says
+  what would have happened, where it used to say only that standard output is not supported. (#101)
 
 
 Version 12.0.0

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,7 +90,7 @@ code the tests do run, how much would they notice being broken?".
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
 | `crypt-data` | `991aa47` (develop, after PR #30) | 1294 | 100.00% | 100.00% | 100.0% (820 / 820) | 100.0% |
-| `mystic-crypt` | `04ea8a59` (PR #102) | 1249 | 99.94% | 100.00% | 99.6% (1498 / 1504) | 99.6% |
+| `mystic-crypt` | `10ef5fd5` (PR #103) | 1261 | 99.94% | 100.00% | 99.6% (1511 / 1517) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
@@ -170,6 +170,40 @@ final class CliSupport
 	}
 
 	/**
+	 * Refuses {@code -} where a path to write to is wanted
+	 * <p>
+	 * The input side reads standard input from {@code -}, so a caller who learned that convention
+	 * reaches for it on the output side too. There it is a plain file name: a file called {@code -}
+	 * appears in the working directory, the command reports success, and the bytes the caller
+	 * expected in a pipe are on disk instead - a private key among them, for
+	 * {@code keygen --out-private}. Standard output is reachable on this side as well, by leaving
+	 * the option out, so the dash is refused rather than given a second meaning (issue #101).
+	 *
+	 * @param file
+	 *            the value of the output option, may be null when the option was left out
+	 * @param option
+	 *            the name of the option, for the message
+	 * @param hint
+	 *            what the caller should do instead, for the message
+	 * @throws IllegalArgumentException
+	 *             if the given file is the dash
+	 */
+	static void refuseDashAsPath(final File file, final String option, final String hint)
+	{
+		if (file != null && "-".equals(file.getPath()))
+		{
+			throw new IllegalArgumentException("'-' is not a file name for " + option
+				+ "; it would create a file called '-' in the working directory. " + hint);
+		}
+	}
+
+	/** What to tell a caller whose output option may simply be left out. */
+	static final String LEAVE_IT_OUT = "Leave the option out to write to standard output.";
+
+	/** What to tell a caller whose output option is required. */
+	static final String PASS_A_PATH = "Pass a real file path.";
+
+	/**
 	 * Reads the bytes to process from the given file, or from standard input when the file is the
 	 * conventional {@code -}.
 	 *

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
@@ -91,6 +91,7 @@ public class ConvertCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
+		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			KeyFileDescription description = KeyFileDescription.of(in);

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
@@ -81,6 +81,7 @@ public class DecryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
+		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
@@ -76,6 +76,7 @@ public class EncryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
+		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeyExchangeCommand.java
@@ -124,6 +124,7 @@ public class KeyExchangeCommand implements Runnable
 		@Override
 		public Integer call()
 		{
+			CliSupport.refuseDashAsPath(key, "--key", CliSupport.PASS_A_PATH);
 			try
 			{
 				KeyExchangeSupport.Party party = KeyExchangeSupport.newParty(algorithm);
@@ -182,6 +183,8 @@ public class KeyExchangeCommand implements Runnable
 		@Override
 		public Integer call()
 		{
+			CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
+			CliSupport.refuseDashAsPath(encrypted, "--encrypted", CliSupport.LEAVE_IT_OUT);
 			try
 			{
 				String publicKey = readEnvelope(recipient);
@@ -240,6 +243,7 @@ public class KeyExchangeCommand implements Runnable
 		@Override
 		public Integer call()
 		{
+			CliSupport.refuseDashAsPath(encrypted, "--encrypted", CliSupport.LEAVE_IT_OUT);
 			try
 			{
 				KeyExchangeSupport.Party party = KeyExchangeSupport.partyFrom(readEnvelope(key));

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/KeygenCommand.java
@@ -108,6 +108,8 @@ public class KeygenCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
+		CliSupport.refuseDashAsPath(outPrivate, "--out-private", CliSupport.LEAVE_IT_OUT);
+		CliSupport.refuseDashAsPath(outPublic, "--out-public", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			KeyPair keyPair = generate();

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
@@ -106,6 +106,7 @@ public class ShareCommand implements Runnable
 		@Override
 		public Integer call()
 		{
+			CliSupport.refuseDashAsPath(out, "--out", CliSupport.PASS_A_PATH);
 			try
 			{
 				byte[] secretBytes = readSecret();
@@ -185,6 +186,7 @@ public class ShareCommand implements Runnable
 		@Override
 		public Integer call()
 		{
+			CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 			// the two phases are kept apart because they answer different questions: reading the
 			// shares can fail before there is anything to reconstruct (exit 2), while combining
 			// them can succeed as an operation and still not produce a secret (exit 1)

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/SignCommand.java
@@ -78,14 +78,9 @@ public class SignCommand implements Callable<Integer>
 	@Override
 	public Integer call() throws Exception
 	{
-		if ("-".equals(signature.getPath()))
-		{
-			// without this guard a file literally named '-' would silently appear in the working
-			// directory - surprising for users who learned the '-' convention from --in
-			throw new IllegalArgumentException(
-				"writing the signature to standard output is not supported; pass a file path "
-					+ "for --signature");
-		}
+		// this command guarded its output path from the start; the guard lives in CliSupport now,
+		// because every other command needed the same one (issue #101)
+		CliSupport.refuseDashAsPath(signature, "--signature", CliSupport.PASS_A_PATH);
 		String keyFactoryAlgorithm = SignatureSupport.keyFactoryAlgorithm(algorithm);
 		byte[] data = CliSupport.readData(in);
 		PrivateKey privateKey = readPrivateKey(keyFactoryAlgorithm);

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/DashAsOutputPathTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/DashAsOutputPathTest.java
@@ -1,0 +1,189 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for issue #101: an output option took {@code -} as a file name, so a file
+ * literally called {@code -} appeared in the working directory while the caller believed the bytes
+ * had gone to standard output.
+ * <p>
+ * The input side teaches that convention - {@code --in -} reads standard input - and standard
+ * output is already reachable on the output side by leaving the option out, which is what the
+ * commands that support it document. So {@code -} as an output path is not a missing feature but a
+ * name that shadows a working one, and every command refuses it the way {@code sign} already did.
+ */
+class DashAsOutputPathTest extends AbstractCliTest
+{
+
+	/**
+	 * Runs the given command line and asserts that it refused, said which option was at fault, and
+	 * left no file behind.
+	 *
+	 * @param option
+	 *            the option whose value was the dash, which the message has to name
+	 * @param args
+	 *            the command line to run
+	 */
+	private void assertTheDashIsRefused(final String option, final String... args)
+	{
+		File dashInTheWorkingDirectory = new File("-");
+		dashInTheWorkingDirectory.delete();
+
+		int exitCode = run(args);
+
+		assertNotEquals(0, exitCode,
+			option + " must not report success for a dash, but the output was: " + out);
+		assertFalse(dashInTheWorkingDirectory.exists(),
+			option + " must not leave a file named '-' in the working directory");
+		assertTrue(String.valueOf(err).contains(option),
+			"the message must name " + option + ", but was: " + err);
+		dashInTheWorkingDirectory.delete();
+	}
+
+	@Test
+	void encryptRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
+	{
+		File plain = new File(tempDir, "plain.txt");
+		Files.writeString(plain.toPath(), "some content");
+
+		assertTheDashIsRefused("--out", "encrypt", "--in", plain.getAbsolutePath(), "--out", "-",
+			"--passphrase", "secret");
+	}
+
+	@Test
+	void decryptRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
+	{
+		File plain = new File(tempDir, "plain.txt");
+		Files.writeString(plain.toPath(), "some content");
+		File encrypted = new File(tempDir, "encrypted.bin");
+		run("encrypt", "--in", plain.getAbsolutePath(), "--out", encrypted.getAbsolutePath(),
+			"--passphrase", "secret");
+
+		assertTheDashIsRefused("--out", "decrypt", "--in", encrypted.getAbsolutePath(), "--out",
+			"-", "--passphrase", "secret");
+	}
+
+	@Test
+	void keygenRefusesADashForThePrivateKey()
+	{
+		assertTheDashIsRefused("--out-private", "keygen", "--algorithm", "RSA", "--size", "2048",
+			"--out-private", "-");
+	}
+
+	@Test
+	void keygenRefusesADashForThePublicKey()
+	{
+		assertTheDashIsRefused("--out-public", "keygen", "--algorithm", "RSA", "--size", "2048",
+			"--out-public", "-");
+	}
+
+	@Test
+	void convertRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "key.pem");
+		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
+			pem.getAbsolutePath());
+
+		assertTheDashIsRefused("--out", "convert", "--in", pem.getAbsolutePath(), "--to", "der",
+			"--out", "-");
+	}
+
+	@Test
+	void shareSplitRefusesADashAsItsOutput()
+	{
+		assertTheDashIsRefused("--out", "share", "split", "--secret", "the-secret", "-t", "2", "-n",
+			"3", "-o", "-");
+	}
+
+	@Test
+	void keyExchangeRefusesADashForTheKeyItWrites()
+	{
+		assertTheDashIsRefused("--key", "keyx", "new", "-a", "X25519", "-k", "-");
+	}
+
+	/**
+	 * The guard is the first statement of every {@code call()}, so it answers before the command
+	 * looks at anything else. These four options are therefore driven with arguments that would not
+	 * carry the command through on their own - what is asserted is the refusal, and that it comes
+	 * first.
+	 */
+	@Test
+	void shareCombineRefusesADashAsItsOutput()
+	{
+		assertTheDashIsRefused("--out", "share", "combine", "--share", "1-aa", "--share", "2-bb",
+			"-o", "-");
+	}
+
+	@Test
+	void keyExchangeSendRefusesADashForTheHandshake()
+	{
+		assertTheDashIsRefused("--out", "keyx", "send", "-r", "no-such-file", "-o", "-");
+	}
+
+	@Test
+	void keyExchangeSendRefusesADashForTheEncryptedMessage()
+	{
+		assertTheDashIsRefused("--encrypted", "keyx", "send", "-r", "no-such-file", "-e", "-");
+	}
+
+	@Test
+	void keyExchangeReceiveRefusesADashForTheEncryptedMessage()
+	{
+		assertTheDashIsRefused("--encrypted", "keyx", "receive", "-k", "no-such-file", "-s",
+			"no-such-file", "-e", "-");
+	}
+
+	/**
+	 * The command that already refused, kept here so the parity is asserted and not assumed: every
+	 * output option answers the same way.
+	 *
+	 * @param tempDir
+	 *            the directory the key is written into
+	 * @throws Exception
+	 *             if the key cannot be generated
+	 */
+	@Test
+	void signStillRefusesADashForTheSignature(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "key.pem");
+		File data = new File(tempDir, "data.txt");
+		Files.writeString(data.toPath(), "sign me");
+		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
+			pem.getAbsolutePath());
+
+		assertTheDashIsRefused("--signature", "sign", "--algorithm", "SHA256withRSA", "--key",
+			pem.getAbsolutePath(), "--in", data.getAbsolutePath(), "--signature", "-");
+	}
+}

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/SignCommandTest.java
@@ -232,8 +232,11 @@ class SignCommandTest extends AbstractCliTest
 		Files.writeString(dataFile.toPath(), "data");
 		assertNotEquals(0, run("sign", "--algorithm", "Ed25519", "--key",
 			privatePem.getAbsolutePath(), "--in", dataFile.getAbsolutePath(), "--signature", "-"));
-		assertTrue(err.contains("standard output is not supported"),
-			"the error must reject '-' as signature target, but was: '" + err + "'");
+		// the wording moved to the shared guard every command uses now (issue #101); what is
+		// asserted is that the option is named and the reason is given, not the old sentence
+		assertTrue(err.contains("--signature") && err.contains("'-' is not a file name"),
+			"the error must reject '-' as signature target and name the option, but was: '" + err
+				+ "'");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #101. Base is `develop`.

## What happened

The input side reads standard input from `-`, so a caller reaches for the same on the output side. There it was a plain file name:

```
encrypt --out -           exit=0   file '-' created, 110 bytes
keygen --out-private -    exit=0   file '-' created, 1704 bytes
```

Both report success. `encrypt` even prints `encrypted 23 bytes to -`.

1704 bytes at `--out-private` is **a private key**, somewhere its owner did not put it. The file is awkward to be rid of too: `rm -` does not remove it without `./` or `--`, and nothing in `.gitignore` covers it.

## Why refusing is the whole answer

Standard output is **already reachable** on the output side, by leaving the option out. `KeygenCommand` says so in as many words:

```java
if (outPrivate == null)
{
    System.out.print(pem);
    return;
}
// deliberately silent: with output files the existing contract is that nothing goes to
// stdout, so a shell can redirect the printed form without a stray line in it
```

`encrypt`, `decrypt`, `convert` and `der2pem` do the same, and two option descriptions already say "instead of stdout".

So `-` is not a missing feature here. It is a name that shadows a working one, and giving it a second meaning would mean first moving every status line to stderr - `System.out.println("decrypted " + n + " bytes to " + out)` would otherwise land in the caller's pipe. That is a feature with its own design, not this fix.

## The change

`sign --signature` had guarded itself from the start, with a comment naming this exact risk. That guard moved to `CliSupport.refuseDashAsPath` and **all twelve output options** use it:

| command | options |
|---|---|
| `encrypt`, `decrypt`, `convert` | `--out` |
| `keygen` | `--out-private`, `--out-public` |
| `share split`, `share combine` | `--out` |
| `keyx new` | `--key` |
| `keyx send` | `--out`, `--encrypted` |
| `keyx receive` | `--encrypted` |
| `sign` | `--signature` |

Each message names the option that was at fault and says what to do instead - leave it out where the command prints by default, pass a path where the option is required.

The guard is **the first statement of every `call()`**, so nothing is generated, encrypted or half written before the refusal.

## Its own test had pinned the old sentence

`SignCommandTest` asserted `err.contains("standard output is not supported")`. Updated here rather than worked around, and it now asserts what the message must *carry* - the option name and the reason - instead of the wording, so the shared guard can be reworded without breaking it.

## Tests (12 cases, 7 RED before the fix)

One per guarded option. The eighth case before the fix was `sign`, which already passed - which is what made the parity break visible rather than assumed.

Each asserts three things: a non-zero exit, that the message names the option, and that **no file named `-` is left in the working directory**.

## Measured on 10ef5fd5

- 1261 tests, 0 failures (was 1249)
- 99.94% line, 100.00% branch - the two uncovered lines are the documented `MysticCryptCli.main` pair
- pitest 1511 / 1517. The six survivors are the documented ones; the thirteen mutants the new code adds are all killed.

## How it was found

A file named `-` appeared in the repository root during `./gradlew pitest` while surveying this repository's writer/reader pairs for parity (PR #102). It does not appear in a normal test run - a mutant had removed `SignCommand`'s guard, and the test that passes `--signature -` then wrote the file instead of expecting the refusal. Chasing where the file came from turned up the eleven options that had no such guard.
