### PR TITLE
chore: open 12.2-SNAPSHOT for the next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Change log
 ----------------------
 
+Version 12.2-SNAPSHOT
+-------------
+
+(nothing released yet)
+
+
 Version 12.1
 -------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ######################
 # project properties #
 ######################
-projectVersion=12.1
+projectVersion=12.2-SNAPSHOT
 groupPackage=io.github.astrapi69
 projectSourceCompatibility=25
 projectInceptionYear=2015


### PR DESCRIPTION
Routine after the 12.1 release, and overdue: `develop` still carried `projectVersion=12.1`.

That is the version now on Maven Central:

```
maven-metadata.xml:  <release>12.1</release>
```

So every build from `develop` was producing artifacts labelled as a released, unchangeable version. A `publishToMavenLocal` from `develop` would shadow the real 12.1 for any consumer resolving from `mavenLocal()` - and nothing in the name would say which one you had. That is exactly the confusion the snapshot suffix exists to prevent.

`12.2-SNAPSHOT` now, with a fresh empty section at the top of the changelog.

1278 tests, unchanged by the version bump.

`crypt-api` has the milder version of the same problem and gets its own change: `develop` is at `10.1-SNAPSHOT` with six commits after `RELEASE-10.1`, so the name says "before 10.1" over work that came after it.