### PR TITLE
release: version 12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ## Change log
 ----------------------
 
-Version 12.1-SNAPSHOT
+Version 12.1
 -------------
+
+ADDED:
+
+- The commands whose result is a stream write it to standard output when the output path is '-':
+  'encrypt', 'decrypt', 'convert' and both halves of 'share'. It is the same marker '--in' already
+  reads standard input from, and it means what leaving the option out means; it exists so that the
+  intent can be said out loud in a pipeline. 'convert --to der' still refuses, because DER is
+  binary and there is nothing to print. (#104)
 
 CHANGED:
 
@@ -16,6 +24,17 @@ CHANGED:
   a key with no traditional form of its own keeps its PKCS#8 encoding under the header that names
   it. A test had held the wrong premise - "an EC key has no traditional label of its own" - and is
   corrected with the code.
+- The message 'sign --signature -' answers with is the shared one now. It names the option and says
+  what would have happened, where it used to say only that standard output is not supported. (#101)
+- In those commands a remark about the result no longer shares the stream with the result. 'wrote
+  23 bytes to out.bin', 'wrote 3 shares to ...' and the description 'convert' prints before
+  converting go to standard error, so standard output carries the bytes alone and a pipeline gets
+  exactly them. With '--describe' the description IS the answer and stays on standard output. A
+  script that parsed these lines out of standard output has to read standard error now. (#104)
+- 'encrypt', 'decrypt', 'convert' and 'share' no longer refuse '-' as an output path; that refusal
+  from #101 was what kept the trap closed until this meaning existed. 'keygen', 'keyx' and 'sign'
+  keep it: a private key, a key exchange secret and a raw signature are not streams a pipeline
+  wants. (#104)
 
 FIXED:
 
@@ -26,31 +45,6 @@ FIXED:
   from, and standard output is already reachable on the output side by leaving the option out - so
   '-' is refused now rather than given a second meaning. 'sign --signature' had guarded itself from
   the start; that guard moved to CliSupport and is used by all twelve output options. (#101)
-
-CHANGED:
-
-- The message 'sign --signature -' answers with is the shared one now. It names the option and says
-  what would have happened, where it used to say only that standard output is not supported. (#101)
-
-ADDED:
-
-- The commands whose result is a stream write it to standard output when the output path is '-':
-  'encrypt', 'decrypt', 'convert' and both halves of 'share'. It is the same marker '--in' already
-  reads standard input from, and it means what leaving the option out means; it exists so that the
-  intent can be said out loud in a pipeline. 'convert --to der' still refuses, because DER is
-  binary and there is nothing to print. (#104)
-
-CHANGED:
-
-- In those commands a remark about the result no longer shares the stream with the result. 'wrote
-  23 bytes to out.bin', 'wrote 3 shares to ...' and the description 'convert' prints before
-  converting go to standard error, so standard output carries the bytes alone and a pipeline gets
-  exactly them. With '--describe' the description IS the answer and stays on standard output. A
-  script that parsed these lines out of standard output has to read standard error now. (#104)
-- 'encrypt', 'decrypt', 'convert' and 'share' no longer refuse '-' as an output path; that refusal
-  from #101 was what kept the trap closed until this meaning existed. 'keygen', 'keyx' and 'sign'
-  keep it: a private key, a key exchange secret and a raw signature are not streams a pipeline
-  wants. (#104)
 
 
 Version 12.0.0

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,8 +89,8 @@ code the tests do run, how much would they notice being broken?".
 | Repo | Measured on | Tests | Line | Branch | Mutation score (killed / generated) | Test strength |
 |---|---|---|---|---|---|---|
 | `crypt-api` | `develop` @ `cf35381` (released as 10.0.0) | 271 | 100.00% | 100.00% | 100.0% (78 / 78) | 100.0% |
-| `crypt-data` | `991aa47` (develop, after PR #30) | 1294 | 100.00% | 100.00% | 100.0% (820 / 820) | 100.0% |
-| `mystic-crypt` | `b930e350` (PR #105) | 1265 | 99.94% | 100.00% | 99.6% (1512 / 1518) | 99.6% |
+| `crypt-data` | `RELEASE-12.2` | 1301 | 100.00% | 100.00% | 100.0% (822 / 822) | 100.0% |
+| `mystic-crypt` | `RELEASE-12.1` | 1278 | 99.94% | 100.00% | 99.6% (1510 / 1516) | 99.6% |
 
 Regenerate with the commands under [How to run](#how-to-run); the reports are
 `build/reports/jacoco/test/jacocoTestReport.xml` and `build/reports/pitest/`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ######################
 # project properties #
 ######################
-projectVersion=12.1-SNAPSHOT
+projectVersion=12.1
 groupPackage=io.github.astrapi69
 projectSourceCompatibility=25
 projectInceptionYear=2015


### PR DESCRIPTION
Release of `mystic-crypt` 12.1. Base is `develop`.

## What is in it

**#101 - a dash was taken as a file name.** Every command that writes to a file accepted `-` as a path, so a file literally called `-` appeared in the working directory while the caller believed the bytes had gone to a pipe:

```
encrypt --out -           exit=0   file '-' created, 110 bytes
keygen --out-private -    exit=0   file '-' created, 1704 bytes
```

1704 bytes at `--out-private` is a private key. Only `sign` had guarded itself, with a comment naming this exact risk; all twelve output options do now.

**#104 - the stream-shaped commands write to standard output.** `encrypt`, `decrypt`, `convert` and both halves of `share` take `-` for it. What makes that usable is the second half: a remark about the result no longer shares the stream with the result.

```
wrote 23 bytes to out.bin             ->  standard error
key.pem is an RSA private key         ->  standard error, while converting
the pem, the plain text, the shares   ->  standard output, alone
```

`convert` printed that description **in front of** the payload, so a piped key arrived behind a line of prose.

**#12 - crypt-data 12.0.0 to 12.2, and `KeyFileWriter` gives the conversions back.** It existed because crypt-data wrote PKCS#1 under a PKCS#8 header; that is fixed at its source. It had carried a smaller version of the same fault - everything but RSA labelled `PRIVATE KEY` over content with the wrapper stripped - which goes with it.

**The post-quantum parameter sets.** The pair tests drove two of twelve SLH-DSA sets and one of three ML-KEM ones. A variant wired to another one''s parameters would have passed all of them - it signs perfectly well, at the wrong size. The signature length is asserted now, against what FIPS 204 and FIPS 205 give for each set.

## Contract changes worth reading before upgrading

- Status lines from `encrypt`, `decrypt`, `convert` and `share` moved from standard output to standard error. A script parsing them out of stdout has to read stderr.
- `keygen`, `keyx` and `sign` refuse `-` as an output path rather than writing a file of that name.
- The traditional PEM form now carries the label of its own algorithm - `EC PRIVATE KEY`, `DSA PRIVATE KEY` - where it used to say `PRIVATE KEY` for everything but RSA.

## Checked in the consumer before being cut

This is the rule this repository added in #106 after crypt-data 12.1 went out without it:

```
mystic-crypt-ui  ->  mystic-crypt 12.1-SNAPSHOT (from mavenLocal)
plugin tests: 553, 0 red
```

## Measured on c4989685

Clean cache, nothing reused:

- 1278 tests, 0 failures
- 99.94% line, 100.00% branch
- pitest 1510 / 1516, test strength 99.6%

The six survivors and the two uncovered lines are the ones documented in `COVERAGE_EXCEPTIONS.md`. `docs/TESTING.md` is updated in the same commit, `crypt-data`''s row with it - it is at `RELEASE-12.2` with 1301 tests and 822 / 822.

## After the merge

1. Tag `RELEASE-12.1` on the merge commit.
2. Ask before the Central upload.
3. Open `12.2-SNAPSHOT`.
