### PR TITLE
feat(cli): write the stream-shaped results to standard output (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ CHANGED:
 - The message 'sign --signature -' answers with is the shared one now. It names the option and says
   what would have happened, where it used to say only that standard output is not supported. (#101)
 
+ADDED:
+
+- The commands whose result is a stream write it to standard output when the output path is '-':
+  'encrypt', 'decrypt', 'convert' and both halves of 'share'. It is the same marker '--in' already
+  reads standard input from, and it means what leaving the option out means; it exists so that the
+  intent can be said out loud in a pipeline. 'convert --to der' still refuses, because DER is
+  binary and there is nothing to print. (#104)
+
+CHANGED:
+
+- In those commands a remark about the result no longer shares the stream with the result. 'wrote
+  23 bytes to out.bin', 'wrote 3 shares to ...' and the description 'convert' prints before
+  converting go to standard error, so standard output carries the bytes alone and a pipeline gets
+  exactly them. With '--describe' the description IS the answer and stays on standard output. A
+  script that parsed these lines out of standard output has to read standard error now. (#104)
+- 'encrypt', 'decrypt', 'convert' and 'share' no longer refuse '-' as an output path; that refusal
+  from #101 was what kept the trap closed until this meaning existed. 'keygen', 'keyx' and 'sign'
+  keep it: a private key, a key exchange secret and a raw signature are not streams a pipeline
+  wants. (#104)
+
 
 Version 12.0.0
 -------------

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,7 +90,7 @@ code the tests do run, how much would they notice being broken?".
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
 | `crypt-data` | `991aa47` (develop, after PR #30) | 1294 | 100.00% | 100.00% | 100.0% (820 / 820) | 100.0% |
-| `mystic-crypt` | `10ef5fd5` (PR #103) | 1261 | 99.94% | 100.00% | 99.6% (1511 / 1517) | 99.6% |
+| `mystic-crypt` | `b930e350` (PR #105) | 1265 | 99.94% | 100.00% | 99.6% (1512 / 1518) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/CliSupport.java
@@ -170,6 +170,37 @@ final class CliSupport
 	}
 
 	/**
+	 * Answers whether the given output option asks for standard output
+	 * <p>
+	 * The commands whose result is a stream take {@code -} for it, the same marker the input side
+	 * reads standard input from. Leaving the option out means the same thing; the marker exists so
+	 * that a required option can still say it (issue #104).
+	 *
+	 * @param out
+	 *            the value of the output option, may be null when the option was left out
+	 * @return true if the result is to go to standard output
+	 */
+	static boolean isStandardOutput(final File out)
+	{
+		return out == null || "-".equals(out.getPath());
+	}
+
+	/**
+	 * Reports what happened, on standard error
+	 * <p>
+	 * A remark about the result is not the result. It goes to the other stream so that standard
+	 * output carries the bytes alone and a pipeline gets exactly them, while the caller still sees
+	 * what was done (issue #104).
+	 *
+	 * @param message
+	 *            what to report
+	 */
+	static void report(final String message)
+	{
+		System.err.println(message);
+	}
+
+	/**
 	 * Refuses {@code -} where a path to write to is wanted
 	 * <p>
 	 * The input side reads standard input from {@code -}, so a caller who learned that convention

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommand.java
@@ -91,16 +91,25 @@ public class ConvertCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			KeyFileDescription description = KeyFileDescription.of(in);
-			System.out.println(in.getPath() + " is " + description.describe());
+			// with --describe the description is the answer and belongs on standard output; while
+			// converting it is a remark about the input and would sit in front of the result
+			String said = in.getPath() + " is " + description.describe();
+			if (describe)
+			{
+				System.out.println(said);
+			}
+			else
+			{
+				CliSupport.report(said);
+			}
 			if (describe || to == null)
 			{
 				if (!describe)
 				{
-					System.out.println("nothing was converted: pass --to to say what to convert it "
+					CliSupport.report("nothing was converted: pass --to to say what to convert it "
 						+ "to, or --describe to ask only what it is");
 				}
 				return 0;
@@ -205,14 +214,14 @@ public class ConvertCommand implements Callable<Integer>
 	{
 		if (converted.text() == null)
 		{
-			if (out == null)
+			if (CliSupport.isStandardOutput(out))
 			{
 				throw new IllegalArgumentException(
 					"DER is binary and cannot be printed; pass --out to write it to a file");
 			}
 			Files.write(out.toPath(), converted.bytes());
 		}
-		else if (out == null)
+		else if (CliSupport.isStandardOutput(out))
 		{
 			System.out.print(converted.text());
 			return;
@@ -221,7 +230,7 @@ public class ConvertCommand implements Callable<Integer>
 		{
 			Files.writeString(out.toPath(), converted.text(), StandardCharsets.UTF_8);
 		}
-		System.out.println("wrote " + converted.what() + " to " + out.getPath());
+		CliSupport.report("wrote " + converted.what() + " to " + out.getPath());
 	}
 
 	private byte[] certificateDerFromPem() throws Exception

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/DecryptCommand.java
@@ -81,7 +81,6 @@ public class DecryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
@@ -93,7 +92,7 @@ public class DecryptCommand implements Callable<Integer>
 				PassphraseCryptSupport::asText);
 			if (printed == null)
 			{
-				System.out.println("decrypted " + decrypted.length + " bytes to " + out.getPath());
+				CliSupport.report("decrypted " + decrypted.length + " bytes to " + out.getPath());
 			}
 			else
 			{

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/EncryptCommand.java
@@ -76,7 +76,6 @@ public class EncryptCommand implements Callable<Integer>
 	@Override
 	public Integer call()
 	{
-		CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 		try
 		{
 			PassphraseCryptSupport.requireOnlyOneStandardInputReader(textStdin, passphraseStdin);
@@ -88,7 +87,7 @@ public class EncryptCommand implements Callable<Integer>
 				PassphraseCryptSupport::asBase64);
 			if (printed == null)
 			{
-				System.out.println("encrypted " + plain.length + " bytes to " + out.getPath());
+				CliSupport.report("encrypted " + plain.length + " bytes to " + out.getPath());
 			}
 			else
 			{

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/PassphraseCryptSupport.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/PassphraseCryptSupport.java
@@ -133,7 +133,7 @@ final class PassphraseCryptSupport
 	static String writeOutput(final File out, final byte[] result, final Printable printable)
 		throws IOException
 	{
-		if (out != null)
+		if (!CliSupport.isStandardOutput(out))
 		{
 			Files.write(out.toPath(), result);
 			return null;

--- a/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
+++ b/src/main/java/io/github/astrapi69/mystic/crypt/cli/ShareCommand.java
@@ -106,7 +106,6 @@ public class ShareCommand implements Runnable
 		@Override
 		public Integer call()
 		{
-			CliSupport.refuseDashAsPath(out, "--out", CliSupport.PASS_A_PATH);
 			try
 			{
 				byte[] secretBytes = readSecret();
@@ -116,10 +115,10 @@ public class ShareCommand implements Runnable
 				{
 					lines.append(share.encode()).append(System.lineSeparator());
 				}
-				if (out != null)
+				if (!CliSupport.isStandardOutput(out))
 				{
 					Files.writeString(out.toPath(), lines.toString(), StandardCharsets.UTF_8);
-					System.out.println("wrote " + split.size() + " shares to " + out.getPath()
+					CliSupport.report("wrote " + split.size() + " shares to " + out.getPath()
 						+ "; any " + threshold + " of them reconstruct the secret");
 				}
 				else
@@ -186,7 +185,6 @@ public class ShareCommand implements Runnable
 		@Override
 		public Integer call()
 		{
-			CliSupport.refuseDashAsPath(out, "--out", CliSupport.LEAVE_IT_OUT);
 			// the two phases are kept apart because they answer different questions: reading the
 			// shares can fail before there is anything to reconstruct (exit 2), while combining
 			// them can succeed as an operation and still not produce a secret (exit 1)
@@ -203,10 +201,10 @@ public class ShareCommand implements Runnable
 			try
 			{
 				byte[] secret = SecretSharing.combine(shares);
-				if (out != null)
+				if (!CliSupport.isStandardOutput(out))
 				{
 					Files.write(out.toPath(), secret);
-					System.out.println("wrote the reconstructed secret to " + out.getPath());
+					CliSupport.report("wrote the reconstructed secret to " + out.getPath());
 				}
 				else
 				{

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ConvertCommandTest.java
@@ -98,9 +98,9 @@ class ConvertCommandTest extends AbstractCliTest
 			run("convert", "--in", der.getPath(), "--to", "pkcs8", "--out", pem.getPath()),
 			"stderr was: '" + err + "'");
 
-		assertTrue(out.contains("is a private key in PKCS#8"),
-			"the run must say what it found first, but was: '" + out + "'");
-		assertTrue(out.contains("wrote PEM"), "stdout was: '" + out + "'");
+		assertTrue(err.contains("is a private key in PKCS#8"),
+			"the run must say what it found first, but was: '" + err + "'");
+		assertTrue(err.contains("wrote PEM"), "stderr was: '" + err + "'");
 	}
 
 	/**
@@ -225,8 +225,8 @@ class ConvertCommandTest extends AbstractCliTest
 
 		assertEquals(0, run("convert", "--in", der.getPath()));
 
-		assertTrue(out.contains("nothing was converted"), "stdout was: '" + out + "'");
-		assertTrue(out.contains("--to"), "stdout was: '" + out + "'");
+		assertTrue(err.contains("nothing was converted"), "stderr was: '" + err + "'");
+		assertTrue(err.contains("--to"), "stderr was: '" + err + "'");
 	}
 
 	@Test
@@ -406,11 +406,11 @@ class ConvertCommandTest extends AbstractCliTest
 
 		assertEquals(0, run("convert", "--in", pkcs8Der.getPath(), "--to", "pem", "--out",
 			new File(tempDir, "a.pem").getPath()));
-		assertTrue(out.contains("wrote PEM, PKCS#8"), "stdout was: '" + out + "'");
+		assertTrue(err.contains("wrote PEM, PKCS#8"), "stderr was: '" + err + "'");
 
 		assertEquals(0, run("convert", "--in", pkcs1Pem.getPath(), "--to", "pem", "--out",
 			new File(tempDir, "b.pem").getPath()));
-		assertTrue(out.contains("wrote PEM, PKCS#1"), "stdout was: '" + out + "'");
+		assertTrue(err.contains("wrote PEM, PKCS#1"), "stderr was: '" + err + "'");
 	}
 
 	/**

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/DashAsOutputPathTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/DashAsOutputPathTest.java
@@ -41,8 +41,12 @@ import org.junit.jupiter.api.io.TempDir;
  * <p>
  * The input side teaches that convention - {@code --in -} reads standard input - and standard
  * output is already reachable on the output side by leaving the option out, which is what the
- * commands that support it document. So {@code -} as an output path is not a missing feature but a
- * name that shadows a working one, and every command refuses it the way {@code sign} already did.
+ * commands that support it document.
+ * <p>
+ * The commands whose output is a stream took the marker on afterwards and write to standard output
+ * for it; what they promise is asserted in {@code StreamOutputTest}. What stays here is everything
+ * that still refuses: a private key, a key exchange secret and a raw signature are not streams a
+ * pipeline wants, so {@code keygen}, {@code keyx} and {@code sign} answer as they did (issue #104).
  */
 class DashAsOutputPathTest extends AbstractCliTest
 {
@@ -72,28 +76,6 @@ class DashAsOutputPathTest extends AbstractCliTest
 		dashInTheWorkingDirectory.delete();
 	}
 
-	@Test
-	void encryptRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
-	{
-		File plain = new File(tempDir, "plain.txt");
-		Files.writeString(plain.toPath(), "some content");
-
-		assertTheDashIsRefused("--out", "encrypt", "--in", plain.getAbsolutePath(), "--out", "-",
-			"--passphrase", "secret");
-	}
-
-	@Test
-	void decryptRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
-	{
-		File plain = new File(tempDir, "plain.txt");
-		Files.writeString(plain.toPath(), "some content");
-		File encrypted = new File(tempDir, "encrypted.bin");
-		run("encrypt", "--in", plain.getAbsolutePath(), "--out", encrypted.getAbsolutePath(),
-			"--passphrase", "secret");
-
-		assertTheDashIsRefused("--out", "decrypt", "--in", encrypted.getAbsolutePath(), "--out",
-			"-", "--passphrase", "secret");
-	}
 
 	@Test
 	void keygenRefusesADashForThePrivateKey()
@@ -109,23 +91,6 @@ class DashAsOutputPathTest extends AbstractCliTest
 			"--out-public", "-");
 	}
 
-	@Test
-	void convertRefusesADashAsItsOutput(@TempDir File tempDir) throws Exception
-	{
-		File pem = new File(tempDir, "key.pem");
-		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
-			pem.getAbsolutePath());
-
-		assertTheDashIsRefused("--out", "convert", "--in", pem.getAbsolutePath(), "--to", "der",
-			"--out", "-");
-	}
-
-	@Test
-	void shareSplitRefusesADashAsItsOutput()
-	{
-		assertTheDashIsRefused("--out", "share", "split", "--secret", "the-secret", "-t", "2", "-n",
-			"3", "-o", "-");
-	}
 
 	@Test
 	void keyExchangeRefusesADashForTheKeyItWrites()
@@ -133,18 +98,6 @@ class DashAsOutputPathTest extends AbstractCliTest
 		assertTheDashIsRefused("--key", "keyx", "new", "-a", "X25519", "-k", "-");
 	}
 
-	/**
-	 * The guard is the first statement of every {@code call()}, so it answers before the command
-	 * looks at anything else. These four options are therefore driven with arguments that would not
-	 * carry the command through on their own - what is asserted is the refusal, and that it comes
-	 * first.
-	 */
-	@Test
-	void shareCombineRefusesADashAsItsOutput()
-	{
-		assertTheDashIsRefused("--out", "share", "combine", "--share", "1-aa", "--share", "2-bb",
-			"-o", "-");
-	}
 
 	@Test
 	void keyExchangeSendRefusesADashForTheHandshake()

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/EncryptDecryptCommandTest.java
@@ -213,13 +213,13 @@ class EncryptDecryptCommandTest extends AbstractCliTest
 
 		assertEquals(0,
 			run("encrypt", "-i", plain.getPath(), "-o", encrypted.getPath(), "-p", "pass"));
-		assertTrue(out.contains("encrypted 10 bytes to " + encrypted.getPath()),
-			"stdout was: '" + out + "'");
+		assertTrue(err.contains("encrypted 10 bytes to " + encrypted.getPath()),
+			"stderr was: '" + err + "'");
 
 		assertEquals(0,
 			run("decrypt", "-i", encrypted.getPath(), "-o", back.getPath(), "-p", "pass"));
-		assertTrue(out.contains("decrypted 10 bytes to " + back.getPath()),
-			"stdout was: '" + out + "'");
+		assertTrue(err.contains("decrypted 10 bytes to " + back.getPath()),
+			"stderr was: '" + err + "'");
 	}
 
 	@Test

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/ShareCommandTest.java
@@ -172,8 +172,8 @@ class ShareCommandTest extends AbstractCliTest
 
 		assertEquals(0, run("share", "split", "--file", secretFile.getPath(), "-t", "2", "-n", "3",
 			"-o", sharesFile.getPath()));
-		assertTrue(out.contains("any 2 of them"),
-			"the confirmation must state the threshold, but was: '" + out + "'");
+		assertTrue(err.contains("any 2 of them"),
+			"the confirmation must state the threshold, but was: '" + err + "'");
 
 		// keep only two of the three lines, the situation combine exists for
 		List<String> all = Files.readAllLines(sharesFile.toPath());
@@ -265,8 +265,8 @@ class ShareCommandTest extends AbstractCliTest
 		assertEquals(0, run("share", "combine", "--share", lines.get(0), "--share", lines.get(1),
 			"-o", recovered.getPath()), "stderr was: '" + err + "'");
 
-		assertTrue(out.contains("wrote the reconstructed secret to " + recovered.getPath()),
-			"stdout was: '" + out + "'");
+		assertTrue(err.contains("wrote the reconstructed secret to " + recovered.getPath()),
+			"stderr was: '" + err + "'");
 		assertEquals(SECRET, Files.readString(recovered.toPath()));
 	}
 

--- a/src/test/java/io/github/astrapi69/mystic/crypt/cli/StreamOutputTest.java
+++ b/src/test/java/io/github/astrapi69/mystic/crypt/cli/StreamOutputTest.java
@@ -1,0 +1,221 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2015 Asterios Raptis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.astrapi69.mystic.crypt.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for issue #104: the commands whose output is a stream write it to standard output when the
+ * output path is {@code -}, and everything that is a remark about the result goes to standard
+ * error.
+ * <p>
+ * The separation is what makes a pipeline work. Standard output carries the result and nothing
+ * else, so {@code | gpg}, {@code | base64 -d} or {@code > file} get exactly the bytes; the caller
+ * still sees what happened, on the other stream.
+ * <p>
+ * {@code keygen}, {@code keyx new} and {@code sign} keep the refusal from #101: a private key or a
+ * raw signature on standard output is its own surprise.
+ */
+class StreamOutputTest extends AbstractCliTest
+{
+
+	private File plainFile(final File tempDir) throws Exception
+	{
+		File plain = new File(tempDir, "plain.txt");
+		Files.writeString(plain.toPath(), "the content under test");
+		return plain;
+	}
+
+	/** Asserts that no file called '-' was left behind, whatever else happened. */
+	private void assertNoDashFile()
+	{
+		File dash = new File("-");
+		boolean existed = dash.exists();
+		dash.delete();
+		assertFalse(existed, "no file named '-' may be left in the working directory");
+	}
+
+	@Test
+	void encryptWritesTheCipherTextToStandardOutput(@TempDir File tempDir) throws Exception
+	{
+		File plain = plainFile(tempDir);
+
+		int exitCode = run("encrypt", "--in", plain.getAbsolutePath(), "--out", "-", "--passphrase",
+			"secret");
+
+		assertNoDashFile();
+		assertEquals(0, exitCode, "encrypt must succeed, but stderr was: " + err);
+		assertFalse(out.isBlank(), "the cipher text must be on standard output");
+		assertFalse(out.contains("encrypted "),
+			"standard output must carry the result alone, but was: " + out);
+	}
+
+	@Test
+	void decryptWritesThePlainTextToStandardOutput(@TempDir File tempDir) throws Exception
+	{
+		File plain = plainFile(tempDir);
+		File encrypted = new File(tempDir, "encrypted.bin");
+		run("encrypt", "--in", plain.getAbsolutePath(), "--out", encrypted.getAbsolutePath(),
+			"--passphrase", "secret");
+
+		int exitCode = run("decrypt", "--in", encrypted.getAbsolutePath(), "--out", "-",
+			"--passphrase", "secret");
+
+		assertNoDashFile();
+		assertEquals(0, exitCode, "decrypt must succeed, but stderr was: " + err);
+		assertEquals("the content under test", out.strip(),
+			"standard output must carry the plain text alone, but was: " + out);
+	}
+
+	@Test
+	void convertWritesThePemToStandardOutput(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "key.pem");
+		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
+			pem.getAbsolutePath());
+
+		int exitCode = run("convert", "--in", pem.getAbsolutePath(), "--to", "pkcs8", "--out", "-");
+
+		assertNoDashFile();
+		assertEquals(0, exitCode, "convert must succeed, but stderr was: " + err);
+		assertTrue(out.startsWith("-----BEGIN"),
+			"standard output must start with the pem itself, but was: "
+				+ out.lines().findFirst().orElse(""));
+		assertFalse(out.contains(" is "),
+			"the description belongs on standard error, but standard output was: " + out);
+	}
+
+	@Test
+	void convertWithoutAnOutputPathAlsoPrintsThePemAlone(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "key.pem");
+		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
+			pem.getAbsolutePath());
+
+		run("convert", "--in", pem.getAbsolutePath(), "--to", "pkcs8");
+
+		assertTrue(out.startsWith("-----BEGIN"),
+			"leaving the option out must print the pem alone, but standard output was: "
+				+ out.lines().findFirst().orElse(""));
+	}
+
+	@Test
+	void shareSplitWritesTheSharesToStandardOutput() throws Exception
+	{
+		int exitCode = run("share", "split", "--secret", "the-secret", "-t", "2", "-n", "3", "-o",
+			"-");
+
+		assertNoDashFile();
+		assertEquals(0, exitCode, "share split must succeed, but stderr was: " + err);
+		assertEquals(3, out.strip().lines().count(),
+			"standard output must carry the three share lines alone, but was: " + out);
+	}
+
+	@Test
+	void shareCombineWritesTheSecretToStandardOutput(@TempDir File tempDir) throws Exception
+	{
+		File shares = new File(tempDir, "shares.txt");
+		run("share", "split", "--secret", "the-secret", "-t", "2", "-n", "3", "-o",
+			shares.getAbsolutePath());
+		String[] lines = Files.readString(shares.toPath(), StandardCharsets.UTF_8).strip()
+			.split("\\R");
+
+		int exitCode = run("share", "combine", "--share", lines[0], "--share", lines[1], "-o", "-");
+
+		assertNoDashFile();
+		assertEquals(0, exitCode, "share combine must succeed, but stderr was: " + err);
+		assertEquals("the-secret", out.strip(),
+			"standard output must carry the secret alone, but was: " + out);
+	}
+
+	/**
+	 * Writing to a file is the other half of the same rule: the remark about what was written is
+	 * not the result either, so it goes to standard error there as well.
+	 *
+	 * @param tempDir
+	 *            the directory the file is written into
+	 * @throws Exception
+	 *             if the run fails
+	 */
+	@Test
+	void theRemarkAboutAWrittenFileIsOnStandardError(@TempDir File tempDir) throws Exception
+	{
+		File plain = plainFile(tempDir);
+		File encrypted = new File(tempDir, "encrypted.bin");
+
+		int exitCode = run("encrypt", "--in", plain.getAbsolutePath(), "--out",
+			encrypted.getAbsolutePath(), "--passphrase", "secret");
+
+		assertEquals(0, exitCode);
+		assertTrue(err.contains("encrypted "),
+			"the remark must be on standard error, but stderr was: " + err);
+		assertTrue(out.isBlank(),
+			"standard output must stay empty when the result went to a file, but was: " + out);
+	}
+
+	/**
+	 * Der is binary, so there is nothing to print. The marker is accepted as far as being
+	 * understood and then refused for what it would mean here, which is a different answer from the
+	 * file named '-' it used to produce.
+	 *
+	 * @param tempDir
+	 *            the directory the key is written into
+	 * @throws Exception
+	 *             if the key cannot be generated
+	 */
+	@Test
+	void convertRefusesToPrintDerBecauseItIsBinary(@TempDir File tempDir) throws Exception
+	{
+		File pem = new File(tempDir, "key.pem");
+		run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private",
+			pem.getAbsolutePath());
+
+		int exitCode = run("convert", "--in", pem.getAbsolutePath(), "--to", "der", "--out", "-");
+
+		assertNoDashFile();
+		assertNotEquals(0, exitCode, "der cannot be printed, so this must not succeed");
+		assertTrue(err.contains("binary and cannot be printed"),
+			"the message must say why, but stderr was: " + err);
+	}
+
+	@Test
+	void keygenStillRefusesADashBecauseAPrivateKeyIsNotAStream()
+	{
+		assertNotEquals(0,
+			run("keygen", "--algorithm", "RSA", "--size", "2048", "--out-private", "-"));
+		assertNoDashFile();
+		assertTrue(err.contains("--out-private"), "the message must name the option: " + err);
+	}
+}


### PR DESCRIPTION
Closes #104. Base is `develop`, on top of #103.

The other half of the decision taken in #101. That one refused `-` because it silently made a file of that name; this one gives it the meaning a caller reaching for it actually wants, where the result is a stream.

## What `-` does now

`encrypt`, `decrypt`, `convert` and both halves of `share` write to standard output for `-`. Same marker `--in` reads standard input from, and it means what leaving the option out already means - it exists so the intent can be **said out loud**, which a pipeline reads better and a required option needs.

## What makes it usable

The second half, and the reason this is a feature and not a flag: in those commands **a remark about the result no longer shares the stream with the result.**

```
wrote 23 bytes to out.bin             ->  standard error
wrote 3 shares to shares.txt          ->  standard error
key.pem is an RSA private key         ->  standard error, while converting
the pem, the plain text, the shares   ->  standard output, alone
```

`convert` printed that description **before** the payload, so a caller who piped it got a line of prose in front of the key:

```
$ mystic-crypt convert --in key.pem --to pkcs8
key.pem is an RSA private key       <- this was on stdout too
-----BEGIN PRIVATE KEY-----
```

With `--describe` the description *is* the answer and stays where it was.

## What still refuses

`convert --to der` - DER is binary, there is nothing to print, and the message says so instead of producing a file called `-`.

`keygen`, `keyx` and `sign` keep the refusal from #101. A private key, a key exchange secret and a raw signature are not streams a pipeline wants, and `keygen` already prints its key when the option is left out, which is the deliberate way to ask for it.

## Two things had to move rather than be worked around

**Six tests asserted the remarks on standard output.** They assert them on standard error now. That is the point of the change rather than an obstacle to it, so they moved with it.

**Five cases in `DashAsOutputPathTest` asserted a refusal that is no longer the contract** for those commands. Their subject moved to `StreamOutputTest` and the class javadoc says where. One of the five had started **passing for the wrong reason**: `convert --to der --out -` still failed, but on the DER message, which happens to contain `--out`. It is now a proper case in `StreamOutputTest` asserting *why* it fails.

## A correction to #103 while in here

`share split --out` is documented as *"Write the shares to this file instead of printing them"* - it is optional and already had a print path. My guard in #103 gave it the `PASS_A_PATH` hint, which was wrong for it. The guard is gone from that command entirely now, so the wrong hint goes with it.

## Tests

`StreamOutputTest`, 9 cases, 7 RED before the change:

- each of the five stream commands writes its result to standard output for `-`, and **only** the result
- `convert` without an output path prints the PEM alone, the description having moved
- the remark about a written file is on standard error, and standard output stays empty
- `convert --to der --out -` refuses, and says why
- `keygen` still refuses, and names the option

Every case also asserts that no file named `-` is left in the working directory.

## Measured on b930e350

- 1265 tests, 0 failures
- 99.94% line, 100.00% branch - the two uncovered lines are the documented `MysticCryptCli.main` pair
- pitest 1512 / 1518, the six survivors are the documented ones

## Deliberately out of scope

`keyx send --out` writes a handshake, which is arguably a stream too. #104 scoped the change to the four commands whose output a caller pipes; the handshake path can follow if it turns out to be wanted.
