### PR TITLE
docs: build the downstream before publishing the upstream

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -45,6 +45,34 @@ Releases follow the family order crypt-api -> crypt-data -> mystic-crypt;
 a downstream release commit is pushed only when the upstream version is
 actually resolvable on Maven Central.
 
+## The downstream is built before the upstream is published
+
+A published version cannot be replaced, so the check that it works belongs
+BEFORE the upload, not after it. Upstream tests passing is not that check:
+they test the library against itself, never against the consumer that will
+get it.
+
+Before `publishAllPublicationsToCentralPortal` for any repo in this family:
+
+1. `./gradlew publishToMavenLocal` in the repo being released
+2. point the downstream at that exact version (`mavenLocal()` is already first
+   in `gradle/repositories.gradle`)
+3. `./gradlew clean build` in the downstream - green, or the release does not
+   go out
+4. report what that run said, then ask
+
+crypt-data 12.1 is why this is written down. Eight defects were fixed and
+verified in crypt-data alone - 100% branch coverage, every mutant killed - and
+published. mystic-crypt had never been compiled against it and failed four
+tests immediately: the fix that made certificate signing name Bouncy Castle
+for EC curves the JDK lacks made it refuse ML-DSA keys the JDK generates.
+Because a version on Central is permanent, that cost a 12.2 that existed only
+to undo it.
+
+The same applies in the small: a change to crypt-api or crypt-data made while
+working in mystic-crypt is built into the consumer locally before it is
+proposed, not after it is merged.
+
 ## Git discipline
 
 - Never `--amend` + force-push on an open PR - add a new commit instead


### PR DESCRIPTION
The rule that would have prevented crypt-data 12.1.

## What the rules said, and what they missed

`workflow.md` said:

> a downstream release commit is pushed only when the upstream version is actually resolvable on Maven Central

That covers one direction - do not point at something that does not exist yet. It says nothing about the other, and that is the one that went wrong: **do not publish something the consumer has never been built against.**

## What it cost

crypt-data 12.1 was published after being verified in crypt-data alone: eight defects fixed, 100% branch coverage, every mutant killed. `mystic-crypt` had never been compiled against it and failed four tests the moment it was:

```
KeystoreAddKeyPairCommandTest  ML-DSA-44, ML-DSA-65, ML-DSA-87, ml_dsa_65
cannot create signer: unknown private key passed to ML-DSA
```

The fix that made certificate signing name Bouncy Castle - for EC curves the JDK does not implement - made it refuse ML-DSA keys the JDK generates. A version on Central is permanent, so undoing it took a 12.2 that exists for no other reason.

## The rule

Four steps, before `publishAllPublicationsToCentralPortal` for any repo in the family:

1. `publishToMavenLocal` in the repo being released
2. point the downstream at that exact version
3. `clean build` in the downstream - green, or the release does not go out
4. report what that run said, then ask

Plus the small version of the same thing: a change to `crypt-api` or `crypt-data` made while working in `mystic-crypt` is built into the consumer locally before it is proposed, not after it is merged.

## Checked, not assumed

The rule claims `mavenLocal()` is already first in `gradle/repositories.gradle`, so step two needs no setup. Verified in both consumers:

```
mystic-crypt/gradle/repositories.gradle   repositories { mavenLocal() mavenCentral() ... }
crypt-data/gradle/repositories.gradle     repositories { mavenLocal() mavenCentral() ... }
```

Documentation only - no code, no tests touched.